### PR TITLE
feat(mcp): implement Slack webhook notifications (Stage 7)

### DIFF
--- a/skills/phase-finalize/SKILL.md
+++ b/skills/phase-finalize/SKILL.md
@@ -437,7 +437,7 @@ Steps 1-8 are IDENTICAL for local and remote mode. Steps 9+ diverge.
               "type": "section",
               "text": {
                 "type": "mrkdwn",
-                "text": "*New MR/PR Ready for Review*\n\n*Stage:* STAGE-XXX-YYY-ZZZ — <stage title>\n*Ticket:* TICKET-XXX-YYY — <ticket title>\n*Epic:* EPIC-XXX — <epic title>\n*URL:* <MR/PR URL>"
+                "text": "*<stage title>*\n\nNew MR/PR Ready for Review\n*Stage:* STAGE-XXX-YYY-ZZZ — <stage title>\n*Ticket:* TICKET-XXX-YYY — <ticket title>\n*Epic:* EPIC-XXX — <epic title>\n<MR/PR URL|View MR/PR>"
               }
             }
           ]

--- a/skills/phase-finalize/SKILL.md
+++ b/skills/phase-finalize/SKILL.md
@@ -437,7 +437,7 @@ Steps 1-8 are IDENTICAL for local and remote mode. Steps 9+ diverge.
               "type": "section",
               "text": {
                 "type": "mrkdwn",
-                "text": "*<stage title>*\n\nNew MR/PR Ready for Review\n*Stage:* STAGE-XXX-YYY-ZZZ — <stage title>\n*Ticket:* TICKET-XXX-YYY — <ticket title>\n*Epic:* EPIC-XXX — <epic title>\n<MR/PR URL|View MR/PR>"
+                "text": "*<stage title>*\n\nNew MR/PR Ready for Review\n*Stage:* STAGE-XXX-YYY-ZZZ\n*Ticket:* TICKET-XXX-YYY — <ticket title>\n*Epic:* EPIC-XXX — <epic title>\n<MR/PR URL|View MR/PR>"
               }
             }
           ]

--- a/skills/review-cycle/SKILL.md
+++ b/skills/review-cycle/SKILL.md
@@ -249,11 +249,9 @@ glab mr view --output json | jq '.iid'
     IF `WORKFLOW_SLACK_WEBHOOK` is set:
 
       **Preferred:** Use the `mcp__kanban__slack_notify` tool:
-      - message: `"Review Comments Addressed"`
+      - message: `"Review Comments Addressed — Round N, M comments addressed"`
       - stage: `STAGE-XXX-YYY-ZZZ`
       - title: `<stage title>`
-      - round: `N`
-      - comments_addressed: `M`
       - url: `<MR/PR URL>`
 
       **Fallback (if MCP unavailable):**

--- a/tools/mcp-server/package-lock.json
+++ b/tools/mcp-server/package-lock.json
@@ -12,6 +12,9 @@
         "kanban-cli": "file:../kanban-cli",
         "zod": "^3.24.0"
       },
+      "bin": {
+        "kanban-mcp": "dist/index.js"
+      },
       "devDependencies": {
         "@types/node": "^22.0.0",
         "tsx": "^4.19.0",

--- a/tools/mcp-server/src/server.ts
+++ b/tools/mcp-server/src/server.ts
@@ -41,7 +41,10 @@ export function createKanbanMcpServer(): McpServer {
   registerPrTools(server, { mockState });
   registerEnrichTools(server, { mockState });
   registerConfluenceTools(server, { mockState });
-  registerSlackTools(server, {});
+  registerSlackTools(server, {
+    mockState,
+    webhookUrl: process.env.WORKFLOW_SLACK_WEBHOOK,
+  });
 
   // Mock admin tools only in mock mode
   if (mockState) {

--- a/tools/mcp-server/src/state.ts
+++ b/tools/mcp-server/src/state.ts
@@ -39,6 +39,18 @@ export interface MockPage {
   url: string;
 }
 
+export interface SlackNotification {
+  message: string;
+  stage?: string;
+  title?: string;
+  ticket?: string;
+  ticket_title?: string;
+  epic?: string;
+  epic_title?: string;
+  url?: string;
+  timestamp: string;
+}
+
 export interface MockSeedData {
   tickets: Record<string, Omit<MockTicket, 'comments'>>;
   pages: Record<string, MockPage>;
@@ -53,6 +65,7 @@ export class MockState {
   private prs: Map<number, MockPR>;
   private tickets: Map<string, MockTicket>;
   private pages: Map<string, MockPage>;
+  private notifications: SlackNotification[];
   private nextPrNumber: number;
   private nextCommentId: number;
 
@@ -60,6 +73,7 @@ export class MockState {
     this.prs = new Map();
     this.tickets = new Map();
     this.pages = new Map();
+    this.notifications = [];
     this.nextCommentId = 1;
 
     if (seedData) {
@@ -236,6 +250,16 @@ export class MockState {
     };
     ticket.comments.push(newComment);
     return deepCopy(newComment);
+  }
+
+  // Slack notifications
+
+  addNotification(notification: SlackNotification): void {
+    this.notifications.push(deepCopy(notification));
+  }
+
+  getNotifications(): SlackNotification[] {
+    return deepCopy(this.notifications);
   }
 
   // Confluence

--- a/tools/mcp-server/src/state.ts
+++ b/tools/mcp-server/src/state.ts
@@ -1,3 +1,5 @@
+import type { SlackNotifyArgs } from './tools/slack.js';
+
 export interface MockComment {
   id: string;
   body: string;
@@ -39,17 +41,7 @@ export interface MockPage {
   url: string;
 }
 
-export interface SlackNotification {
-  message: string;
-  stage?: string;
-  title?: string;
-  ticket?: string;
-  ticket_title?: string;
-  epic?: string;
-  epic_title?: string;
-  url?: string;
-  timestamp: string;
-}
+export type SlackNotification = SlackNotifyArgs & { timestamp: string };
 
 export interface MockSeedData {
   tickets: Record<string, Omit<MockTicket, 'comments'>>;

--- a/tools/mcp-server/src/tools/slack.ts
+++ b/tools/mcp-server/src/tools/slack.ts
@@ -19,7 +19,6 @@ export type SlackNotifyArgs = {
   epic?: string;
   epic_title?: string;
   url?: string;
-  channel?: string;
 };
 
 // --- Exported handler functions (testable without MCP server) ---
@@ -28,7 +27,11 @@ export async function handleSlackNotify(
   args: SlackNotifyArgs,
   deps: SlackToolDeps,
 ): Promise<ToolResult> {
-  // Mock mode: store in MockState
+  // Mock mode: store in MockState.
+  // When KANBAN_MOCK=true, the server always provides mockState. If mockState is null here,
+  // it means mock mode is active but no state object was wired up — return early with a
+  // "skipped" message. Even if a real webhookUrl is configured, it will NOT fire in this
+  // path; the null-state early-return is intentional.
   if (isMockMode()) {
     if (deps.mockState) {
       deps.mockState.addNotification({
@@ -111,7 +114,6 @@ export function registerSlackTools(server: McpServer, deps: SlackToolDeps): void
       epic: z.string().optional(),
       epic_title: z.string().optional(),
       url: z.string().optional(),
-      channel: z.string().optional(),
     },
     (args) => handleSlackNotify(args, deps),
   );

--- a/tools/mcp-server/tests/slack.test.ts
+++ b/tools/mcp-server/tests/slack.test.ts
@@ -4,16 +4,15 @@ import {
   registerSlackTools,
   type SlackToolDeps,
 } from '../src/tools/slack.js';
+import { MockState } from '../src/state.js';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { parseResult } from './helpers.js';
 
 describe('Slack tools', () => {
-  let deps: SlackToolDeps;
   let savedEnv: string | undefined;
 
   beforeEach(() => {
     savedEnv = process.env.KANBAN_MOCK;
-    deps = {};
   });
 
   afterEach(() => {
@@ -24,21 +23,199 @@ describe('Slack tools', () => {
     }
   });
 
-  describe('handleSlackNotify', () => {
-    it('returns not-implemented error in mock mode', async () => {
+  describe('handleSlackNotify — mock mode', () => {
+    let mockState: MockState;
+    let deps: SlackToolDeps;
+
+    beforeEach(() => {
       process.env.KANBAN_MOCK = 'true';
-      const result = await handleSlackNotify({ message: 'Hello', channel: '#general' }, deps);
-      expect(result.isError).toBe(true);
-      const data = parseResult(result);
-      expect(data.error).toContain('not yet implemented');
+      mockState = new MockState();
+      deps = { mockState };
     });
 
-    it('returns not-implemented error in real mode', async () => {
-      delete process.env.KANBAN_MOCK;
-      const result = await handleSlackNotify({ message: 'Hello' }, deps);
-      expect(result.isError).toBe(true);
+    it('stores notification with all fields in MockState', async () => {
+      const args = {
+        message: 'PR created successfully',
+        stage: 'STAGE-001',
+        title: 'New MR Ready',
+        ticket: 'TICKET-001',
+        ticket_title: 'Auth flow',
+        epic: 'EPIC-001',
+        epic_title: 'User Auth',
+        url: 'https://github.com/org/repo/pull/42',
+      };
+      await handleSlackNotify(args, deps);
+
+      const notifications = mockState.getNotifications();
+      expect(notifications).toHaveLength(1);
+      expect(notifications[0].message).toBe('PR created successfully');
+      expect(notifications[0].stage).toBe('STAGE-001');
+      expect(notifications[0].title).toBe('New MR Ready');
+      expect(notifications[0].ticket).toBe('TICKET-001');
+      expect(notifications[0].ticket_title).toBe('Auth flow');
+      expect(notifications[0].epic).toBe('EPIC-001');
+      expect(notifications[0].epic_title).toBe('User Auth');
+      expect(notifications[0].url).toBe('https://github.com/org/repo/pull/42');
+    });
+
+    it('returns success ToolResult', async () => {
+      const result = await handleSlackNotify({ message: 'test' }, deps);
+      expect(result.isError).toBeUndefined();
       const data = parseResult(result);
-      expect(data.error).toContain('not yet implemented');
+      expect(data).toContain('mock mode');
+    });
+
+    it('notification includes ISO timestamp', async () => {
+      await handleSlackNotify({ message: 'test' }, deps);
+      const notifications = mockState.getNotifications();
+      expect(notifications[0].timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    });
+
+    it('with mockState: null returns success with skipped message', async () => {
+      const nullDeps: SlackToolDeps = { mockState: null };
+      const result = await handleSlackNotify({ message: 'test' }, nullDeps);
+      expect(result.isError).toBeUndefined();
+      const data = parseResult(result);
+      expect(data).toContain('skipped');
+    });
+  });
+
+  describe('handleSlackNotify — real mode, no webhook URL', () => {
+    it('returns success with skipped message when webhookUrl is undefined', async () => {
+      delete process.env.KANBAN_MOCK;
+      const deps: SlackToolDeps = { mockState: null };
+      const result = await handleSlackNotify({ message: 'test' }, deps);
+      expect(result.isError).toBeUndefined();
+      const data = parseResult(result);
+      expect(data).toContain('skipped');
+      expect(data).toContain('no webhook URL');
+    });
+
+    it('returns success with skipped message when webhookUrl is empty string', async () => {
+      delete process.env.KANBAN_MOCK;
+      const deps: SlackToolDeps = { mockState: null, webhookUrl: '' };
+      const result = await handleSlackNotify({ message: 'test' }, deps);
+      expect(result.isError).toBeUndefined();
+      const data = parseResult(result);
+      expect(data).toContain('skipped');
+    });
+  });
+
+  describe('handleSlackNotify — real mode, webhook POST', () => {
+    let mockFetch: ReturnType<typeof vi.fn>;
+    let deps: SlackToolDeps;
+
+    beforeEach(() => {
+      delete process.env.KANBAN_MOCK;
+      mockFetch = vi.fn();
+      deps = {
+        mockState: null,
+        webhookUrl: 'https://hooks.slack.com/services/T000/B000/xxx',
+        fetch: mockFetch as unknown as typeof globalThis.fetch,
+      };
+    });
+
+    it('POST success returns success with sent message', async () => {
+      mockFetch.mockResolvedValue({ ok: true, status: 200 });
+      const result = await handleSlackNotify({ message: 'PR created' }, deps);
+      expect(result.isError).toBeUndefined();
+      const data = parseResult(result);
+      expect(data).toContain('sent');
+    });
+
+    it('POST non-2xx returns success with warning (not error)', async () => {
+      mockFetch.mockResolvedValue({ ok: false, status: 403 });
+      const result = await handleSlackNotify({ message: 'test' }, deps);
+      expect(result.isError).toBeUndefined();
+      const data = parseResult(result);
+      expect(data).toContain('failed');
+      expect(data).toContain('403');
+    });
+
+    it('POST network error returns success with warning (not error)', async () => {
+      mockFetch.mockRejectedValue(new Error('ECONNREFUSED'));
+      const result = await handleSlackNotify({ message: 'test' }, deps);
+      expect(result.isError).toBeUndefined();
+      const data = parseResult(result);
+      expect(data).toContain('failed');
+      expect(data).toContain('ECONNREFUSED');
+    });
+
+    it('payload includes top-level text fallback field', async () => {
+      mockFetch.mockResolvedValue({ ok: true, status: 200 });
+      await handleSlackNotify({ message: 'PR created for auth' }, deps);
+
+      const [, options] = mockFetch.mock.calls[0];
+      const payload = JSON.parse(options.body);
+      expect(payload.text).toBe('PR created for auth');
+    });
+
+    it('payload blocks contain all provided fields in mrkdwn format', async () => {
+      mockFetch.mockResolvedValue({ ok: true, status: 200 });
+      await handleSlackNotify(
+        {
+          message: 'PR created',
+          stage: 'STAGE-001',
+          title: 'New MR Ready',
+          ticket: 'TICKET-001',
+          ticket_title: 'Auth flow',
+          epic: 'EPIC-001',
+          epic_title: 'User Auth',
+          url: 'https://github.com/org/repo/pull/42',
+        },
+        deps,
+      );
+
+      const [, options] = mockFetch.mock.calls[0];
+      const payload = JSON.parse(options.body);
+      const mrkdwn = payload.blocks[0].text.text;
+      expect(mrkdwn).toContain('*New MR Ready*');
+      expect(mrkdwn).toContain('PR created');
+      expect(mrkdwn).toContain('*Stage:* STAGE-001');
+      expect(mrkdwn).toContain('*Ticket:* TICKET-001');
+      expect(mrkdwn).toContain('Auth flow');
+      expect(mrkdwn).toContain('*Epic:* EPIC-001');
+      expect(mrkdwn).toContain('User Auth');
+      expect(mrkdwn).toContain('<https://github.com/org/repo/pull/42|View MR/PR>');
+    });
+
+    it('payload omits absent optional fields (no undefined in output)', async () => {
+      mockFetch.mockResolvedValue({ ok: true, status: 200 });
+      await handleSlackNotify({ message: 'minimal notification' }, deps);
+
+      const [, options] = mockFetch.mock.calls[0];
+      const payload = JSON.parse(options.body);
+      const mrkdwn = payload.blocks[0].text.text;
+      expect(mrkdwn).not.toContain('undefined');
+      expect(mrkdwn).not.toContain('*Stage:*');
+      expect(mrkdwn).not.toContain('*Ticket:*');
+      expect(mrkdwn).not.toContain('*Epic:*');
+      expect(mrkdwn).not.toContain('View MR/PR');
+    });
+
+    it('payload with only message renders cleanly', async () => {
+      mockFetch.mockResolvedValue({ ok: true, status: 200 });
+      await handleSlackNotify({ message: 'Just a message' }, deps);
+
+      const [, options] = mockFetch.mock.calls[0];
+      const payload = JSON.parse(options.body);
+      expect(payload.text).toBe('Just a message');
+      expect(payload.blocks).toHaveLength(1);
+      expect(payload.blocks[0].type).toBe('section');
+      const mrkdwn = payload.blocks[0].text.text;
+      expect(mrkdwn).toContain('*Workflow Notification*');
+      expect(mrkdwn).toContain('Just a message');
+    });
+
+    it('POSTs to the correct webhook URL with correct headers', async () => {
+      mockFetch.mockResolvedValue({ ok: true, status: 200 });
+      await handleSlackNotify({ message: 'test' }, deps);
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const [url, options] = mockFetch.mock.calls[0];
+      expect(url).toBe('https://hooks.slack.com/services/T000/B000/xxx');
+      expect(options.method).toBe('POST');
+      expect(options.headers['Content-Type']).toBe('application/json');
     });
   });
 
@@ -46,6 +223,7 @@ describe('Slack tools', () => {
     it('registers 1 tool on the server without error', () => {
       const server = new McpServer({ name: 'test-server', version: '0.0.1' });
       const spy = vi.spyOn(server, 'tool');
+      const deps: SlackToolDeps = { mockState: null };
       registerSlackTools(server, deps);
       expect(spy).toHaveBeenCalledTimes(1);
     });

--- a/tools/mcp-server/tests/state.test.ts
+++ b/tools/mcp-server/tests/state.test.ts
@@ -374,6 +374,53 @@ describe('MockState', () => {
     });
   });
 
+  describe('notifications', () => {
+    it('starts with empty notifications array', () => {
+      const fresh = new MockState();
+      expect(fresh.getNotifications()).toEqual([]);
+    });
+
+    it('stores and retrieves notifications via addNotification/getNotifications', () => {
+      const notification = {
+        message: 'PR created',
+        stage: 'STAGE-001',
+        title: 'New MR Ready',
+        ticket: 'TICKET-001',
+        ticket_title: 'Auth flow',
+        epic: 'EPIC-001',
+        epic_title: 'User Auth',
+        url: 'https://github.com/org/repo/pull/42',
+        timestamp: '2026-02-24T00:00:00.000Z',
+      };
+      state.addNotification(notification);
+      const notifications = state.getNotifications();
+      expect(notifications).toHaveLength(1);
+      expect(notifications[0]).toEqual(notification);
+    });
+
+    it('accumulates multiple notifications in order', () => {
+      state.addNotification({ message: 'first', timestamp: '2026-02-24T00:00:00.000Z' });
+      state.addNotification({ message: 'second', timestamp: '2026-02-24T00:01:00.000Z' });
+      state.addNotification({ message: 'third', timestamp: '2026-02-24T00:02:00.000Z' });
+      const notifications = state.getNotifications();
+      expect(notifications).toHaveLength(3);
+      expect(notifications[0].message).toBe('first');
+      expect(notifications[1].message).toBe('second');
+      expect(notifications[2].message).toBe('third');
+    });
+
+    it('returns a deep copy - mutation does not affect store', () => {
+      state.addNotification({ message: 'original', timestamp: '2026-02-24T00:00:00.000Z' });
+      const copy = state.getNotifications();
+      copy[0].message = 'mutated';
+      copy.push({ message: 'extra', timestamp: 'fake' });
+
+      const fresh = state.getNotifications();
+      expect(fresh).toHaveLength(1);
+      expect(fresh[0].message).toBe('original');
+    });
+  });
+
   describe('getPage', () => {
     it('returns seeded page', () => {
       const page = state.getPage('12345');


### PR DESCRIPTION
Closes #1

## What

Implements Slack webhook notifications that fire after a successful MR/PR is created in the finalize phase. The `slack_notify` MCP tool was previously a stub returning "not yet implemented" — this replaces it with a working implementation.

## Why this approach

- **Skill-internal, not orchestrator-coupled** — the notification fires from within `phase-finalize`, keeping the orchestrator unaware of Slack. This matches the constraint in the issue and avoids cross-cutting concerns.
- **Graceful degradation** — if no webhook URL is configured, the tool silently succeeds. If the POST fails, it warns but does not block finalization. Slack notifications should never cause a workflow to fail.
- **Mock mode support** — notifications are stored in `MockState` so integration tests can assert on what was sent without real HTTP calls. This is consistent with how PR and Jira tools handle test isolation.
- **Block Kit format** — uses Slack's structured message format with a `mrkdwn` section and a top-level `text` fallback, matching the format specified in the issue. Optional fields are conditionally included so the payload stays clean when only `message` is provided.