### PR TITLE
feat: Global CLI + Multi-Repo (Stage 8)

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -50,7 +50,7 @@ Task 8-14 (Documentation + handoff) ──depends-on──▶ 8-13
 
 **Success Criteria**: `npm run verify` passes
 
-**Status**: Not Started
+**Status**: Complete
 
 ---
 
@@ -87,7 +87,7 @@ Task 8-14 (Documentation + handoff) ──depends-on──▶ 8-13
 
 **Success Criteria**: `npm run verify` passes
 
-**Status**: Not Started
+**Status**: Complete
 
 ---
 
@@ -113,7 +113,7 @@ Task 8-14 (Documentation + handoff) ──depends-on──▶ 8-13
 
 **Success Criteria**: `npm run verify` passes
 
-**Status**: Not Started
+**Status**: Complete
 
 ---
 
@@ -137,7 +137,7 @@ Task 8-14 (Documentation + handoff) ──depends-on──▶ 8-13
 
 **Success Criteria**: `npm run verify` passes, existing tests still pass
 
-**Status**: Not Started
+**Status**: Complete
 
 ---
 
@@ -163,7 +163,7 @@ Task 8-14 (Documentation + handoff) ──depends-on──▶ 8-13
 
 **Success Criteria**: `npm run verify` passes
 
-**Status**: Not Started
+**Status**: Complete
 
 ---
 
@@ -204,7 +204,7 @@ Task 8-14 (Documentation + handoff) ──depends-on──▶ 8-13
 
 **Success Criteria**: `npm run verify` passes
 
-**Status**: Not Started
+**Status**: Complete
 
 ---
 
@@ -235,7 +235,7 @@ Task 8-14 (Documentation + handoff) ──depends-on──▶ 8-13
 
 **Success Criteria**: `npm run verify` passes, all existing sync tests still pass
 
-**Status**: Not Started
+**Status**: Complete
 
 ---
 
@@ -264,7 +264,7 @@ Task 8-14 (Documentation + handoff) ──depends-on──▶ 8-13
 
 **Success Criteria**: `npm run verify` passes
 
-**Status**: Not Started
+**Status**: Complete
 
 ---
 
@@ -293,7 +293,7 @@ Task 8-14 (Documentation + handoff) ──depends-on──▶ 8-13
 
 **Success Criteria**: `npm run verify` passes
 
-**Status**: Not Started
+**Status**: Complete
 
 ---
 
@@ -322,7 +322,7 @@ Task 8-14 (Documentation + handoff) ──depends-on──▶ 8-13
 
 **Success Criteria**: `npm run verify` passes
 
-**Status**: Not Started
+**Status**: Complete
 
 ---
 
@@ -356,7 +356,7 @@ Task 8-14 (Documentation + handoff) ──depends-on──▶ 8-13
 
 **Success Criteria**: `npm run verify` passes
 
-**Status**: Not Started
+**Status**: Complete
 
 ---
 
@@ -384,7 +384,7 @@ Task 8-14 (Documentation + handoff) ──depends-on──▶ 8-13
 
 **Success Criteria**: `npm run verify` passes (in both mcp-server and kanban-cli)
 
-**Status**: Not Started
+**Status**: Complete
 
 ---
 
@@ -414,7 +414,7 @@ Task 8-14 (Documentation + handoff) ──depends-on──▶ 8-13
 
 **Success Criteria**: `npm run verify` passes
 
-**Status**: Not Started
+**Status**: Complete
 
 ---
 
@@ -433,4 +433,4 @@ Task 8-14 (Documentation + handoff) ──depends-on──▶ 8-13
 
 **Success Criteria**: Docs accurately reflect what shipped
 
-**Status**: Not Started
+**Status**: Complete

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -1,85 +1,436 @@
-# Stage 6E: Insights Threshold Cron — Implementation Plan
+# Stage 8: Global CLI + Multi-Repo — Implementation Plan
 
-Design: `docs/plans/2026-02-24-insights-threshold-cron-design.md`
+**Design Doc**: `docs/plans/2026-02-24-stage-8-multi-repo-design.md`
+**Branch**: `feat/stage-8-multi-repo`
 
-## Task 1: Create insights-threshold module with tests
+## Task Dependency Graph
 
-**Goal**: Build `createInsightsThresholdChecker(deps)` with full unit test coverage.
+```
+Task 8-1 (RepoRepository methods)
+Task 8-2 (Repo registry module) ──depends-on──▶ 8-1
+Task 8-3 (Cross-repo dep parser)
+Task 8-4 (DB schema migration) ──depends-on──▶ 8-1
+Task 8-5 (Multi-repo helper) ──depends-on──▶ 8-1, 8-2
+Task 8-6 (CLI: register/unregister/list) ──depends-on──▶ 8-2, 8-5
+Task 8-7 (Cross-repo dep resolution in sync) ──depends-on──▶ 8-3, 8-4, 8-1
+Task 8-8 (board --global) ──depends-on──▶ 8-5, 8-7
+Task 8-9 (next --global) ──depends-on──▶ 8-5, 8-7
+Task 8-10 (graph --global) ──depends-on──▶ 8-5, 8-7
+Task 8-11 (validate --global) ──depends-on──▶ 8-5, 8-7
+Task 8-12 (Slack webhook_url override) ──depends-on──▶ 8-2
+Task 8-13 (Integration tests) ──depends-on──▶ 8-8, 8-9, 8-10, 8-11
+Task 8-14 (Documentation + handoff) ──depends-on──▶ 8-13
+```
 
-**Files**:
-- `tools/orchestrator/src/insights-threshold.ts` (new)
-- `tools/orchestrator/src/__tests__/insights-threshold.test.ts` (new)
+## Parallelization Strategy
 
-**Implementation**:
-1. Define types: `LearningsResult`, `InsightsThresholdDeps`, `InsightsThresholdChecker`
-2. Implement `createInsightsThresholdChecker(deps)` factory with:
-   - Default deps (no-op logger, Date.now, no-op spawnSession, shell-based countLearnings)
-   - `check(repoPath)` method with threshold check → cooldown check → spawn
-   - In-memory `lastTriggeredAt` cooldown tracking
-3. Write unit tests covering:
-   - Threshold not exceeded → no spawn
-   - Threshold exceeded → spawn called
-   - Cooldown active → spawn skipped
-   - Cooldown expired → spawn called again
-   - countLearnings failure → logged, no crash
-   - spawnSession failure → logged, no crash, cooldown still set
-   - Logger receives correct messages
-
-**Success criteria**: `npm run verify` passes in orchestrator.
-
-**Status**: Complete
-
----
-
-## Task 2: Wire checker into loop.ts cron placeholder
-
-**Goal**: Replace the no-op `insights-threshold` placeholder in `buildCronScheduler()` with the real checker.
-
-**Files**:
-- `tools/orchestrator/src/loop.ts`
-
-**Implementation**:
-1. Import `createInsightsThresholdChecker`
-2. Build `countLearnings` wrapper that shells to `count-unanalyzed.sh` and parses output
-3. Build `spawnSession` wrapper that calls `sessionExecutor.spawn()` with meta-insights skill config
-4. Create checker instance and replace the no-op execute function
-5. Pass through `shared.logger`, `deps.now`, and interval config
-
-**Success criteria**: `npm run verify` passes in orchestrator. Existing 369+ orchestrator tests still pass.
-
-**Status**: Complete
+**Wave 1** (independent foundations): 8-1, 8-3 — run in parallel
+**Wave 2** (depends on Wave 1): 8-2, 8-4 — run in parallel
+**Wave 3** (depends on Wave 2): 8-5, 8-7 — run in parallel
+**Wave 4** (depends on Wave 3): 8-6, 8-8, 8-9, 8-10, 8-11, 8-12 — run in parallel (6 tasks)
+**Wave 5** (integration): 8-13
+**Wave 6** (docs): 8-14
 
 ---
 
-## Task 3: Integration tests
+## Task 8-1: RepoRepository Methods
 
-**Goal**: Test the full wiring — cron job creation, checker invocation, session spawning.
+**Goal**: Add `findAll()` and `findByName()` to `RepoRepository`
 
 **Files**:
-- `tools/orchestrator/src/__tests__/insights-threshold-integration.test.ts` (new)
+- `tools/kanban-cli/src/db/repositories/repo-repository.ts` — Add methods
+- `tools/kanban-cli/tests/db/repositories.test.ts` — Add tests
 
-**Implementation**:
-1. Test that `buildCronScheduler()` creates an insights-threshold job when config is present
-2. Test that the job's execute() calls through to the checker
-3. Test end-to-end: config → cron job → learnings check → session spawn
-4. Test disabled config → job not enabled
-5. Test missing config → no job created
+**Tests**:
+- `findAll()` returns empty array when no repos exist
+- `findAll()` returns all registered repos after multiple upserts
+- `findByName()` returns null when name not found
+- `findByName()` returns correct repo when name matches
+- `findByName()` is case-sensitive
 
-**Success criteria**: `npm run verify` passes in orchestrator.
+**Success Criteria**: `npm run verify` passes
 
-**Status**: Complete
+**Status**: Not Started
 
 ---
 
-## Task 4: Final verification and documentation
+## Task 8-2: Repo Registry Module
 
-**Goal**: Full verify across both packages, update stage tracking docs.
+**Goal**: Create `repos.yaml` loader/writer with Zod validation and DI
+
+**Files**:
+- `tools/kanban-cli/src/repos/registry.ts` — New module
+- `tools/kanban-cli/tests/repos/registry.test.ts` — New tests
+- `tools/kanban-cli/src/config/loader.ts` — Add `REPOS_PATH` to CONFIG_PATHS
 
 **Implementation**:
-1. Run `npm run verify` in both `tools/orchestrator` and `tools/kanban-cli`
-2. Update `docs/plans/stage-6e-insights-threshold-handoff.md` to mark complete
-3. Commit all changes
+- Zod schema: `repoEntrySchema` (path, name, slack_webhook optional)
+- `reposConfigSchema` with `repos` array
+- `createRegistry(deps)` factory with:
+  - `loadRepos()`: Parse repos.yaml, validate, return entries
+  - `registerRepo(entry)`: Add to list, validate unique name/path, write file
+  - `unregisterRepo(name)`: Remove by name, write file
+  - `findByName(name)`: Lookup by name
+- DI: `readFile`, `writeFile`, `existsSync`, `mkdirSync`, `registryPath`
 
-**Success criteria**: All tests pass, no lint warnings, docs updated.
+**Tests**:
+- `loadRepos()` returns empty when file doesn't exist
+- `loadRepos()` parses valid YAML with multiple repos
+- `loadRepos()` throws on invalid YAML (missing name, bad schema)
+- `registerRepo()` adds to file, creates dir if needed
+- `registerRepo()` rejects duplicate name
+- `registerRepo()` rejects duplicate path
+- `unregisterRepo()` removes entry
+- `unregisterRepo()` throws when name not found
+- `findByName()` returns match or null
+- `slack_webhook` is optional and validated as URL when present
 
-**Status**: Complete
+**Success Criteria**: `npm run verify` passes
+
+**Status**: Not Started
+
+---
+
+## Task 8-3: Cross-Repo Dependency Parser
+
+**Goal**: Parse `<repoName>/ITEM-ID` format in `depends_on` values
+
+**Files**:
+- `tools/kanban-cli/src/parser/cross-repo-deps.ts` — New module
+- `tools/kanban-cli/tests/parser/cross-repo-deps.test.ts` — New tests
+
+**Implementation**:
+- `parseDependencyRef(ref)`: Split on first `/`. If no slash → `{ type: 'local', itemId: ref }`. If slash → `{ type: 'cross-repo', repoName, itemId }`
+- `isCrossRepoDep(ref)`: Returns `ref.includes('/')`
+- `formatCrossRepoDep(repoName, itemId)`: Returns `${repoName}/${itemId}`
+
+**Tests**:
+- Local dep: `"STAGE-001-001-001"` → `{ type: 'local', itemId: 'STAGE-001-001-001' }`
+- Cross-repo: `"backend/STAGE-002-001-001"` → `{ type: 'cross-repo', repoName: 'backend', itemId: 'STAGE-002-001-001' }`
+- Cross-repo ticket: `"backend/TICKET-002-001"` → correct parse
+- Format roundtrip: `formatCrossRepoDep('backend', 'STAGE-001')` → `'backend/STAGE-001'`
+- `isCrossRepoDep` returns true/false correctly
+
+**Success Criteria**: `npm run verify` passes
+
+**Status**: Not Started
+
+---
+
+## Task 8-4: Database Schema Migration
+
+**Goal**: Add `target_repo_name` column to `dependencies` table
+
+**Files**:
+- `tools/kanban-cli/src/db/schema.ts` — Add column to CREATE TABLE + migration logic
+- `tools/kanban-cli/tests/db/database.test.ts` — Add migration test
+
+**Implementation**:
+- Add `target_repo_name TEXT` to dependencies table definition (nullable)
+- Add migration: `ALTER TABLE dependencies ADD COLUMN target_repo_name TEXT` for existing DBs
+- Migration runs on database open (same pattern as existing migrations if any)
+
+**Tests**:
+- Fresh DB creates table with `target_repo_name` column
+- Existing DB without column gets it added via migration
+- Column accepts NULL (local deps) and text values (cross-repo deps)
+
+**Success Criteria**: `npm run verify` passes, existing tests still pass
+
+**Status**: Not Started
+
+---
+
+## Task 8-5: Multi-Repo Helper
+
+**Goal**: Shared utility for syncing all repos and loading aggregated data
+
+**Files**:
+- `tools/kanban-cli/src/repos/multi-repo.ts` — New module
+- `tools/kanban-cli/tests/repos/multi-repo.test.ts` — New tests
+
+**Implementation**:
+- `createMultiRepoHelper(deps)` factory with DI
+- `syncAllRepos()`: Load registry → for each repo, call syncRepo → return repo info list
+- `loadAllRepoData(repoIds)`: Query all repositories for given repo IDs, return aggregated { epics, tickets, stages, deps }
+
+**Tests**:
+- `syncAllRepos()` syncs each registered repo
+- `syncAllRepos()` returns correct repo info list
+- `syncAllRepos()` handles empty registry (no repos)
+- `loadAllRepoData()` aggregates data from multiple repos
+- `loadAllRepoData()` adds `repo` field to each item
+
+**Success Criteria**: `npm run verify` passes
+
+**Status**: Not Started
+
+---
+
+## Task 8-6: CLI Commands — register-repo, unregister-repo, list-repos
+
+**Goal**: Three new CLI commands for repo management
+
+**Files**:
+- `tools/kanban-cli/src/cli/commands/register-repo.ts` — New
+- `tools/kanban-cli/src/cli/commands/unregister-repo.ts` — New
+- `tools/kanban-cli/src/cli/commands/list-repos.ts` — New
+- `tools/kanban-cli/src/cli/index.ts` — Register commands
+- `tools/kanban-cli/tests/cli/commands/register-repo.test.ts` — New
+- `tools/kanban-cli/tests/cli/commands/unregister-repo.test.ts` — New
+- `tools/kanban-cli/tests/cli/commands/list-repos.test.ts` — New
+
+**Implementation**:
+- `register-repo <path> [--name <name>] [--slack-webhook <url>]`
+  - Resolves path, validates it exists and has `epics/` dir
+  - Name defaults to `path.basename(path)`
+  - Adds to registry, then calls `syncRepo()` immediately
+  - Outputs registered repo info as JSON
+- `unregister-repo <name>`
+  - Removes from registry
+  - Does NOT delete DB data (user can re-register later)
+- `list-repos`
+  - Shows all registered repos with name, path, and last sync time from DB
+  - Supports `--pretty` and `-o <file>`
+
+**Tests**:
+- register-repo adds to registry and syncs
+- register-repo rejects non-existent path
+- register-repo rejects duplicate
+- unregister-repo removes entry
+- unregister-repo errors on unknown name
+- list-repos shows all repos
+- list-repos handles empty registry
+
+**Success Criteria**: `npm run verify` passes
+
+**Status**: Not Started
+
+---
+
+## Task 8-7: Cross-Repo Dependency Resolution in Sync
+
+**Goal**: Store and resolve cross-repo dependencies during syncRepo
+
+**Files**:
+- `tools/kanban-cli/src/sync/sync.ts` — Extend dependency handling
+- `tools/kanban-cli/src/db/repositories/dependency-repository.ts` — Support target_repo_name
+- `tools/kanban-cli/tests/sync/sync.test.ts` — Add cross-repo dep tests
+- `tools/kanban-cli/tests/db/repositories.test.ts` — Add target_repo_name tests
+
+**Implementation**:
+- In `syncRepo()`, when processing `depends_on` entries:
+  - Use `parseDependencyRef()` to detect cross-repo deps
+  - Store `target_repo_name` in dependency record
+  - For resolution: look up target repo by name, get its repo_id, check target item status
+- `DependencyRepository.upsert()` accepts optional `target_repo_name`
+- Cross-repo deps that can't be resolved (repo not in DB) stay unresolved
+
+**Tests**:
+- Local deps continue working unchanged
+- Cross-repo dep stored with `target_repo_name`
+- Cross-repo dep resolves when target repo synced and item is Complete
+- Cross-repo dep stays unresolved when target repo not in DB
+- Cross-repo dep stays unresolved when target item not Complete
+
+**Success Criteria**: `npm run verify` passes, all existing sync tests still pass
+
+**Status**: Not Started
+
+---
+
+## Task 8-8: `board --global`
+
+**Goal**: Add `--global` flag to board command for cross-repo aggregation
+
+**Files**:
+- `tools/kanban-cli/src/cli/commands/board.ts` — Add `--global` branch
+- `tools/kanban-cli/src/cli/logic/board.ts` — Add repo field to output types
+- `tools/kanban-cli/tests/cli/logic/board.test.ts` — Add global board tests
+
+**Implementation**:
+- Add `.option('--global', 'Aggregate across all registered repos', false)`
+- When `--global`: use multi-repo helper to sync all + aggregate
+- Each item in columns gets `repo: "<name>"` field
+- Top-level output: `repos: string[]` array replacing single `repo` path
+- When not `--global`: existing behavior unchanged, no `repo` field on items
+
+**Tests**:
+- `--global` aggregates stages from multiple repos
+- Each item has `repo` field set to repo name
+- Columns work correctly with mixed-repo items
+- Filtering by epic/ticket still works in global mode
+- Without `--global`, output unchanged (backward-compatible)
+
+**Success Criteria**: `npm run verify` passes
+
+**Status**: Not Started
+
+---
+
+## Task 8-9: `next --global`
+
+**Goal**: Add `--global` flag to next command for cross-repo ready stages
+
+**Files**:
+- `tools/kanban-cli/src/cli/commands/next.ts` — Add `--global` branch
+- `tools/kanban-cli/src/cli/logic/next.ts` — Add repo field to output types
+- `tools/kanban-cli/tests/cli/logic/next.test.ts` — Add global next tests
+
+**Implementation**:
+- Add `.option('--global', 'Show ready stages across all registered repos', false)`
+- When `--global`: sync all repos, aggregate stage data, consider cross-repo deps
+- Each ready stage gets `repo: "<name>"` field
+- Cross-repo deps factor into blocking determination
+- Without `--global`: unchanged
+
+**Tests**:
+- `--global` shows ready stages from all repos
+- Cross-repo blocked stage excluded from ready list
+- Cross-repo resolved dep allows stage to be ready
+- Each result has `repo` field
+- Without `--global`, output unchanged
+
+**Success Criteria**: `npm run verify` passes
+
+**Status**: Not Started
+
+---
+
+## Task 8-10: `graph --global`
+
+**Goal**: Add `--global` flag to graph command for cross-repo dependency visualization
+
+**Files**:
+- `tools/kanban-cli/src/cli/commands/graph.ts` — Add `--global` branch
+- `tools/kanban-cli/src/cli/logic/graph.ts` — Support cross-repo nodes/edges
+- `tools/kanban-cli/tests/cli/logic/graph.test.ts` — Add global graph tests
+
+**Implementation**:
+- Add `.option('--global', 'Show dependency graph across all registered repos', false)`
+- When `--global`: nodes from all repos with `repo` field, edges include cross-repo
+- Cross-repo edges marked with `cross_repo: true` in edge data
+- Mermaid output groups nodes by repo subgraph
+- Cycle detection spans all repos
+
+**Tests**:
+- `--global` includes nodes from multiple repos
+- Cross-repo edges have `cross_repo: true` flag
+- Cycle detection catches cross-repo cycles
+- Mermaid output renders repo subgraphs
+- Without `--global`, unchanged
+
+**Success Criteria**: `npm run verify` passes
+
+**Status**: Not Started
+
+---
+
+## Task 8-11: `validate --global`
+
+**Goal**: Add `--global` flag to validate command for cross-repo validation
+
+**Files**:
+- `tools/kanban-cli/src/cli/commands/validate.ts` — Add `--global` branch
+- `tools/kanban-cli/src/cli/logic/validate.ts` — Support cross-repo validation
+- `tools/kanban-cli/tests/cli/logic/validate.test.ts` — Add global validate tests
+
+**Implementation**:
+- Add `.option('--global', 'Validate across all registered repos', false)`
+- When `--global`:
+  - Run per-repo validation for each registered repo
+  - Check cross-repo reference existence (target repo registered, target item exists)
+  - Check cross-repo dep type validity (same rules as local)
+  - Run cross-repo cycle detection (extended Tarjan)
+  - Include `repo` field in error/warning objects
+- Without `--global`: cross-repo deps produce warnings (not errors) if target can't be resolved
+
+**Tests**:
+- `--global` validates all repos
+- Reports error for reference to unregistered repo
+- Reports error for reference to non-existent item in registered repo
+- Detects cross-repo circular dependencies
+- Type rules enforced across repos
+- Errors include `repo` field
+- Without `--global`, cross-repo deps produce warnings
+
+**Success Criteria**: `npm run verify` passes
+
+**Status**: Not Started
+
+---
+
+## Task 8-12: Slack webhook_url Override
+
+**Goal**: Add `webhook_url` parameter to `slack_notify` MCP tool and per-repo routing
+
+**Files**:
+- `tools/mcp-server/src/tools/slack.ts` — Add `webhook_url` param
+- `tools/mcp-server/tests/slack.test.ts` — Add override tests
+- `skills/phase-finalize/SKILL.md` — Document repo webhook lookup
+- `skills/review-cycle/SKILL.md` — Document repo webhook lookup
+
+**Implementation**:
+- `SlackNotifyArgs` gains optional `webhook_url: string`
+- When `webhook_url` is provided, use it instead of global `WORKFLOW_SLACK_WEBHOOK`
+- Resolution: `webhook_url` param > global env var > skip
+- Skills updated to look up repo webhook from `repos.yaml` before calling `slack_notify`
+
+**Tests**:
+- `webhook_url` override sends to specified URL
+- Without `webhook_url`, existing global behavior unchanged
+- `webhook_url` takes precedence over global webhook
+- Mock mode still works with `webhook_url` override
+
+**Success Criteria**: `npm run verify` passes (in both mcp-server and kanban-cli)
+
+**Status**: Not Started
+
+---
+
+## Task 8-13: Integration Tests
+
+**Goal**: End-to-end tests with two repos, cross-repo dependencies, and global commands
+
+**Files**:
+- `tools/kanban-cli/tests/integration/multi-repo.test.ts` — New
+
+**Implementation**:
+- Set up two temp repo directories with epics/tickets/stages
+- Repo A has stage depending on `repoB/STAGE-xxx`
+- Register both repos
+- Test sync, board --global, next --global, graph --global, validate --global
+- Verify cross-repo dep resolution
+- Verify cross-repo cycle detection
+- Verify repo field in output
+
+**Tests**:
+- Two repos register and sync successfully
+- Global board shows stages from both repos
+- Global next excludes cross-repo blocked stages
+- Global graph includes cross-repo edges
+- Global validate detects cross-repo errors
+- Cross-repo dep resolves when target completes
+
+**Success Criteria**: `npm run verify` passes
+
+**Status**: Not Started
+
+---
+
+## Task 8-14: Documentation + Handoff
+
+**Goal**: Update handoff doc with completion summary
+
+**Files**:
+- `docs/plans/stage-8-global-cli-multi-repo-handoff.md` — Update with completion summary
+- `docs/plans/2026-02-24-stage-8-multi-repo-design.md` — Mark as complete
+
+**Implementation**:
+- Add completion summary to handoff doc
+- Document any deferred items or known limitations
+- Update test count
+
+**Success Criteria**: Docs accurately reflect what shipped
+
+**Status**: Not Started

--- a/docs/plans/2026-02-24-stage-8-multi-repo-design.md
+++ b/docs/plans/2026-02-24-stage-8-multi-repo-design.md
@@ -2,7 +2,9 @@
 
 **Date**: 2026-02-24
 **Branch**: `feat/stage-8-multi-repo` (based on `kanban` + `feat/stage-7-slack-notifications`)
-**Status**: Approved
+**Status**: Implemented
+
+> This design document was approved and fully implemented. See `/docs/plans/stage-8-global-cli-multi-repo-handoff.md` for the completion summary including all 14 tasks, test counts, files added/modified, and known limitations.
 
 ## Design Decisions
 

--- a/docs/plans/2026-02-24-stage-8-multi-repo-design.md
+++ b/docs/plans/2026-02-24-stage-8-multi-repo-design.md
@@ -1,0 +1,223 @@
+# Stage 8: Global CLI + Multi-Repo — Design Document
+
+**Date**: 2026-02-24
+**Branch**: `feat/stage-8-multi-repo` (based on `kanban` + `feat/stage-7-slack-notifications`)
+**Status**: Approved
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Repo registry location | Separate `~/.config/kanban-workflow/repos.yaml` | Keeps pipeline config clean, independently editable |
+| Architecture | Global Middleware Layer (Approach A) | Additive changes, existing single-repo paths untouched |
+| Global command sync | Auto-sync all registered repos | Ensures data freshness for cross-repo queries |
+| Repo identification in output | `repo` field on every item | Minimal output change, easy to filter downstream |
+| Cross-repo dep format | `<repo-name>/ITEM-ID` (slash delimiter) | Simple, no prefix needed — slash distinguishes from local IDs |
+| Cross-repo cycle detection | Full Tarjan SCC across repos | Thorough validation prevents hidden circular blocks |
+| Slack channel routing | Per-repo `slack_webhook` in `repos.yaml` | MCP tool gets `webhook_url` override, stays stateless |
+
+## 1. Repo Registry
+
+### File: `~/.config/kanban-workflow/repos.yaml`
+
+```yaml
+repos:
+  - path: /home/user/projects/backend
+    name: backend
+    slack_webhook: "https://hooks.slack.com/services/T.../B.../backend-channel"
+  - path: /home/user/projects/frontend
+    name: frontend
+    # No slack_webhook — uses global WORKFLOW_SLACK_WEBHOOK
+```
+
+### New Module: `src/repos/registry.ts`
+
+Zod-validated registry with DI:
+
+```typescript
+const repoEntrySchema = z.object({
+  path: z.string().min(1),
+  name: z.string().min(1),
+  slack_webhook: z.string().url().optional(),
+});
+
+const reposConfigSchema = z.object({
+  repos: z.array(repoEntrySchema).default([]),
+});
+
+export interface RegistryDeps {
+  readFile: typeof fs.readFileSync;
+  writeFile: typeof fs.writeFileSync;
+  existsSync: typeof fs.existsSync;
+  mkdirSync: typeof fs.mkdirSync;
+  registryPath: string;
+}
+
+export function createRegistry(deps: Partial<RegistryDeps> = {}) {
+  return {
+    loadRepos(): RepoEntry[],
+    registerRepo(entry: RepoEntry): void,
+    unregisterRepo(name: string): void,
+    findByName(name: string): RepoEntry | null,
+  };
+}
+```
+
+### CLI Commands
+
+- `register-repo <path> [--name <name>] [--slack-webhook <url>]` — Adds repo, syncs it immediately
+- `unregister-repo <name>` — Removes from registry (does NOT delete DB data)
+- `list-repos` — Shows all registered repos with last-sync status
+
+### RepoRepository Additions
+
+- `findAll(): RepoRecord[]`
+- `findByName(name: string): RepoRecord | null`
+
+## 2. Cross-Repo Dependencies
+
+### Format
+
+```yaml
+depends_on:
+  - STAGE-001-001-003              # Local dep (no slash)
+  - backend/STAGE-002-001-001      # Cross-repo dep (slash present)
+  - backend/TICKET-002-001         # Cross-repo ticket reference
+```
+
+### Parser: `src/parser/cross-repo-deps.ts`
+
+```typescript
+export interface CrossRepoDep {
+  repoName: string;
+  itemId: string;
+}
+
+export function parseDependencyRef(ref: string):
+  | { type: 'local'; itemId: string }
+  | { type: 'cross-repo'; repoName: string; itemId: string }
+
+export function isCrossRepoDep(ref: string): boolean
+export function formatCrossRepoDep(repoName: string, itemId: string): string
+```
+
+### Database Change
+
+Add `target_repo_name TEXT` nullable column to `dependencies` table. Local deps keep null. Cross-repo deps store the target repo name.
+
+### Resolution Flow
+
+1. During `syncRepo()`, cross-repo deps are stored with `target_repo_name`
+2. During resolution, resolver looks up target repo via `RepoRepository.findByName()`, gets its `repo_id`, queries target item status
+3. For `--global` commands, all repos are pre-synced so cross-repo lookups are always fresh
+
+## 3. Global Commands
+
+### `--global` Flag Pattern
+
+```typescript
+.option('--global', 'Aggregate across all registered repos', false)
+```
+
+When `--global` is set:
+1. Load registered repos from `repos.yaml`
+2. For each repo: `syncRepo({ repoPath, db, config })`
+3. Query all repos from DB, aggregate data
+4. Add `repo: "<name>"` field to every item in output
+5. Resolve cross-repo dependencies during aggregation
+
+When `--global` is NOT set: existing single-repo behavior, completely unchanged.
+
+### Commands Gaining `--global`
+
+| Command | Global Behavior |
+|---------|----------------|
+| `board` | Columns contain stages from all repos, each with `repo` field |
+| `next` | Ready stages from all repos, cross-repo deps in blocking |
+| `graph` | Nodes/edges span all repos, cross-repo edges marked distinctly |
+| `validate` | All repos + cross-repo references + cross-repo cycles |
+
+### Shared Helper: `src/repos/multi-repo.ts`
+
+```typescript
+export interface MultiRepoDeps {
+  registry: ReturnType<typeof createRegistry>;
+  db: KanbanDatabase;
+  loadConfig: typeof loadConfig;
+  syncRepo: typeof syncRepo;
+}
+
+export function createMultiRepoHelper(deps: Partial<MultiRepoDeps> = {}) {
+  return {
+    syncAllRepos(): { repoId: number; repoName: string; repoPath: string }[],
+    loadAllRepoData(repoIds: number[]): { epics, tickets, stages, deps },
+  };
+}
+```
+
+### Output Format
+
+Single-repo (unchanged):
+```json
+{ "repo": "/path/to/repo", "columns": { ... } }
+```
+
+Global:
+```json
+{ "repos": ["backend", "frontend"], "columns": { "backlog": [{ "type": "stage", "id": "STAGE-001-001-001", "repo": "backend", ... }] } }
+```
+
+## 4. Slack Channel Routing
+
+### `repos.yaml` Extension
+
+Each repo entry optionally includes `slack_webhook`:
+```yaml
+repos:
+  - path: /home/user/projects/backend
+    name: backend
+    slack_webhook: "https://hooks.slack.com/services/T.../B.../backend"
+```
+
+### Resolution Order
+
+1. Repo-specific `slack_webhook` from `repos.yaml`
+2. Global `WORKFLOW_SLACK_WEBHOOK` (env var or config default)
+3. No webhook — silently skipped
+
+### MCP Server Change
+
+`slack_notify` gains optional `webhook_url` parameter. When provided, it overrides the global webhook. The MCP server stays stateless — callers resolve the webhook.
+
+### Skill Changes
+
+`phase-finalize` and `review-cycle` skills look up the current repo's webhook from `repos.yaml` and pass it as `webhook_url` to `slack_notify`.
+
+## 5. Validation & Error Handling
+
+### `validate --global` Checks
+
+1. All existing per-repo validation for each registered repo
+2. Cross-repo reference existence: `<repoName>/ITEM-ID` must point to registered repo with matching item
+3. Cross-repo type rules: same as local (stage→any, ticket→ticket/epic, epic→epic)
+4. Cross-repo cycle detection: extended Tarjan SCC spanning all repos
+5. Unregistered repo references: error when dep references unknown repo name
+
+### Error Format
+
+```json
+{
+  "repo": "frontend",
+  "file": "epics/EPIC-001/.../STAGE-001-001-001.md",
+  "field": "depends_on",
+  "error": "Cross-repo dependency 'backend/STAGE-002-001-001' references unregistered repo 'backend'"
+}
+```
+
+### Single-repo `validate` with cross-repo deps
+
+When running without `--global`, cross-repo deps that can't be resolved (target repo not in DB) produce warnings (not errors), since the other repo may not have been synced yet.
+
+## 6. Repo-to-Item Association
+
+`syncRepo()` already tags all items with `repo_id`. No changes needed to the sync flow. `register-repo` triggers an immediate sync to populate the shared database.

--- a/skills/phase-finalize/SKILL.md
+++ b/skills/phase-finalize/SKILL.md
@@ -416,8 +416,11 @@ Steps 1-8 are IDENTICAL for local and remote mode. Steps 9+ diverge.
 14. [CONDITIONAL: Slack Notification]
     IF `WORKFLOW_SLACK_WEBHOOK` environment variable is set:
 
+      **Per-repo webhook routing:** Before calling `slack_notify`, check if `~/.config/kanban-workflow/repos.yaml` exists. If it does, look up the current repo's entry by matching the repo path. If the entry has a `slack_webhook` field, pass it as `webhook_url` to `slack_notify` — this routes the notification to a repo-specific Slack channel instead of the global one.
+
       **Preferred:** Use the `mcp__kanban__slack_notify` tool:
       - message: `"New MR/PR Ready for Review"`
+      - webhook_url: `<repo slack_webhook from repos.yaml, if found>` (omit if not found)
       - stage: `STAGE-XXX-YYY-ZZZ`
       - title: `<stage title>`
       - ticket: `TICKET-XXX-YYY`

--- a/skills/review-cycle/SKILL.md
+++ b/skills/review-cycle/SKILL.md
@@ -248,8 +248,11 @@ glab mr view --output json | jq '.iid'
 11. [CONDITIONAL: Slack Notification]
     IF `WORKFLOW_SLACK_WEBHOOK` is set:
 
+      **Per-repo webhook routing:** Before calling `slack_notify`, check if `~/.config/kanban-workflow/repos.yaml` exists. If it does, look up the current repo's entry by matching the repo path. If the entry has a `slack_webhook` field, pass it as `webhook_url` to `slack_notify` — this routes the notification to a repo-specific Slack channel instead of the global one.
+
       **Preferred:** Use the `mcp__kanban__slack_notify` tool:
       - message: `"Review Comments Addressed"`
+      - webhook_url: `<repo slack_webhook from repos.yaml, if found>` (omit if not found)
       - stage: `STAGE-XXX-YYY-ZZZ`
       - title: `<stage title>`
       - round: `N`

--- a/tools/kanban-cli/src/cli/commands/board.ts
+++ b/tools/kanban-cli/src/cli/commands/board.ts
@@ -12,10 +12,13 @@ import { buildBoard } from '../logic/board.js';
 import type { BoardTicketRow, BoardStageRow, BoardEpicRow, BoardDependencyRow } from '../logic/board.js';
 import { renderBoardHtml } from '../formatters/board-html.js';
 import { writeOutput } from '../utils/output.js';
+import { createMultiRepoHelper } from '../../repos/multi-repo.js';
+import { createRegistry } from '../../repos/registry.js';
 
 export const boardCommand = new Command('board')
   .description('Output kanban board as JSON')
   .option('--repo <path>', 'Path to repository', process.cwd())
+  .option('--global', 'Aggregate board across all registered repos', false)
   .option('--epic <id>', 'Filter to a specific epic')
   .option('--ticket <id>', 'Filter to a specific ticket')
   .option('--column <name>', 'Filter to a specific column (snake_case)')
@@ -25,96 +28,191 @@ export const boardCommand = new Command('board')
   .option('-o, --output <file>', 'Write output to file instead of stdout')
   .action(async (options) => {
     try {
-      const repoPath = path.resolve(options.repo);
-      const config = loadConfig({ repoPath });
       const db = new KanbanDatabase();
 
-      // Ensure data is fresh
-      syncRepo({ repoPath, db, config });
+      if (options.global) {
+        // ── Global mode: aggregate across all registered repos ──
+        const registry = createRegistry();
+        const helper = createMultiRepoHelper({ registry, db });
 
-      // Get the repo ID
-      const repoRepo = new RepoRepository(db);
-      const repo = repoRepo.findByPath(repoPath);
-      if (!repo) {
-        process.stderr.write('Error: Repository not found after sync\n');
-        process.exit(2);
-        return;
-      }
-      const repoId = repo.id;
+        const repoInfos = helper.syncAllRepos();
+        if (repoInfos.length === 0) {
+          process.stderr.write('Error: No repos registered. Use register-repo to add repos.\n');
+          process.exit(2);
+          return;
+        }
 
-      // Query all data
-      const epicRows = new EpicRepository(db).listByRepo(repoId);
-      const ticketRows = new TicketRepository(db).listByRepo(repoId);
-      const stageRows = new StageRepository(db).listByRepo(repoId);
-      const depRows = new DependencyRepository(db).listByRepo(repoId);
+        const repoIds = repoInfos.map((r) => r.repoId);
+        const repoNames = repoInfos.map((r) => r.repoName);
+        const aggregated = helper.loadAllRepoData(repoIds);
 
-      // Map DB rows to logic input types
-      const epics: BoardEpicRow[] = epicRows.map((e) => ({
-        id: e.id,
-        title: e.title ?? '',
-        status: e.status ?? 'Not Started',
-        file_path: e.file_path,
-      }));
+        // Use config from the first repo for pipeline columns
+        const config = loadConfig({ repoPath: repoInfos[0].repoPath });
 
-      const tickets: BoardTicketRow[] = ticketRows.map((t) => ({
-        id: t.id,
-        epic_id: t.epic_id ?? '',
-        title: t.title ?? '',
-        status: t.status ?? 'Not Started',
-        jira_key: t.jira_key,
-        source: t.source ?? 'local',
-        has_stages: (t.has_stages ?? 0) === 1,
-        file_path: t.file_path,
-      }));
+        // Map aggregated DB rows to logic input types (with repo field)
+        const epics: BoardEpicRow[] = aggregated.epics.map((e) => ({
+          id: e.id,
+          title: e.title ?? '',
+          status: e.status ?? 'Not Started',
+          file_path: e.file_path,
+        }));
 
-      const stages: BoardStageRow[] = stageRows.map((s) => ({
-        id: s.id,
-        ticket_id: s.ticket_id ?? '',
-        epic_id: s.epic_id ?? '',
-        title: s.title ?? '',
-        status: s.status ?? 'Not Started',
-        kanban_column: s.kanban_column ?? 'backlog',
-        refinement_type: s.refinement_type ?? '[]',
-        worktree_branch: s.worktree_branch ?? '',
-        priority: s.priority,
-        due_date: s.due_date,
-        session_active: s.session_active === 1,
-        pending_merge_parents: s.pending_merge_parents ?? undefined,
-        file_path: s.file_path,
-      }));
+        const tickets: BoardTicketRow[] = aggregated.tickets.map((t) => ({
+          id: t.id,
+          epic_id: t.epic_id ?? '',
+          title: t.title ?? '',
+          status: t.status ?? 'Not Started',
+          jira_key: t.jira_key,
+          source: t.source ?? 'local',
+          has_stages: (t.has_stages ?? 0) === 1,
+          file_path: t.file_path,
+          repo: t.repo,
+        }));
 
-      const dependencies: BoardDependencyRow[] = depRows.map((d) => ({
-        id: d.id,
-        from_id: d.from_id,
-        to_id: d.to_id,
-        from_type: d.from_type,
-        to_type: d.to_type,
-        resolved: d.resolved === 1,
-      }));
+        const stages: BoardStageRow[] = aggregated.stages.map((s) => ({
+          id: s.id,
+          ticket_id: s.ticket_id ?? '',
+          epic_id: s.epic_id ?? '',
+          title: s.title ?? '',
+          status: s.status ?? 'Not Started',
+          kanban_column: s.kanban_column ?? 'backlog',
+          refinement_type: s.refinement_type ?? '[]',
+          worktree_branch: s.worktree_branch ?? '',
+          priority: s.priority,
+          due_date: s.due_date,
+          session_active: s.session_active === 1,
+          pending_merge_parents: s.pending_merge_parents ?? undefined,
+          file_path: s.file_path,
+          repo: s.repo,
+        }));
 
-      const result = buildBoard({
-        config,
-        repoPath,
-        epics,
-        tickets,
-        stages,
-        dependencies,
-        filters: {
-          epic: options.epic,
-          ticket: options.ticket,
-          column: options.column,
-          excludeDone: options.excludeDone,
-        },
-      });
+        const dependencies: BoardDependencyRow[] = aggregated.deps.map((d) => ({
+          id: d.id,
+          from_id: d.from_id,
+          to_id: d.to_id,
+          from_type: d.from_type,
+          to_type: d.to_type,
+          resolved: d.resolved === 1,
+        }));
 
-      let output: string;
-      if (options.html) {
-        output = renderBoardHtml(result);
+        const result = buildBoard({
+          config,
+          repoPath: '(global)',
+          epics,
+          tickets,
+          stages,
+          dependencies,
+          filters: {
+            epic: options.epic,
+            ticket: options.ticket,
+            column: options.column,
+            excludeDone: options.excludeDone,
+          },
+          global: true,
+          repos: repoNames,
+        });
+
+        let output: string;
+        if (options.html) {
+          output = renderBoardHtml(result);
+        } else {
+          const indent = options.pretty ? 2 : undefined;
+          output = JSON.stringify(result, null, indent) + '\n';
+        }
+        writeOutput(output, options.output);
       } else {
-        const indent = options.pretty ? 2 : undefined;
-        output = JSON.stringify(result, null, indent) + '\n';
+        // ── Single-repo mode: existing behavior unchanged ──
+        const repoPath = path.resolve(options.repo);
+        const config = loadConfig({ repoPath });
+
+        // Ensure data is fresh
+        syncRepo({ repoPath, db, config });
+
+        // Get the repo ID
+        const repoRepo = new RepoRepository(db);
+        const repo = repoRepo.findByPath(repoPath);
+        if (!repo) {
+          process.stderr.write('Error: Repository not found after sync\n');
+          process.exit(2);
+          return;
+        }
+        const repoId = repo.id;
+
+        // Query all data
+        const epicRows = new EpicRepository(db).listByRepo(repoId);
+        const ticketRows = new TicketRepository(db).listByRepo(repoId);
+        const stageRows = new StageRepository(db).listByRepo(repoId);
+        const depRows = new DependencyRepository(db).listByRepo(repoId);
+
+        // Map DB rows to logic input types
+        const epics: BoardEpicRow[] = epicRows.map((e) => ({
+          id: e.id,
+          title: e.title ?? '',
+          status: e.status ?? 'Not Started',
+          file_path: e.file_path,
+        }));
+
+        const tickets: BoardTicketRow[] = ticketRows.map((t) => ({
+          id: t.id,
+          epic_id: t.epic_id ?? '',
+          title: t.title ?? '',
+          status: t.status ?? 'Not Started',
+          jira_key: t.jira_key,
+          source: t.source ?? 'local',
+          has_stages: (t.has_stages ?? 0) === 1,
+          file_path: t.file_path,
+        }));
+
+        const stages: BoardStageRow[] = stageRows.map((s) => ({
+          id: s.id,
+          ticket_id: s.ticket_id ?? '',
+          epic_id: s.epic_id ?? '',
+          title: s.title ?? '',
+          status: s.status ?? 'Not Started',
+          kanban_column: s.kanban_column ?? 'backlog',
+          refinement_type: s.refinement_type ?? '[]',
+          worktree_branch: s.worktree_branch ?? '',
+          priority: s.priority,
+          due_date: s.due_date,
+          session_active: s.session_active === 1,
+          pending_merge_parents: s.pending_merge_parents ?? undefined,
+          file_path: s.file_path,
+        }));
+
+        const dependencies: BoardDependencyRow[] = depRows.map((d) => ({
+          id: d.id,
+          from_id: d.from_id,
+          to_id: d.to_id,
+          from_type: d.from_type,
+          to_type: d.to_type,
+          resolved: d.resolved === 1,
+        }));
+
+        const result = buildBoard({
+          config,
+          repoPath,
+          epics,
+          tickets,
+          stages,
+          dependencies,
+          filters: {
+            epic: options.epic,
+            ticket: options.ticket,
+            column: options.column,
+            excludeDone: options.excludeDone,
+          },
+        });
+
+        let output: string;
+        if (options.html) {
+          output = renderBoardHtml(result);
+        } else {
+          const indent = options.pretty ? 2 : undefined;
+          output = JSON.stringify(result, null, indent) + '\n';
+        }
+        writeOutput(output, options.output);
       }
-      writeOutput(output, options.output);
+
       db.close();
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);

--- a/tools/kanban-cli/src/cli/commands/board.ts
+++ b/tools/kanban-cli/src/cli/commands/board.ts
@@ -7,6 +7,7 @@ import { EpicRepository } from '../../db/repositories/epic-repository.js';
 import { TicketRepository } from '../../db/repositories/ticket-repository.js';
 import { StageRepository } from '../../db/repositories/stage-repository.js';
 import { DependencyRepository } from '../../db/repositories/dependency-repository.js';
+import type { EpicRow, TicketRow, StageRow, DependencyRow } from '../../db/repositories/types.js';
 import { syncRepo } from '../../sync/sync.js';
 import { buildBoard } from '../logic/board.js';
 import type { BoardTicketRow, BoardStageRow, BoardEpicRow, BoardDependencyRow } from '../logic/board.js';
@@ -14,6 +15,70 @@ import { renderBoardHtml } from '../formatters/board-html.js';
 import { writeOutput } from '../utils/output.js';
 import { createMultiRepoHelper } from '../../repos/multi-repo.js';
 import { createRegistry } from '../../repos/registry.js';
+
+// ── Shared row-mapping helper ──
+
+interface EpicLikeRow { id: string; title: string | null; status: string | null; file_path: string; repo?: string }
+interface TicketLikeRow { id: string; epic_id: string | null; title: string | null; status: string | null; jira_key: string | null; source: string | null; has_stages: number | null; file_path: string; repo?: string }
+interface StageLikeRow { id: string; ticket_id: string | null; epic_id: string | null; title: string | null; status: string | null; kanban_column: string | null; refinement_type: string | null; worktree_branch: string | null; priority: number; due_date: string | null; session_active: number; pending_merge_parents: string | null; file_path: string; repo?: string }
+interface DepLikeRow { id: number; from_id: string; to_id: string; from_type: string; to_type: string; resolved: number; repo?: string }
+
+function mapBoardRows(
+  epicRows: EpicLikeRow[],
+  ticketRows: TicketLikeRow[],
+  stageRows: StageLikeRow[],
+  depRows: DepLikeRow[],
+  options: { includeRepo: boolean },
+): { epics: BoardEpicRow[]; tickets: BoardTicketRow[]; stages: BoardStageRow[]; dependencies: BoardDependencyRow[] } {
+  const epics: BoardEpicRow[] = epicRows.map((e) => ({
+    id: e.id,
+    title: e.title ?? '',
+    status: e.status ?? 'Not Started',
+    file_path: e.file_path,
+  }));
+
+  const tickets: BoardTicketRow[] = ticketRows.map((t) => ({
+    id: t.id,
+    epic_id: t.epic_id ?? '',
+    title: t.title ?? '',
+    status: t.status ?? 'Not Started',
+    jira_key: t.jira_key,
+    source: t.source ?? 'local',
+    has_stages: (t.has_stages ?? 0) === 1,
+    file_path: t.file_path,
+    ...(options.includeRepo && t.repo ? { repo: t.repo } : {}),
+  }));
+
+  const stages: BoardStageRow[] = stageRows.map((s) => ({
+    id: s.id,
+    ticket_id: s.ticket_id ?? '',
+    epic_id: s.epic_id ?? '',
+    title: s.title ?? '',
+    status: s.status ?? 'Not Started',
+    kanban_column: s.kanban_column ?? 'backlog',
+    refinement_type: s.refinement_type ?? '[]',
+    worktree_branch: s.worktree_branch ?? '',
+    priority: s.priority,
+    due_date: s.due_date,
+    session_active: s.session_active === 1,
+    pending_merge_parents: s.pending_merge_parents ?? undefined,
+    file_path: s.file_path,
+    ...(options.includeRepo && s.repo ? { repo: s.repo } : {}),
+  }));
+
+  const dependencies: BoardDependencyRow[] = depRows.map((d) => ({
+    id: d.id,
+    from_id: d.from_id,
+    to_id: d.to_id,
+    from_type: d.from_type,
+    to_type: d.to_type,
+    resolved: d.resolved === 1,
+  }));
+
+  return { epics, tickets, stages, dependencies };
+}
+
+// ── Command ──
 
 export const boardCommand = new Command('board')
   .description('Output kanban board as JSON')
@@ -27,9 +92,8 @@ export const boardCommand = new Command('board')
   .option('--html', 'Output as standalone HTML page', false)
   .option('-o, --output <file>', 'Write output to file instead of stdout')
   .action(async (options) => {
+    const db = new KanbanDatabase();
     try {
-      const db = new KanbanDatabase();
-
       if (options.global) {
         // ── Global mode: aggregate across all registered repos ──
         const registry = createRegistry();
@@ -46,54 +110,18 @@ export const boardCommand = new Command('board')
         const repoNames = repoInfos.map((r) => r.repoName);
         const aggregated = helper.loadAllRepoData(repoIds);
 
-        // Use config from the first repo for pipeline columns
+        // TODO: Global mode currently uses the first repo's pipeline config for column layout.
+        // Repos with different pipeline phases may have stages placed in unexpected columns.
+        // Fix: merge workflow.phases from all repos into a superset.
         const config = loadConfig({ repoPath: repoInfos[0].repoPath });
 
-        // Map aggregated DB rows to logic input types (with repo field)
-        const epics: BoardEpicRow[] = aggregated.epics.map((e) => ({
-          id: e.id,
-          title: e.title ?? '',
-          status: e.status ?? 'Not Started',
-          file_path: e.file_path,
-        }));
-
-        const tickets: BoardTicketRow[] = aggregated.tickets.map((t) => ({
-          id: t.id,
-          epic_id: t.epic_id ?? '',
-          title: t.title ?? '',
-          status: t.status ?? 'Not Started',
-          jira_key: t.jira_key,
-          source: t.source ?? 'local',
-          has_stages: (t.has_stages ?? 0) === 1,
-          file_path: t.file_path,
-          repo: t.repo,
-        }));
-
-        const stages: BoardStageRow[] = aggregated.stages.map((s) => ({
-          id: s.id,
-          ticket_id: s.ticket_id ?? '',
-          epic_id: s.epic_id ?? '',
-          title: s.title ?? '',
-          status: s.status ?? 'Not Started',
-          kanban_column: s.kanban_column ?? 'backlog',
-          refinement_type: s.refinement_type ?? '[]',
-          worktree_branch: s.worktree_branch ?? '',
-          priority: s.priority,
-          due_date: s.due_date,
-          session_active: s.session_active === 1,
-          pending_merge_parents: s.pending_merge_parents ?? undefined,
-          file_path: s.file_path,
-          repo: s.repo,
-        }));
-
-        const dependencies: BoardDependencyRow[] = aggregated.deps.map((d) => ({
-          id: d.id,
-          from_id: d.from_id,
-          to_id: d.to_id,
-          from_type: d.from_type,
-          to_type: d.to_type,
-          resolved: d.resolved === 1,
-        }));
+        const { epics, tickets, stages, dependencies } = mapBoardRows(
+          aggregated.epics,
+          aggregated.tickets,
+          aggregated.stages,
+          aggregated.deps,
+          { includeRepo: true },
+        );
 
         const result = buildBoard({
           config,
@@ -144,49 +172,13 @@ export const boardCommand = new Command('board')
         const stageRows = new StageRepository(db).listByRepo(repoId);
         const depRows = new DependencyRepository(db).listByRepo(repoId);
 
-        // Map DB rows to logic input types
-        const epics: BoardEpicRow[] = epicRows.map((e) => ({
-          id: e.id,
-          title: e.title ?? '',
-          status: e.status ?? 'Not Started',
-          file_path: e.file_path,
-        }));
-
-        const tickets: BoardTicketRow[] = ticketRows.map((t) => ({
-          id: t.id,
-          epic_id: t.epic_id ?? '',
-          title: t.title ?? '',
-          status: t.status ?? 'Not Started',
-          jira_key: t.jira_key,
-          source: t.source ?? 'local',
-          has_stages: (t.has_stages ?? 0) === 1,
-          file_path: t.file_path,
-        }));
-
-        const stages: BoardStageRow[] = stageRows.map((s) => ({
-          id: s.id,
-          ticket_id: s.ticket_id ?? '',
-          epic_id: s.epic_id ?? '',
-          title: s.title ?? '',
-          status: s.status ?? 'Not Started',
-          kanban_column: s.kanban_column ?? 'backlog',
-          refinement_type: s.refinement_type ?? '[]',
-          worktree_branch: s.worktree_branch ?? '',
-          priority: s.priority,
-          due_date: s.due_date,
-          session_active: s.session_active === 1,
-          pending_merge_parents: s.pending_merge_parents ?? undefined,
-          file_path: s.file_path,
-        }));
-
-        const dependencies: BoardDependencyRow[] = depRows.map((d) => ({
-          id: d.id,
-          from_id: d.from_id,
-          to_id: d.to_id,
-          from_type: d.from_type,
-          to_type: d.to_type,
-          resolved: d.resolved === 1,
-        }));
+        const { epics, tickets, stages, dependencies } = mapBoardRows(
+          epicRows,
+          ticketRows,
+          stageRows,
+          depRows,
+          { includeRepo: false },
+        );
 
         const result = buildBoard({
           config,
@@ -215,6 +207,7 @@ export const boardCommand = new Command('board')
 
       db.close();
     } catch (err) {
+      db.close();
       const message = err instanceof Error ? err.message : String(err);
       process.stderr.write(`Error: ${message}\n`);
       process.exit(2);

--- a/tools/kanban-cli/src/cli/commands/graph.ts
+++ b/tools/kanban-cli/src/cli/commands/graph.ts
@@ -12,92 +12,177 @@ import { buildGraph } from '../logic/graph.js';
 import type { GraphEpicRow, GraphTicketRow, GraphStageRow, GraphDependencyRow } from '../logic/graph.js';
 import { formatGraphAsMermaid } from '../formatters/graph-mermaid.js';
 import { writeOutput } from '../utils/output.js';
+import { createMultiRepoHelper } from '../../repos/multi-repo.js';
+import { createRegistry } from '../../repos/registry.js';
 
 export const graphCommand = new Command('graph')
   .description('Output dependency graph as JSON')
   .option('--repo <path>', 'Path to repository', process.cwd())
+  .option('--global', 'Show dependency graph across all registered repos', false)
   .option('--epic <id>', 'Filter to a specific epic')
   .option('--ticket <id>', 'Filter to a specific ticket')
   .option('--pretty', 'Pretty-print JSON output', false)
   .option('--mermaid', 'Output as Mermaid diagram instead of JSON', false)
   .option('-o, --output <file>', 'Write output to file instead of stdout')
   .action(async (options) => {
+    const db = new KanbanDatabase();
     try {
-      const repoPath = path.resolve(options.repo);
-      const config = loadConfig({ repoPath });
-      const db = new KanbanDatabase();
+      if (options.global) {
+        // ── Global mode: aggregate across all registered repos ──
+        const registry = createRegistry();
+        const helper = createMultiRepoHelper({ registry, db });
 
-      // Ensure data is fresh
-      syncRepo({ repoPath, db, config });
+        const repoInfos = helper.syncAllRepos();
+        if (repoInfos.length === 0) {
+          process.stderr.write('Error: No repos registered. Use register-repo to add repos.\n');
+          process.exit(2);
+          return;
+        }
 
-      // Get the repo ID
-      const repoRepo = new RepoRepository(db);
-      const repo = repoRepo.findByPath(repoPath);
-      if (!repo) {
-        process.stderr.write('Error: Repository not found after sync\n');
-        process.exit(2);
-        return;
-      }
-      const repoId = repo.id;
+        const repoIds = repoInfos.map((r) => r.repoId);
+        const repoNames = repoInfos.map((r) => r.repoName);
+        const aggregated = helper.loadAllRepoData(repoIds);
 
-      // Query all data
-      const epicRows = new EpicRepository(db).listByRepo(repoId);
-      const ticketRows = new TicketRepository(db).listByRepo(repoId);
-      const stageRows = new StageRepository(db).listByRepo(repoId);
-      const depRows = new DependencyRepository(db).listByRepo(repoId);
+        // TODO: Global mode currently uses the first repo's pipeline config for column layout.
+        // Repos with different pipeline phases may have stages placed in unexpected columns.
+        // Fix: merge workflow.phases from all repos into a superset.
+        const config = loadConfig({ repoPath: repoInfos[0].repoPath });
 
-      // Map DB rows to logic input types
-      const epics: GraphEpicRow[] = epicRows.map((e) => ({
-        id: e.id,
-        title: e.title ?? '',
-        status: e.status ?? 'Not Started',
-      }));
+        // Map aggregated rows to GraphEpicRow types with repo field
+        const epics: GraphEpicRow[] = aggregated.epics.map((e) => ({
+          id: e.id,
+          title: e.title ?? '',
+          status: e.status ?? 'Not Started',
+          repo: e.repo,
+        }));
 
-      const tickets: GraphTicketRow[] = ticketRows.map((t) => ({
-        id: t.id,
-        epic_id: t.epic_id ?? '',
-        title: t.title ?? '',
-        status: t.status ?? 'Not Started',
-      }));
+        const tickets: GraphTicketRow[] = aggregated.tickets.map((t) => ({
+          id: t.id,
+          epic_id: t.epic_id ?? '',
+          title: t.title ?? '',
+          status: t.status ?? 'Not Started',
+          repo: t.repo,
+        }));
 
-      const stages: GraphStageRow[] = stageRows.map((s) => ({
-        id: s.id,
-        ticket_id: s.ticket_id ?? '',
-        epic_id: s.epic_id ?? '',
-        title: s.title ?? '',
-        status: s.status ?? 'Not Started',
-      }));
+        const stages: GraphStageRow[] = aggregated.stages.map((s) => ({
+          id: s.id,
+          ticket_id: s.ticket_id ?? '',
+          epic_id: s.epic_id ?? '',
+          title: s.title ?? '',
+          status: s.status ?? 'Not Started',
+          repo: s.repo,
+        }));
 
-      const dependencies: GraphDependencyRow[] = depRows.map((d) => ({
-        id: d.id,
-        from_id: d.from_id,
-        to_id: d.to_id,
-        from_type: d.from_type,
-        to_type: d.to_type,
-        resolved: d.resolved === 1,
-      }));
+        const dependencies: GraphDependencyRow[] = aggregated.deps.map((d) => ({
+          id: d.id,
+          from_id: d.from_id,
+          to_id: d.to_id,
+          from_type: d.from_type,
+          to_type: d.to_type,
+          resolved: d.resolved === 1,
+          repo: d.repo,
+        }));
 
-      const result = buildGraph({
-        epics,
-        tickets,
-        stages,
-        dependencies,
-        filters: {
-          epic: options.epic,
-          ticket: options.ticket,
-        },
-      });
+        const result = buildGraph({
+          epics,
+          tickets,
+          stages,
+          dependencies,
+          filters: {
+            epic: options.epic,
+            ticket: options.ticket,
+          },
+          global: true,
+          repos: repoNames,
+        });
 
-      let output: string;
-      if (options.mermaid) {
-        output = formatGraphAsMermaid(result) + '\n';
+        let output: string;
+        if (options.mermaid) {
+          output = formatGraphAsMermaid(result) + '\n';
+        } else {
+          const indent = options.pretty ? 2 : undefined;
+          output = JSON.stringify(result, null, indent) + '\n';
+        }
+        writeOutput(output, options.output);
       } else {
-        const indent = options.pretty ? 2 : undefined;
-        output = JSON.stringify(result, null, indent) + '\n';
+        // ── Single-repo mode: existing behavior unchanged ──
+        const repoPath = path.resolve(options.repo);
+        const config = loadConfig({ repoPath });
+
+        // Ensure data is fresh
+        syncRepo({ repoPath, db, config });
+
+        // Get the repo ID
+        const repoRepo = new RepoRepository(db);
+        const repo = repoRepo.findByPath(repoPath);
+        if (!repo) {
+          process.stderr.write('Error: Repository not found after sync\n');
+          process.exit(2);
+          return;
+        }
+        const repoId = repo.id;
+
+        // Query all data
+        const epicRows = new EpicRepository(db).listByRepo(repoId);
+        const ticketRows = new TicketRepository(db).listByRepo(repoId);
+        const stageRows = new StageRepository(db).listByRepo(repoId);
+        const depRows = new DependencyRepository(db).listByRepo(repoId);
+
+        // Map DB rows to logic input types
+        const epics: GraphEpicRow[] = epicRows.map((e) => ({
+          id: e.id,
+          title: e.title ?? '',
+          status: e.status ?? 'Not Started',
+        }));
+
+        const tickets: GraphTicketRow[] = ticketRows.map((t) => ({
+          id: t.id,
+          epic_id: t.epic_id ?? '',
+          title: t.title ?? '',
+          status: t.status ?? 'Not Started',
+        }));
+
+        const stages: GraphStageRow[] = stageRows.map((s) => ({
+          id: s.id,
+          ticket_id: s.ticket_id ?? '',
+          epic_id: s.epic_id ?? '',
+          title: s.title ?? '',
+          status: s.status ?? 'Not Started',
+        }));
+
+        const dependencies: GraphDependencyRow[] = depRows.map((d) => ({
+          id: d.id,
+          from_id: d.from_id,
+          to_id: d.to_id,
+          from_type: d.from_type,
+          to_type: d.to_type,
+          resolved: d.resolved === 1,
+        }));
+
+        const result = buildGraph({
+          epics,
+          tickets,
+          stages,
+          dependencies,
+          filters: {
+            epic: options.epic,
+            ticket: options.ticket,
+          },
+        });
+
+        let output: string;
+        if (options.mermaid) {
+          output = formatGraphAsMermaid(result) + '\n';
+        } else {
+          const indent = options.pretty ? 2 : undefined;
+          output = JSON.stringify(result, null, indent) + '\n';
+        }
+        writeOutput(output, options.output);
       }
-      writeOutput(output, options.output);
+
       db.close();
     } catch (err) {
+      db.close();
       const message = err instanceof Error ? err.message : String(err);
       process.stderr.write(`Error: ${message}\n`);
       process.exit(2);

--- a/tools/kanban-cli/src/cli/commands/list-repos.ts
+++ b/tools/kanban-cli/src/cli/commands/list-repos.ts
@@ -1,0 +1,31 @@
+import { Command } from 'commander';
+import { createRegistry } from '../../repos/registry.js';
+import { writeOutput } from '../utils/output.js';
+
+export const listReposCommand = new Command('list-repos')
+  .description('List all registered repositories')
+  .option('--pretty', 'Pretty-print JSON output', false)
+  .option('-o, --output <file>', 'Write output to file instead of stdout')
+  .action(async (options) => {
+    try {
+      const registry = createRegistry();
+      const repos = registry.loadRepos();
+
+      const result = {
+        repos: repos.map((r) => ({
+          name: r.name,
+          path: r.path,
+          ...(r.slack_webhook ? { slack_webhook: r.slack_webhook } : {}),
+        })),
+        count: repos.length,
+      };
+
+      const indent = options.pretty ? 2 : undefined;
+      const output = JSON.stringify(result, null, indent) + '\n';
+      writeOutput(output, options.output);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      process.stderr.write(`Error: ${message}\n`);
+      process.exit(2);
+    }
+  });

--- a/tools/kanban-cli/src/cli/commands/next.ts
+++ b/tools/kanban-cli/src/cli/commands/next.ts
@@ -10,82 +10,161 @@ import { syncRepo } from '../../sync/sync.js';
 import { buildNext } from '../logic/next.js';
 import type { NextStageRow, NextTicketRow, NextDependencyRow } from '../logic/next.js';
 import { writeOutput } from '../utils/output.js';
+import { createMultiRepoHelper } from '../../repos/multi-repo.js';
+import { createRegistry } from '../../repos/registry.js';
 
 export const nextCommand = new Command('next')
   .description('Output next workable stages, sorted by priority')
   .option('--repo <path>', 'Path to repository', process.cwd())
+  .option('--global', 'Show ready stages across all registered repos', false)
   .option('--max <n>', 'Maximum number of stages to return', '5')
   .option('--pretty', 'Pretty-print JSON output', false)
   .option('-o, --output <file>', 'Write output to file instead of stdout')
   .action(async (options) => {
+    const db = new KanbanDatabase();
     try {
-      const repoPath = path.resolve(options.repo);
-      const config = loadConfig({ repoPath });
-      const db = new KanbanDatabase();
+      if (options.global) {
+        // ── Global mode: aggregate across all registered repos ──
+        const registry = createRegistry();
+        const helper = createMultiRepoHelper({ registry, db });
 
-      // Ensure data is fresh
-      syncRepo({ repoPath, db, config });
+        const repoInfos = helper.syncAllRepos();
+        if (repoInfos.length === 0) {
+          process.stderr.write('Error: No repos registered. Use register-repo to add repos.\n');
+          process.exit(2);
+          return;
+        }
 
-      // Get the repo ID
-      const repoRepo = new RepoRepository(db);
-      const repo = repoRepo.findByPath(repoPath);
-      if (!repo) {
-        process.stderr.write('Error: Repository not found after sync\n');
-        process.exit(2);
-        return;
+        const repoIds = repoInfos.map((r) => r.repoId);
+        const repoNames = repoInfos.map((r) => r.repoName);
+        const aggregated = helper.loadAllRepoData(repoIds);
+
+        // TODO: Global mode currently uses the first repo's pipeline config for column layout.
+        // Repos with different pipeline phases may have stages placed in unexpected columns.
+        // Fix: merge workflow.phases from all repos into a superset.
+        const config = loadConfig({ repoPath: repoInfos[0].repoPath });
+
+        // Map aggregated data to logic input types (with repo field)
+        const stages: NextStageRow[] = aggregated.stages.map((s) => ({
+          id: s.id,
+          ticket_id: s.ticket_id ?? '',
+          epic_id: s.epic_id ?? '',
+          title: s.title ?? '',
+          status: s.status ?? 'Not Started',
+          kanban_column: s.kanban_column ?? 'backlog',
+          refinement_type: s.refinement_type ?? '[]',
+          worktree_branch: s.worktree_branch ?? '',
+          priority: s.priority,
+          due_date: s.due_date,
+          session_active: s.session_active === 1,
+          repo: s.repo,
+        }));
+
+        const tickets: NextTicketRow[] = aggregated.tickets.map((t) => ({
+          id: t.id,
+          epic_id: t.epic_id ?? '',
+          has_stages: (t.has_stages ?? 0) === 1,
+        }));
+
+        const dependencies: NextDependencyRow[] = aggregated.deps.map((d) => ({
+          id: d.id,
+          from_id: d.from_id,
+          to_id: d.to_id,
+          from_type: d.from_type,
+          to_type: d.to_type,
+          resolved: d.resolved === 1,
+        }));
+
+        const maxValue = parseInt(options.max, 10);
+
+        const result = buildNext({
+          config,
+          stages,
+          dependencies,
+          tickets,
+          max: isNaN(maxValue) ? 5 : maxValue,
+        });
+
+        // Add repos field for global mode
+        const output = {
+          ...result,
+          repos: repoNames,
+        };
+
+        const indent = options.pretty ? 2 : undefined;
+        const outputStr = JSON.stringify(output, null, indent) + '\n';
+        writeOutput(outputStr, options.output);
+      } else {
+        // ── Single-repo mode: existing behavior unchanged ──
+        const repoPath = path.resolve(options.repo);
+        const config = loadConfig({ repoPath });
+
+        // Ensure data is fresh
+        syncRepo({ repoPath, db, config });
+
+        // Get the repo ID
+        const repoRepo = new RepoRepository(db);
+        const repo = repoRepo.findByPath(repoPath);
+        if (!repo) {
+          process.stderr.write('Error: Repository not found after sync\n');
+          process.exit(2);
+          return;
+        }
+        const repoId = repo.id;
+
+        // Query all data
+        const ticketRows = new TicketRepository(db).listByRepo(repoId);
+        const stageRows = new StageRepository(db).listByRepo(repoId);
+        const depRows = new DependencyRepository(db).listByRepo(repoId);
+
+        // Map DB rows to logic input types
+        const stages: NextStageRow[] = stageRows.map((s) => ({
+          id: s.id,
+          ticket_id: s.ticket_id ?? '',
+          epic_id: s.epic_id ?? '',
+          title: s.title ?? '',
+          status: s.status ?? 'Not Started',
+          kanban_column: s.kanban_column ?? 'backlog',
+          refinement_type: s.refinement_type ?? '[]',
+          worktree_branch: s.worktree_branch ?? '',
+          priority: s.priority,
+          due_date: s.due_date,
+          session_active: s.session_active === 1,
+        }));
+
+        const tickets: NextTicketRow[] = ticketRows.map((t) => ({
+          id: t.id,
+          epic_id: t.epic_id ?? '',
+          has_stages: (t.has_stages ?? 0) === 1,
+        }));
+
+        const dependencies: NextDependencyRow[] = depRows.map((d) => ({
+          id: d.id,
+          from_id: d.from_id,
+          to_id: d.to_id,
+          from_type: d.from_type,
+          to_type: d.to_type,
+          resolved: d.resolved === 1,
+        }));
+
+        const maxValue = parseInt(options.max, 10);
+
+        const result = buildNext({
+          config,
+          stages,
+          dependencies,
+          tickets,
+          max: isNaN(maxValue) ? 5 : maxValue,
+        });
+
+        const indent = options.pretty ? 2 : undefined;
+        const output = JSON.stringify(result, null, indent) + '\n';
+        writeOutput(output, options.output);
       }
-      const repoId = repo.id;
 
-      // Query all data
-      const ticketRows = new TicketRepository(db).listByRepo(repoId);
-      const stageRows = new StageRepository(db).listByRepo(repoId);
-      const depRows = new DependencyRepository(db).listByRepo(repoId);
-
-      // Map DB rows to logic input types
-      const stages: NextStageRow[] = stageRows.map((s) => ({
-        id: s.id,
-        ticket_id: s.ticket_id ?? '',
-        epic_id: s.epic_id ?? '',
-        title: s.title ?? '',
-        status: s.status ?? 'Not Started',
-        kanban_column: s.kanban_column ?? 'backlog',
-        refinement_type: s.refinement_type ?? '[]',
-        worktree_branch: s.worktree_branch ?? '',
-        priority: s.priority,
-        due_date: s.due_date,
-        session_active: s.session_active === 1,
-      }));
-
-      const tickets: NextTicketRow[] = ticketRows.map((t) => ({
-        id: t.id,
-        epic_id: t.epic_id ?? '',
-        has_stages: (t.has_stages ?? 0) === 1,
-      }));
-
-      const dependencies: NextDependencyRow[] = depRows.map((d) => ({
-        id: d.id,
-        from_id: d.from_id,
-        to_id: d.to_id,
-        from_type: d.from_type,
-        to_type: d.to_type,
-        resolved: d.resolved === 1,
-      }));
-
-      const maxValue = parseInt(options.max, 10);
-
-      const result = buildNext({
-        config,
-        stages,
-        dependencies,
-        tickets,
-        max: isNaN(maxValue) ? 5 : maxValue,
-      });
-
-      const indent = options.pretty ? 2 : undefined;
-      const output = JSON.stringify(result, null, indent) + '\n';
-      writeOutput(output, options.output);
       db.close();
     } catch (err) {
+      db.close();
       const message = err instanceof Error ? err.message : String(err);
       process.stderr.write(`Error: ${message}\n`);
       process.exit(2);

--- a/tools/kanban-cli/src/cli/commands/register-repo.ts
+++ b/tools/kanban-cli/src/cli/commands/register-repo.ts
@@ -1,0 +1,64 @@
+import { Command } from 'commander';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { loadConfig } from '../../config/loader.js';
+import { KanbanDatabase } from '../../db/database.js';
+import { syncRepo } from '../../sync/sync.js';
+import { createRegistry } from '../../repos/registry.js';
+import { writeOutput } from '../utils/output.js';
+
+export const registerRepoCommand = new Command('register-repo')
+  .description('Register a repository for multi-repo tracking')
+  .argument('<path>', 'Path to repository')
+  .option('--name <name>', 'Display name (defaults to directory basename)')
+  .option('--slack-webhook <url>', 'Slack webhook URL for this repo')
+  .option('--pretty', 'Pretty-print JSON output', false)
+  .option('-o, --output <file>', 'Write output to file instead of stdout')
+  .action(async (repoPath: string, options) => {
+    try {
+      const resolved = path.resolve(repoPath);
+
+      if (!fs.existsSync(resolved)) {
+        throw new Error(`Path does not exist: ${resolved}`);
+      }
+
+      const name = options.name ?? path.basename(resolved);
+
+      const registry = createRegistry();
+      registry.registerRepo({
+        path: resolved,
+        name,
+        ...(options.slackWebhook ? { slack_webhook: options.slackWebhook } : {}),
+      });
+
+      // Sync the newly registered repo into the database
+      const config = loadConfig({ repoPath: resolved });
+      const db = new KanbanDatabase();
+      const syncResult = syncRepo({ repoPath: resolved, db, config });
+      db.close();
+
+      const result = {
+        success: true,
+        repo: {
+          name,
+          path: resolved,
+          ...(options.slackWebhook ? { slack_webhook: options.slackWebhook } : {}),
+        },
+        sync: {
+          epics: syncResult.epics,
+          tickets: syncResult.tickets,
+          stages: syncResult.stages,
+          dependencies: syncResult.dependencies,
+          errors: syncResult.errors,
+        },
+      };
+
+      const indent = options.pretty ? 2 : undefined;
+      const output = JSON.stringify(result, null, indent) + '\n';
+      writeOutput(output, options.output);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      process.stderr.write(`Error: ${message}\n`);
+      process.exit(2);
+    }
+  });

--- a/tools/kanban-cli/src/cli/commands/unregister-repo.ts
+++ b/tools/kanban-cli/src/cli/commands/unregister-repo.ts
@@ -1,0 +1,28 @@
+import { Command } from 'commander';
+import { createRegistry } from '../../repos/registry.js';
+import { writeOutput } from '../utils/output.js';
+
+export const unregisterRepoCommand = new Command('unregister-repo')
+  .description('Unregister a repository from multi-repo tracking')
+  .argument('<name>', 'Name of the repo to unregister')
+  .option('--pretty', 'Pretty-print JSON output', false)
+  .option('-o, --output <file>', 'Write output to file instead of stdout')
+  .action(async (name: string, options) => {
+    try {
+      const registry = createRegistry();
+      registry.unregisterRepo(name);
+
+      const result = {
+        success: true,
+        unregistered: name,
+      };
+
+      const indent = options.pretty ? 2 : undefined;
+      const output = JSON.stringify(result, null, indent) + '\n';
+      writeOutput(output, options.output);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      process.stderr.write(`Error: ${message}\n`);
+      process.exit(2);
+    }
+  });

--- a/tools/kanban-cli/src/cli/commands/validate.ts
+++ b/tools/kanban-cli/src/cli/commands/validate.ts
@@ -16,171 +16,335 @@ import { registerBuiltinResolvers } from '../../resolvers/builtins/index.js';
 import { StateMachine } from '../../engine/state-machine.js';
 import { RESERVED_STATUSES } from '../../types/pipeline.js';
 import { writeOutput } from '../utils/output.js';
+import { createMultiRepoHelper } from '../../repos/multi-repo.js';
+import { createRegistry } from '../../repos/registry.js';
 
 export const validateCommand = new Command('validate')
   .description('Validate all frontmatter and dependency integrity')
   .option('--repo <path>', 'Path to repository', process.cwd())
+  .option('--global', 'Validate across all registered repos', false)
   .option('--pretty', 'Pretty-print JSON output', false)
   .option('-o, --output <file>', 'Write output to file instead of stdout')
   .action(async (options) => {
+    const db = new KanbanDatabase();
     try {
-      const repoPath = path.resolve(options.repo);
-      const config = loadConfig({ repoPath });
-      const db = new KanbanDatabase();
+      if (options.global) {
+        // ── Global mode: validate across all registered repos ──
+        const registry = createRegistry();
+        const helper = createMultiRepoHelper({ registry, db });
 
-      // Sync files into database
-      syncRepo({ repoPath, db, config });
-
-      // Get the repo ID
-      const repoRepo = new RepoRepository(db);
-      const repo = repoRepo.findByPath(repoPath);
-      if (!repo) {
-        process.stderr.write('Error: Repository not found after sync\n');
-        process.exit(2);
-        return;
-      }
-      const repoId = repo.id;
-
-      // Load all data from repositories
-      const epicRows = new EpicRepository(db).listByRepo(repoId);
-      const ticketRows = new TicketRepository(db).listByRepo(repoId);
-      const stageRows = new StageRepository(db).listByRepo(repoId);
-      const depRows = new DependencyRepository(db).listByRepo(repoId);
-
-      // Build the set of all known IDs
-      const allIds = new Set<string>();
-      for (const e of epicRows) allIds.add(e.id);
-      for (const t of ticketRows) allIds.add(t.id);
-      for (const s of stageRows) allIds.add(s.id);
-
-      // Build valid status set: reserved + pipeline statuses + common statuses
-      const sm = StateMachine.fromConfig(config);
-      const validStatuses = new Set<string>([
-        ...RESERVED_STATUSES,
-        'Complete',
-        'In Progress',
-        'Skipped',
-        ...sm.getAllStatuses(),
-      ]);
-
-      // Build dependency lookup for depends_on arrays
-      const depsByFromId = new Map<string, string[]>();
-      for (const d of depRows) {
-        const existing = depsByFromId.get(d.from_id) || [];
-        existing.push(d.to_id);
-        depsByFromId.set(d.from_id, existing);
-      }
-
-      // Build stage-to-ticket lookup for ticket.stages
-      const stagesByTicket = new Map<string, string[]>();
-      for (const s of stageRows) {
-        if (s.ticket_id) {
-          const existing = stagesByTicket.get(s.ticket_id) || [];
-          existing.push(s.id);
-          stagesByTicket.set(s.ticket_id, existing);
+        const repoInfos = helper.syncAllRepos();
+        if (repoInfos.length === 0) {
+          process.stderr.write('Error: No repos registered. Use register-repo to add repos.\n');
+          process.exit(2);
+          return;
         }
-      }
 
-      // Build ticket-to-epic lookup for epic.tickets
-      const ticketsByEpic = new Map<string, string[]>();
-      for (const t of ticketRows) {
-        if (t.epic_id) {
-          const existing = ticketsByEpic.get(t.epic_id) || [];
-          existing.push(t.id);
-          ticketsByEpic.set(t.epic_id, existing);
+        const repoIds = repoInfos.map((r) => r.repoId);
+        const repoNames = repoInfos.map((r) => r.repoName);
+        const aggregated = helper.loadAllRepoData(repoIds);
+
+        // TODO: Global mode currently uses the first repo's pipeline config for validation.
+        // Repos with different pipeline phases may produce unexpected validation results.
+        // Fix: merge workflow.phases from all repos into a superset.
+        const config = loadConfig({ repoPath: repoInfos[0].repoPath });
+
+        // Build the set of all known IDs across all repos
+        const allIds = new Set<string>();
+        for (const e of aggregated.epics) allIds.add(e.id);
+        for (const t of aggregated.tickets) allIds.add(t.id);
+        for (const s of aggregated.stages) allIds.add(s.id);
+
+        // Build valid status set: reserved + pipeline statuses + common statuses
+        const sm = StateMachine.fromConfig(config);
+        const validStatuses = new Set<string>([
+          ...RESERVED_STATUSES,
+          'Complete',
+          'In Progress',
+          'Skipped',
+          ...sm.getAllStatuses(),
+        ]);
+
+        // Build dependency lookup for depends_on arrays (across all repos)
+        const depsByFromId = new Map<string, string[]>();
+        for (const d of aggregated.deps) {
+          const existing = depsByFromId.get(d.from_id) || [];
+          existing.push(d.to_id);
+          depsByFromId.set(d.from_id, existing);
         }
+
+        // Build stage-to-ticket lookup for ticket.stages
+        const stagesByTicket = new Map<string, string[]>();
+        for (const s of aggregated.stages) {
+          if (s.ticket_id) {
+            const existing = stagesByTicket.get(s.ticket_id) || [];
+            existing.push(s.id);
+            stagesByTicket.set(s.ticket_id, existing);
+          }
+        }
+
+        // Build ticket-to-epic lookup for epic.tickets
+        const ticketsByEpic = new Map<string, string[]>();
+        for (const t of aggregated.tickets) {
+          if (t.epic_id) {
+            const existing = ticketsByEpic.get(t.epic_id) || [];
+            existing.push(t.id);
+            ticketsByEpic.set(t.epic_id, existing);
+          }
+        }
+
+        // Map DB rows to validate logic input types (with repo field)
+        const epics: ValidateEpicRow[] = aggregated.epics.map((e) => ({
+          id: e.id,
+          title: e.title ?? '',
+          status: e.status ?? 'Not Started',
+          jira_key: e.jira_key,
+          tickets: ticketsByEpic.get(e.id) || [],
+          depends_on: depsByFromId.get(e.id) || [],
+          file_path: e.file_path,
+          repo: e.repo,
+        }));
+
+        const tickets: ValidateTicketRow[] = aggregated.tickets.map((t) => ({
+          id: t.id,
+          epic_id: t.epic_id ?? '',
+          title: t.title ?? '',
+          status: t.status ?? 'Not Started',
+          jira_key: t.jira_key,
+          source: t.source ?? 'local',
+          stages: stagesByTicket.get(t.id) || [],
+          depends_on: depsByFromId.get(t.id) || [],
+          jira_links: [],  // jira_links are not stored in DB; validation applies to frontmatter-parsed data
+          file_path: t.file_path,
+          repo: t.repo,
+        }));
+
+        const stages: ValidateStageRow[] = aggregated.stages.map((s) => ({
+          id: s.id,
+          ticket_id: s.ticket_id ?? '',
+          epic_id: s.epic_id ?? '',
+          title: s.title ?? '',
+          status: s.status ?? 'Not Started',
+          refinement_type: s.refinement_type ?? '[]',
+          worktree_branch: s.worktree_branch ?? '',
+          priority: s.priority,
+          due_date: s.due_date,
+          session_active: s.session_active === 1,
+          depends_on: depsByFromId.get(s.id) || [],
+          pending_merge_parents: s.pending_merge_parents ? JSON.parse(s.pending_merge_parents) : [],
+          is_draft: s.is_draft === 1,
+          file_path: s.file_path,
+          repo: s.repo,
+        }));
+
+        const dependencies: ValidateDependencyRow[] = aggregated.deps.map((d) => ({
+          from_id: d.from_id,
+          to_id: d.to_id,
+          resolved: d.resolved === 1,
+        }));
+
+        // Run work-item validation
+        const workItemResult = validateWorkItems({
+          epics,
+          tickets,
+          stages,
+          dependencies,
+          allIds,
+          validStatuses,
+          global: true,
+        });
+
+        // Also run pipeline validation (using first repo's config - see TODO above)
+        const resolverRegistry = new ResolverRegistry();
+        registerBuiltinResolvers(resolverRegistry);
+        const pipelineResult = await validatePipeline(config, { registry: resolverRegistry });
+
+        // Combine results
+        const combined: ValidateOutput & { pipeline_valid: boolean } = {
+          valid: workItemResult.valid && pipelineResult.valid,
+          errors: [
+            ...workItemResult.errors,
+            ...pipelineResult.errors.map((e) => ({
+              file: '.kanban-workflow.yaml',
+              field: 'pipeline',
+              error: e,
+            })),
+          ],
+          warnings: [
+            ...workItemResult.warnings,
+            ...pipelineResult.warnings.map((w) => ({
+              file: '.kanban-workflow.yaml',
+              field: 'pipeline',
+              warning: w,
+            })),
+          ],
+          pipeline_valid: pipelineResult.valid,
+          repos: repoNames,
+        };
+
+        const indent = options.pretty ? 2 : undefined;
+        const output = JSON.stringify(combined, null, indent) + '\n';
+        writeOutput(output, options.output);
+      } else {
+        // ── Single-repo mode: existing behavior unchanged ──
+        const repoPath = path.resolve(options.repo);
+        const config = loadConfig({ repoPath });
+
+        // Sync files into database
+        syncRepo({ repoPath, db, config });
+
+        // Get the repo ID
+        const repoRepo = new RepoRepository(db);
+        const repo = repoRepo.findByPath(repoPath);
+        if (!repo) {
+          process.stderr.write('Error: Repository not found after sync\n');
+          process.exit(2);
+          return;
+        }
+        const repoId = repo.id;
+
+        // Load all data from repositories
+        const epicRows = new EpicRepository(db).listByRepo(repoId);
+        const ticketRows = new TicketRepository(db).listByRepo(repoId);
+        const stageRows = new StageRepository(db).listByRepo(repoId);
+        const depRows = new DependencyRepository(db).listByRepo(repoId);
+
+        // Build the set of all known IDs
+        const allIds = new Set<string>();
+        for (const e of epicRows) allIds.add(e.id);
+        for (const t of ticketRows) allIds.add(t.id);
+        for (const s of stageRows) allIds.add(s.id);
+
+        // Build valid status set: reserved + pipeline statuses + common statuses
+        const sm = StateMachine.fromConfig(config);
+        const validStatuses = new Set<string>([
+          ...RESERVED_STATUSES,
+          'Complete',
+          'In Progress',
+          'Skipped',
+          ...sm.getAllStatuses(),
+        ]);
+
+        // Build dependency lookup for depends_on arrays
+        const depsByFromId = new Map<string, string[]>();
+        for (const d of depRows) {
+          const existing = depsByFromId.get(d.from_id) || [];
+          existing.push(d.to_id);
+          depsByFromId.set(d.from_id, existing);
+        }
+
+        // Build stage-to-ticket lookup for ticket.stages
+        const stagesByTicket = new Map<string, string[]>();
+        for (const s of stageRows) {
+          if (s.ticket_id) {
+            const existing = stagesByTicket.get(s.ticket_id) || [];
+            existing.push(s.id);
+            stagesByTicket.set(s.ticket_id, existing);
+          }
+        }
+
+        // Build ticket-to-epic lookup for epic.tickets
+        const ticketsByEpic = new Map<string, string[]>();
+        for (const t of ticketRows) {
+          if (t.epic_id) {
+            const existing = ticketsByEpic.get(t.epic_id) || [];
+            existing.push(t.id);
+            ticketsByEpic.set(t.epic_id, existing);
+          }
+        }
+
+        // Map DB rows to validate logic input types
+        const epics: ValidateEpicRow[] = epicRows.map((e) => ({
+          id: e.id,
+          title: e.title ?? '',
+          status: e.status ?? 'Not Started',
+          jira_key: e.jira_key,
+          tickets: ticketsByEpic.get(e.id) || [],
+          depends_on: depsByFromId.get(e.id) || [],
+          file_path: e.file_path,
+        }));
+
+        const tickets: ValidateTicketRow[] = ticketRows.map((t) => ({
+          id: t.id,
+          epic_id: t.epic_id ?? '',
+          title: t.title ?? '',
+          status: t.status ?? 'Not Started',
+          jira_key: t.jira_key,
+          source: t.source ?? 'local',
+          stages: stagesByTicket.get(t.id) || [],
+          depends_on: depsByFromId.get(t.id) || [],
+          jira_links: [],  // jira_links are not stored in DB; validation applies to frontmatter-parsed data
+          file_path: t.file_path,
+        }));
+
+        const stages: ValidateStageRow[] = stageRows.map((s) => ({
+          id: s.id,
+          ticket_id: s.ticket_id ?? '',
+          epic_id: s.epic_id ?? '',
+          title: s.title ?? '',
+          status: s.status ?? 'Not Started',
+          refinement_type: s.refinement_type ?? '[]',
+          worktree_branch: s.worktree_branch ?? '',
+          priority: s.priority,
+          due_date: s.due_date,
+          session_active: s.session_active === 1,
+          depends_on: depsByFromId.get(s.id) || [],
+          pending_merge_parents: s.pending_merge_parents ? JSON.parse(s.pending_merge_parents) : [],
+          is_draft: s.is_draft === 1,
+          file_path: s.file_path,
+        }));
+
+        const dependencies: ValidateDependencyRow[] = depRows.map((d) => ({
+          from_id: d.from_id,
+          to_id: d.to_id,
+          resolved: d.resolved === 1,
+        }));
+
+        // Run work-item validation
+        const workItemResult = validateWorkItems({
+          epics,
+          tickets,
+          stages,
+          dependencies,
+          allIds,
+          validStatuses,
+        });
+
+        // Also run pipeline validation
+        const resolverRegistry = new ResolverRegistry();
+        registerBuiltinResolvers(resolverRegistry);
+        const pipelineResult = await validatePipeline(config, { registry: resolverRegistry });
+
+        // Combine results
+        const combined: ValidateOutput & { pipeline_valid: boolean } = {
+          valid: workItemResult.valid && pipelineResult.valid,
+          errors: [
+            ...workItemResult.errors,
+            ...pipelineResult.errors.map((e) => ({
+              file: '.kanban-workflow.yaml',
+              field: 'pipeline',
+              error: e,
+            })),
+          ],
+          warnings: [
+            ...workItemResult.warnings,
+            ...pipelineResult.warnings.map((w) => ({
+              file: '.kanban-workflow.yaml',
+              field: 'pipeline',
+              warning: w,
+            })),
+          ],
+          pipeline_valid: pipelineResult.valid,
+        };
+
+        const indent = options.pretty ? 2 : undefined;
+        const output = JSON.stringify(combined, null, indent) + '\n';
+        writeOutput(output, options.output);
+        db.close();
+        process.exit(combined.valid ? 0 : 1);
       }
-
-      // Map DB rows to validate logic input types
-      const epics: ValidateEpicRow[] = epicRows.map((e) => ({
-        id: e.id,
-        title: e.title ?? '',
-        status: e.status ?? 'Not Started',
-        jira_key: e.jira_key,
-        tickets: ticketsByEpic.get(e.id) || [],
-        depends_on: depsByFromId.get(e.id) || [],
-        file_path: e.file_path,
-      }));
-
-      const tickets: ValidateTicketRow[] = ticketRows.map((t) => ({
-        id: t.id,
-        epic_id: t.epic_id ?? '',
-        title: t.title ?? '',
-        status: t.status ?? 'Not Started',
-        jira_key: t.jira_key,
-        source: t.source ?? 'local',
-        stages: stagesByTicket.get(t.id) || [],
-        depends_on: depsByFromId.get(t.id) || [],
-        jira_links: [],  // jira_links are not stored in DB; validation applies to frontmatter-parsed data
-        file_path: t.file_path,
-      }));
-
-      const stages: ValidateStageRow[] = stageRows.map((s) => ({
-        id: s.id,
-        ticket_id: s.ticket_id ?? '',
-        epic_id: s.epic_id ?? '',
-        title: s.title ?? '',
-        status: s.status ?? 'Not Started',
-        refinement_type: s.refinement_type ?? '[]',
-        worktree_branch: s.worktree_branch ?? '',
-        priority: s.priority,
-        due_date: s.due_date,
-        session_active: s.session_active === 1,
-        depends_on: depsByFromId.get(s.id) || [],
-        pending_merge_parents: s.pending_merge_parents ? JSON.parse(s.pending_merge_parents) : [],
-        is_draft: s.is_draft === 1,
-        file_path: s.file_path,
-      }));
-
-      const dependencies: ValidateDependencyRow[] = depRows.map((d) => ({
-        from_id: d.from_id,
-        to_id: d.to_id,
-        resolved: d.resolved === 1,
-      }));
-
-      // Run work-item validation
-      const workItemResult = validateWorkItems({
-        epics,
-        tickets,
-        stages,
-        dependencies,
-        allIds,
-        validStatuses,
-      });
-
-      // Also run pipeline validation
-      const registry = new ResolverRegistry();
-      registerBuiltinResolvers(registry);
-      const pipelineResult = await validatePipeline(config, { registry });
-
-      // Combine results
-      const combined: ValidateOutput & { pipeline_valid: boolean } = {
-        valid: workItemResult.valid && pipelineResult.valid,
-        errors: [
-          ...workItemResult.errors,
-          ...pipelineResult.errors.map((e) => ({
-            file: '.kanban-workflow.yaml',
-            field: 'pipeline',
-            error: e,
-          })),
-        ],
-        warnings: [
-          ...workItemResult.warnings,
-          ...pipelineResult.warnings.map((w) => ({
-            file: '.kanban-workflow.yaml',
-            field: 'pipeline',
-            warning: w,
-          })),
-        ],
-        pipeline_valid: pipelineResult.valid,
-      };
-
-      const indent = options.pretty ? 2 : undefined;
-      const output = JSON.stringify(combined, null, indent) + '\n';
-      writeOutput(output, options.output);
-      db.close();
-      process.exit(combined.valid ? 0 : 1);
     } catch (err) {
+      db.close();
       const message = err instanceof Error ? err.message : String(err);
       process.stderr.write(`Error: ${message}\n`);
       process.exit(2);

--- a/tools/kanban-cli/src/cli/formatters/board-html.ts
+++ b/tools/kanban-cli/src/cli/formatters/board-html.ts
@@ -51,6 +51,7 @@ function renderTicketCard(item: TicketBoardItem): string {
           ${item.epic ? `<span class="badge badge-epic">${escapeHtml(item.epic)}</span>` : ''}
           <span class="badge badge-source">${escapeHtml(item.source)}</span>
           ${item.jira_key ? `<span class="badge badge-jira">${escapeHtml(item.jira_key)}</span>` : ''}
+          ${item.repo ? `<span class="badge badge-repo">${escapeHtml(item.repo)}</span>` : ''}
         </div>
       </div>`;
 }
@@ -72,6 +73,7 @@ function renderStageCard(item: StageBoardItem): string {
           ${item.epic ? `<span class="badge badge-epic">${escapeHtml(item.epic)}</span>` : ''}
           ${item.blocked_by && item.blocked_by.length > 0 ? `<span class="badge badge-blocked">Blocked</span>` : ''}
           ${item.worktree_branch ? `<span class="badge badge-branch" title="${escapeHtml(item.worktree_branch)}">branch</span>` : ''}
+          ${item.repo ? `<span class="badge badge-repo">${escapeHtml(item.repo)}</span>` : ''}
         </div>
       </div>`;
 }
@@ -137,7 +139,7 @@ export function renderBoardHtml(board: BoardOutput): string {
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Kanban Board - ${escapeHtml(board.repo)}</title>
+  <title>Kanban Board - ${board.repos ? 'Global' : escapeHtml(board.repo)}</title>
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }
     body {
@@ -237,6 +239,7 @@ export function renderBoardHtml(board: BoardOutput): string {
     .badge-jira { background: #fff3e0; color: #e65100; }
     .badge-blocked { background: #ffebee; color: #c62828; }
     .badge-branch { background: #e8f5e9; color: #2e7d32; }
+    .badge-repo { background: #fce4ec; color: #880e4f; }
     .pending-merge { cursor: help; }
     .session-dot {
       display: inline-block;
@@ -267,7 +270,7 @@ export function renderBoardHtml(board: BoardOutput): string {
   <div class="board">
     ${columnsHtml}
   </div>
-  <footer>Generated ${escapeHtml(board.generated_at)} &mdash; ${escapeHtml(board.repo)}</footer>
+  <footer>Generated ${escapeHtml(board.generated_at)} &mdash; ${board.repos ? `Global (${board.repos.map(escapeHtml).join(', ')})` : escapeHtml(board.repo)}</footer>
 </body>
 </html>`;
 }

--- a/tools/kanban-cli/src/cli/formatters/graph-mermaid.ts
+++ b/tools/kanban-cli/src/cli/formatters/graph-mermaid.ts
@@ -113,15 +113,17 @@ function nodeDefinition(node: GraphNode): string {
  * Format a GraphOutput as a Mermaid diagram string.
  *
  * Produces a `graph TD` diagram with:
- * - Subgraphs grouping tickets/stages under their epic
+ * - In global mode: top-level subgraphs per repo, then epic subgraphs inside
+ * - In single-repo mode: subgraphs grouping tickets/stages under their epic
  * - Shaped nodes by type (stadium for epics, rect for tickets, rounded for stages)
  * - Colored nodes by status
  * - Solid arrows for resolved deps, dashed arrows for unresolved
+ * - Thick dashed arrows for cross-repo edges (global mode only)
  * - Thick arrows for critical path edges
  * - Comments noting any detected cycles
  */
 export function formatGraphAsMermaid(graph: GraphOutput): string {
-  const { nodes, edges, cycles, critical_path } = graph;
+  const { nodes, edges, cycles, critical_path, repos } = graph;
   const lines: string[] = ['graph TD'];
 
   if (nodes.length === 0) {
@@ -146,81 +148,190 @@ export function formatGraphAsMermaid(graph: GraphOutput): string {
     criticalEdges.add(`${critical_path[i + 1]}|${critical_path[i]}`);
   }
 
-  // Group nodes by epic for subgraph rendering
-  const epicNodes = nodes.filter((n) => n.type === 'epic');
-  const epicChildMap = new Map<string, GraphNode[]>(); // epicId -> children (tickets + stages)
-  const ungroupedNodes: GraphNode[] = [];
+  // Check if this is global mode
+  const isGlobal = repos && repos.length > 0;
 
-  // Initialize epic groups
-  for (const epic of epicNodes) {
-    epicChildMap.set(epic.id, []);
-  }
+  if (isGlobal) {
+    // ── Global mode: group by repo, then by epic ──
 
-  // Assign tickets and stages to their epic groups
-  for (const node of nodes) {
-    if (node.type === 'epic') continue;
-    const epicId = inferEpicId(node);
-    if (epicId && epicChildMap.has(epicId)) {
-      epicChildMap.get(epicId)!.push(node);
-    } else {
-      ungroupedNodes.push(node);
-    }
-  }
+    // Group nodes by repo
+    const repoNodeMap = new Map<string, GraphNode[]>();
+    const ungroupedByRepo: GraphNode[] = [];
 
-  // Render subgraphs for each epic with nested ticket subgraphs
-  for (const epic of epicNodes) {
-    const children = epicChildMap.get(epic.id) || [];
-    const safeEpicId = sanitizeNodeId(epic.id);
-    lines.push(`    subgraph sub_${safeEpicId} ["${epic.id}: ${epic.title}"]`);
-    // Epic node itself inside the subgraph
-    lines.push(`        ${nodeDefinition(epic)}`);
-
-    // Separate children into tickets and stages, group stages by ticket
-    const tickets = children.filter((n) => n.type === 'ticket');
-    const stages = children.filter((n) => n.type === 'stage');
-
-    // Map ticketId -> stages belonging to that ticket
-    const ticketStageMap = new Map<string, GraphNode[]>();
-    const ungroupedStages: GraphNode[] = [];
-
-    // Initialize ticket stage groups
-    for (const ticket of tickets) {
-      ticketStageMap.set(ticket.id, []);
+    for (const repo of repos) {
+      repoNodeMap.set(repo, []);
     }
 
-    // Assign stages to their ticket groups
-    for (const stage of stages) {
-      const ticketId = inferTicketId(stage);
-      if (ticketId && ticketStageMap.has(ticketId)) {
-        ticketStageMap.get(ticketId)!.push(stage);
+    for (const node of nodes) {
+      if (node.repo && repoNodeMap.has(node.repo)) {
+        repoNodeMap.get(node.repo)!.push(node);
       } else {
-        ungroupedStages.push(stage);
+        ungroupedByRepo.push(node);
       }
     }
 
-    // Render ticket subgraphs
-    for (const ticket of tickets) {
-      const safeTicketId = sanitizeNodeId(ticket.id);
-      const ticketStages = ticketStageMap.get(ticket.id) || [];
-      lines.push(`        subgraph sub_${safeTicketId} ["${ticket.id}: ${ticket.title}"]`);
-      lines.push(`            ${nodeDefinition(ticket)}`);
-      for (const stage of ticketStages) {
-        lines.push(`            ${nodeDefinition(stage)}`);
+    // Render repo subgraphs
+    for (const repo of repos) {
+      const repoNodes = repoNodeMap.get(repo) || [];
+      if (repoNodes.length === 0) continue;
+
+      const safeRepoId = sanitizeNodeId(repo);
+      lines.push(`    subgraph repo_${safeRepoId} ["${repo}"]`);
+
+      // Group nodes within repo by epic
+      const epicNodes = repoNodes.filter((n) => n.type === 'epic');
+      const epicChildMap = new Map<string, GraphNode[]>();
+      const repoUngroupedNodes: GraphNode[] = [];
+
+      for (const epic of epicNodes) {
+        epicChildMap.set(epic.id, []);
       }
-      lines.push('        end');
+
+      for (const node of repoNodes) {
+        if (node.type === 'epic') continue;
+        const epicId = inferEpicId(node);
+        if (epicId && epicChildMap.has(epicId)) {
+          epicChildMap.get(epicId)!.push(node);
+        } else {
+          repoUngroupedNodes.push(node);
+        }
+      }
+
+      // Render epic subgraphs within repo
+      for (const epic of epicNodes) {
+        const children = epicChildMap.get(epic.id) || [];
+        const safeEpicId = sanitizeNodeId(epic.id);
+        lines.push(`        subgraph sub_${safeEpicId} ["${epic.id}: ${epic.title}"]`);
+        lines.push(`            ${nodeDefinition(epic)}`);
+
+        const tickets = children.filter((n) => n.type === 'ticket');
+        const stages = children.filter((n) => n.type === 'stage');
+
+        const ticketStageMap = new Map<string, GraphNode[]>();
+        const ungroupedStages: GraphNode[] = [];
+
+        for (const ticket of tickets) {
+          ticketStageMap.set(ticket.id, []);
+        }
+
+        for (const stage of stages) {
+          const ticketId = inferTicketId(stage);
+          if (ticketId && ticketStageMap.has(ticketId)) {
+            ticketStageMap.get(ticketId)!.push(stage);
+          } else {
+            ungroupedStages.push(stage);
+          }
+        }
+
+        for (const ticket of tickets) {
+          const safeTicketId = sanitizeNodeId(ticket.id);
+          const ticketStages = ticketStageMap.get(ticket.id) || [];
+          lines.push(`            subgraph sub_${safeTicketId} ["${ticket.id}: ${ticket.title}"]`);
+          lines.push(`                ${nodeDefinition(ticket)}`);
+          for (const stage of ticketStages) {
+            lines.push(`                ${nodeDefinition(stage)}`);
+          }
+          lines.push('            end');
+        }
+
+        for (const stage of ungroupedStages) {
+          lines.push(`            ${nodeDefinition(stage)}`);
+        }
+
+        lines.push('        end');
+      }
+
+      // Render ungrouped nodes within repo
+      for (const node of repoUngroupedNodes) {
+        lines.push(`        ${nodeDefinition(node)}`);
+      }
+
+      lines.push('    end');
     }
 
-    // Render any stages that couldn't be matched to a ticket
-    for (const stage of ungroupedStages) {
-      lines.push(`        ${nodeDefinition(stage)}`);
+    // Render ungrouped nodes (no repo field)
+    for (const node of ungroupedByRepo) {
+      lines.push(`    ${nodeDefinition(node)}`);
+    }
+  } else {
+    // ── Single-repo mode: group by epic only ──
+
+    // Group nodes by epic for subgraph rendering
+    const epicNodes = nodes.filter((n) => n.type === 'epic');
+    const epicChildMap = new Map<string, GraphNode[]>(); // epicId -> children (tickets + stages)
+    const ungroupedNodes: GraphNode[] = [];
+
+    // Initialize epic groups
+    for (const epic of epicNodes) {
+      epicChildMap.set(epic.id, []);
     }
 
-    lines.push('    end');
-  }
+    // Assign tickets and stages to their epic groups
+    for (const node of nodes) {
+      if (node.type === 'epic') continue;
+      const epicId = inferEpicId(node);
+      if (epicId && epicChildMap.has(epicId)) {
+        epicChildMap.get(epicId)!.push(node);
+      } else {
+        ungroupedNodes.push(node);
+      }
+    }
 
-  // Render ungrouped nodes
-  for (const node of ungroupedNodes) {
-    lines.push(`    ${nodeDefinition(node)}`);
+    // Render subgraphs for each epic with nested ticket subgraphs
+    for (const epic of epicNodes) {
+      const children = epicChildMap.get(epic.id) || [];
+      const safeEpicId = sanitizeNodeId(epic.id);
+      lines.push(`    subgraph sub_${safeEpicId} ["${epic.id}: ${epic.title}"]`);
+      // Epic node itself inside the subgraph
+      lines.push(`        ${nodeDefinition(epic)}`);
+
+      // Separate children into tickets and stages, group stages by ticket
+      const tickets = children.filter((n) => n.type === 'ticket');
+      const stages = children.filter((n) => n.type === 'stage');
+
+      // Map ticketId -> stages belonging to that ticket
+      const ticketStageMap = new Map<string, GraphNode[]>();
+      const ungroupedStages: GraphNode[] = [];
+
+      // Initialize ticket stage groups
+      for (const ticket of tickets) {
+        ticketStageMap.set(ticket.id, []);
+      }
+
+      // Assign stages to their ticket groups
+      for (const stage of stages) {
+        const ticketId = inferTicketId(stage);
+        if (ticketId && ticketStageMap.has(ticketId)) {
+          ticketStageMap.get(ticketId)!.push(stage);
+        } else {
+          ungroupedStages.push(stage);
+        }
+      }
+
+      // Render ticket subgraphs
+      for (const ticket of tickets) {
+        const safeTicketId = sanitizeNodeId(ticket.id);
+        const ticketStages = ticketStageMap.get(ticket.id) || [];
+        lines.push(`        subgraph sub_${safeTicketId} ["${ticket.id}: ${ticket.title}"]`);
+        lines.push(`            ${nodeDefinition(ticket)}`);
+        for (const stage of ticketStages) {
+          lines.push(`            ${nodeDefinition(stage)}`);
+        }
+        lines.push('        end');
+      }
+
+      // Render any stages that couldn't be matched to a ticket
+      for (const stage of ungroupedStages) {
+        lines.push(`        ${nodeDefinition(stage)}`);
+      }
+
+      lines.push('    end');
+    }
+
+    // Render ungrouped nodes
+    for (const node of ungroupedNodes) {
+      lines.push(`    ${nodeDefinition(node)}`);
+    }
   }
 
   // Render edges
@@ -231,6 +342,9 @@ export function formatGraphAsMermaid(graph: GraphOutput): string {
 
     if (isCritical) {
       lines.push(`    ${fromSafe} ==> ${toSafe}`);
+    } else if (edge.cross_repo) {
+      // Cross-repo edges use thick dashed style
+      lines.push(`    ${fromSafe} -.->|cross-repo| ${toSafe}`);
     } else if (edge.resolved) {
       lines.push(`    ${fromSafe} --> ${toSafe}`);
     } else {

--- a/tools/kanban-cli/src/cli/index.ts
+++ b/tools/kanban-cli/src/cli/index.ts
@@ -12,6 +12,9 @@ import { jiraImportCommand } from './commands/jira-import.js';
 import { jiraSyncCommand } from './commands/jira-sync.js';
 import { learningsCountCommand } from './commands/learnings-count.js';
 import { enrichCommand } from './commands/enrich.js';
+import { registerRepoCommand } from './commands/register-repo.js';
+import { unregisterRepoCommand } from './commands/unregister-repo.js';
+import { listReposCommand } from './commands/list-repos.js';
 
 const program = new Command();
 
@@ -32,5 +35,8 @@ program.addCommand(jiraImportCommand);
 program.addCommand(jiraSyncCommand);
 program.addCommand(learningsCountCommand);
 program.addCommand(enrichCommand);
+program.addCommand(registerRepoCommand);
+program.addCommand(unregisterRepoCommand);
+program.addCommand(listReposCommand);
 
 program.parse();

--- a/tools/kanban-cli/src/cli/logic/next.ts
+++ b/tools/kanban-cli/src/cli/logic/next.ts
@@ -16,6 +16,7 @@ export interface NextStageRow {
   priority: number;
   due_date: string | null;
   session_active: boolean;
+  repo?: string;
 }
 
 export interface NextDependencyRow {
@@ -45,6 +46,7 @@ export interface ReadyStage {
   priority_score: number;
   priority_reason: string;
   needs_human: boolean;
+  repo?: string;
 }
 
 export interface NextOutput {
@@ -52,6 +54,7 @@ export interface NextOutput {
   blocked_count: number;
   in_progress_count: number;
   to_convert_count: number;
+  repos?: string[];
 }
 
 export interface BuildNextInput {
@@ -207,6 +210,7 @@ export function buildNext(input: BuildNextInput): NextOutput {
       priority_score: priorityScore,
       priority_reason: priorityReason,
       needs_human: needsHuman,
+      ...(stage.repo ? { repo: stage.repo } : {}),
     } satisfies ReadyStage;
   });
 

--- a/tools/kanban-cli/src/cli/logic/validate.ts
+++ b/tools/kanban-cli/src/cli/logic/validate.ts
@@ -458,11 +458,15 @@ export function validateWorkItems(input: ValidateInput): ValidateOutput {
   // --- Check for circular dependencies ---
   const circles = findCircularDeps(dependencies);
   for (const cycle of circles) {
-    errors.push({
+    const err: ValidationError = {
       file: '',
       field: 'depends_on',
       error: `Circular dependency detected: ${cycle.join(' → ')} → ${cycle[0]}`,
-    });
+    };
+    if (global) {
+      err.repo = 'cross-repo';
+    }
+    errors.push(err);
   }
 
   return {

--- a/tools/kanban-cli/src/cli/logic/validate.ts
+++ b/tools/kanban-cli/src/cli/logic/validate.ts
@@ -8,6 +8,7 @@ export interface ValidateEpicRow {
   tickets: string[];
   depends_on: string[];
   file_path: string;
+  repo?: string;
 }
 
 export interface ValidateJiraLinkRow {
@@ -28,6 +29,7 @@ export interface ValidateTicketRow {
   depends_on: string[];
   jira_links: ValidateJiraLinkRow[];
   file_path: string;
+  repo?: string;
 }
 
 export interface ValidatePendingMergeParentRow {
@@ -52,6 +54,7 @@ export interface ValidateStageRow {
   pending_merge_parents: ValidatePendingMergeParentRow[];
   is_draft: boolean;
   file_path: string;
+  repo?: string;
 }
 
 export interface ValidateDependencyRow {
@@ -66,18 +69,21 @@ export interface ValidationError {
   file: string;
   field: string;
   error: string;
+  repo?: string;
 }
 
 export interface ValidationWarning {
   file: string;
   field: string;
   warning: string;
+  repo?: string;
 }
 
 export interface ValidateOutput {
   valid: boolean;
   errors: ValidationError[];
   warnings: ValidationWarning[];
+  repos?: string[];
 }
 
 export interface ValidateInput {
@@ -87,6 +93,7 @@ export interface ValidateInput {
   dependencies: ValidateDependencyRow[];
   allIds: Set<string>;
   validStatuses: Set<string>;
+  global?: boolean;
 }
 
 // ---------- Helpers ----------
@@ -171,7 +178,7 @@ const VALID_DEP_PAIRS: Record<string, Set<string>> = {
 // ---------- Core logic ----------
 
 export function validateWorkItems(input: ValidateInput): ValidateOutput {
-  const { epics, tickets, stages, dependencies, allIds, validStatuses } = input;
+  const { epics, tickets, stages, dependencies, allIds, validStatuses, global } = input;
   const errors: ValidationError[] = [];
   const warnings: ValidationWarning[] = [];
 
@@ -184,49 +191,59 @@ export function validateWorkItems(input: ValidateInput): ValidateOutput {
   for (const epic of epics) {
     // Required fields
     if (!epic.title) {
-      errors.push({ file: epic.file_path, field: 'title', error: 'Epic title is required' });
+      const err: ValidationError = { file: epic.file_path, field: 'title', error: 'Epic title is required' };
+      if (global && epic.repo) err.repo = epic.repo;
+      errors.push(err);
     }
 
     // Validate tickets array references
     for (const ticketId of epic.tickets) {
       if (!ticketIds.has(ticketId) && !allIds.has(ticketId)) {
-        errors.push({
+        const err: ValidationError = {
           file: epic.file_path,
           field: 'tickets',
           error: `Referenced ticket ${ticketId} does not exist`,
-        });
+        };
+        if (global && epic.repo) err.repo = epic.repo;
+        errors.push(err);
       }
     }
 
     // Validate depends_on references
     for (const depId of epic.depends_on) {
       if (!allIds.has(depId)) {
-        errors.push({
+        const err: ValidationError = {
           file: epic.file_path,
           field: 'depends_on',
           error: `Reference ${depId} does not exist`,
-        });
+        };
+        if (global && epic.repo) err.repo = epic.repo;
+        errors.push(err);
       } else {
         // Check valid dependency type
         const depType = getEntityType(depId);
         const allowed = VALID_DEP_PAIRS['epic'];
         if (allowed && !allowed.has(depType)) {
-          errors.push({
+          const err: ValidationError = {
             file: epic.file_path,
             field: 'depends_on',
             error: `Epic cannot depend on ${depType} (${depId}). Epics can only depend on other epics.`,
-          });
+          };
+          if (global && epic.repo) err.repo = epic.repo;
+          errors.push(err);
         }
       }
     }
 
     // Validate status
     if (!validStatuses.has(epic.status)) {
-      errors.push({
+      const err: ValidationError = {
         file: epic.file_path,
         field: 'status',
         error: `Invalid status "${epic.status}". Valid values: ${[...validStatuses].join(', ')}`,
-      });
+      };
+      if (global && epic.repo) err.repo = epic.repo;
+      errors.push(err);
     }
   }
 
@@ -234,87 +251,107 @@ export function validateWorkItems(input: ValidateInput): ValidateOutput {
   for (const ticket of tickets) {
     // Required fields
     if (!ticket.title) {
-      errors.push({ file: ticket.file_path, field: 'title', error: 'Ticket title is required' });
+      const err: ValidationError = { file: ticket.file_path, field: 'title', error: 'Ticket title is required' };
+      if (global && ticket.repo) err.repo = ticket.repo;
+      errors.push(err);
     }
 
     // Warning for tickets without stages
     if (ticket.stages.length === 0) {
-      warnings.push({
+      const warn: ValidationWarning = {
         file: ticket.file_path,
         field: 'stages',
         warning: 'Ticket has no stages — needs conversion',
-      });
+      };
+      if (global && ticket.repo) warn.repo = ticket.repo;
+      warnings.push(warn);
     }
 
     // Validate stages array references
     for (const stageId of ticket.stages) {
       if (!stageIds.has(stageId) && !allIds.has(stageId)) {
-        errors.push({
+        const err: ValidationError = {
           file: ticket.file_path,
           field: 'stages',
           error: `Referenced stage ${stageId} does not exist`,
-        });
+        };
+        if (global && ticket.repo) err.repo = ticket.repo;
+        errors.push(err);
       }
     }
 
     // Validate depends_on references
     for (const depId of ticket.depends_on) {
       if (!allIds.has(depId)) {
-        errors.push({
+        const err: ValidationError = {
           file: ticket.file_path,
           field: 'depends_on',
           error: `Reference ${depId} does not exist`,
-        });
+        };
+        if (global && ticket.repo) err.repo = ticket.repo;
+        errors.push(err);
       } else {
         const depType = getEntityType(depId);
         const allowed = VALID_DEP_PAIRS['ticket'];
         if (allowed && !allowed.has(depType)) {
-          errors.push({
+          const err: ValidationError = {
             file: ticket.file_path,
             field: 'depends_on',
             error: `Ticket cannot depend on ${depType} (${depId}). Tickets can depend on tickets and epics.`,
-          });
+          };
+          if (global && ticket.repo) err.repo = ticket.repo;
+          errors.push(err);
         }
       }
     }
 
     // Validate status
     if (!validStatuses.has(ticket.status)) {
-      errors.push({
+      const err: ValidationError = {
         file: ticket.file_path,
         field: 'status',
         error: `Invalid status "${ticket.status}". Valid values: ${[...validStatuses].join(', ')}`,
-      });
+      };
+      if (global && ticket.repo) err.repo = ticket.repo;
+      errors.push(err);
     }
 
     // Validate jira_links
     for (const link of ticket.jira_links) {
       if (!link.type) {
-        errors.push({
+        const err: ValidationError = {
           file: ticket.file_path,
           field: 'jira_links',
           error: 'Jira link is missing required field "type"',
-        });
+        };
+        if (global && ticket.repo) err.repo = ticket.repo;
+        errors.push(err);
       } else if (!(VALID_JIRA_LINK_TYPES as readonly string[]).includes(link.type)) {
-        errors.push({
+        const err: ValidationError = {
           file: ticket.file_path,
           field: 'jira_links',
           error: `Invalid jira_links type "${link.type}". Valid values: ${VALID_JIRA_LINK_TYPES.join(', ')}`,
-        });
+        };
+        if (global && ticket.repo) err.repo = ticket.repo;
+        errors.push(err);
       }
       if (!link.url) {
-        errors.push({
+        const err: ValidationError = {
           file: ticket.file_path,
           field: 'jira_links',
           error: 'Jira link is missing required field "url"',
-        });
+        };
+        if (global && ticket.repo) err.repo = ticket.repo;
+        errors.push(err);
       }
       if (!link.title) {
-        errors.push({
+        const err: ValidationError = {
           file: ticket.file_path,
           field: 'jira_links',
           error: 'Jira link is missing required field "title"',
-        });
+        };
+        if (global && ticket.repo) err.repo = ticket.repo;
+        errors.push(err);
       }
     }
   }
@@ -325,35 +362,43 @@ export function validateWorkItems(input: ValidateInput): ValidateOutput {
   for (const stage of stages) {
     // Required fields
     if (!stage.title) {
-      errors.push({ file: stage.file_path, field: 'title', error: 'Stage title is required' });
+      const err: ValidationError = { file: stage.file_path, field: 'title', error: 'Stage title is required' };
+      if (global && stage.repo) err.repo = stage.repo;
+      errors.push(err);
     }
 
     // Validate status
     if (!validStatuses.has(stage.status)) {
-      errors.push({
+      const err: ValidationError = {
         file: stage.file_path,
         field: 'status',
         error: `Invalid status "${stage.status}". Valid values: ${[...validStatuses].join(', ')}`,
-      });
+      };
+      if (global && stage.repo) err.repo = stage.repo;
+      errors.push(err);
     }
 
     // Validate depends_on references
     for (const depId of stage.depends_on) {
       if (!allIds.has(depId)) {
-        errors.push({
+        const err: ValidationError = {
           file: stage.file_path,
           field: 'depends_on',
           error: `Reference ${depId} does not exist`,
-        });
+        };
+        if (global && stage.repo) err.repo = stage.repo;
+        errors.push(err);
       } else {
         const depType = getEntityType(depId);
         const allowed = VALID_DEP_PAIRS['stage'];
         if (allowed && !allowed.has(depType)) {
-          errors.push({
+          const err: ValidationError = {
             file: stage.file_path,
             field: 'depends_on',
             error: `Stage cannot depend on ${depType} (${depId}). Invalid dependency type.`,
-          });
+          };
+          if (global && stage.repo) err.repo = stage.repo;
+          errors.push(err);
         }
       }
     }
@@ -362,11 +407,13 @@ export function validateWorkItems(input: ValidateInput): ValidateOutput {
     if (stage.worktree_branch) {
       const existingFile = worktreeBranches.get(stage.worktree_branch);
       if (existingFile) {
-        errors.push({
+        const err: ValidationError = {
           file: stage.file_path,
           field: 'worktree_branch',
           error: `Duplicate worktree_branch "${stage.worktree_branch}" — also used by ${existingFile}`,
-        });
+        };
+        if (global && stage.repo) err.repo = stage.repo;
+        errors.push(err);
       } else {
         worktreeBranches.set(stage.worktree_branch, stage.file_path);
       }
@@ -375,30 +422,36 @@ export function validateWorkItems(input: ValidateInput): ValidateOutput {
     // Validate pending_merge_parents
     for (const parent of stage.pending_merge_parents) {
       if (!stageIds.has(parent.stage_id)) {
-        errors.push({
+        const err: ValidationError = {
           file: stage.file_path,
           field: 'pending_merge_parents',
           error: `Referenced stage ${parent.stage_id} does not exist`,
-        });
+        };
+        if (global && stage.repo) err.repo = stage.repo;
+        errors.push(err);
       } else {
         const parentStatus = stageStatusById.get(parent.stage_id);
         if (parentStatus && !ACCEPTABLE_PARENT_STATUSES.has(parentStatus)) {
-          warnings.push({
+          const warn: ValidationWarning = {
             file: stage.file_path,
             field: 'pending_merge_parents',
             warning: `Parent stage ${parent.stage_id} has status "${parentStatus}" — expected PR Created, Addressing Comments, or Complete`,
-          });
+          };
+          if (global && stage.repo) warn.repo = stage.repo;
+          warnings.push(warn);
         }
       }
     }
 
     // is_draft: true with empty pending_merge_parents is inconsistent
     if (stage.is_draft && stage.pending_merge_parents.length === 0) {
-      warnings.push({
+      const warn: ValidationWarning = {
         file: stage.file_path,
         field: 'is_draft',
         warning: 'Stage is marked as draft but has no pending merge parents — inconsistent state',
-      });
+      };
+      if (global && stage.repo) warn.repo = stage.repo;
+      warnings.push(warn);
     }
   }
 

--- a/tools/kanban-cli/src/config/loader.ts
+++ b/tools/kanban-cli/src/config/loader.ts
@@ -14,6 +14,12 @@ export const CONFIG_PATHS = {
     'config.yaml'
   ),
   repoConfigName: '.kanban-workflow.yaml',
+  reposConfig: path.join(
+    os.homedir(),
+    '.config',
+    'kanban-workflow',
+    'repos.yaml'
+  ),
 } as const;
 
 export interface LoadConfigOptions {

--- a/tools/kanban-cli/src/db/repositories/dependency-repository.ts
+++ b/tools/kanban-cli/src/db/repositories/dependency-repository.ts
@@ -7,6 +7,7 @@ export interface DependencyUpsertData {
   from_type: string;
   to_type: string;
   repo_id: number;
+  target_repo_name?: string | null;
 }
 
 /**
@@ -24,6 +25,7 @@ export class DependencyRepository {
    */
   upsert(data: DependencyUpsertData): void {
     const raw = this.db.raw();
+    const targetRepoName = data.target_repo_name ?? null;
 
     const existing = raw
       .prepare('SELECT id FROM dependencies WHERE from_id = ? AND to_id = ?')
@@ -32,16 +34,16 @@ export class DependencyRepository {
     if (existing) {
       raw
         .prepare(
-          'UPDATE dependencies SET from_type = ?, to_type = ?, repo_id = ? WHERE id = ?'
+          'UPDATE dependencies SET from_type = ?, to_type = ?, repo_id = ?, target_repo_name = ? WHERE id = ?'
         )
-        .run(data.from_type, data.to_type, data.repo_id, existing.id);
+        .run(data.from_type, data.to_type, data.repo_id, targetRepoName, existing.id);
     } else {
       raw
         .prepare(
-          `INSERT INTO dependencies (from_id, to_id, from_type, to_type, repo_id)
-           VALUES (?, ?, ?, ?, ?)`
+          `INSERT INTO dependencies (from_id, to_id, from_type, to_type, repo_id, target_repo_name)
+           VALUES (?, ?, ?, ?, ?, ?)`
         )
-        .run(data.from_id, data.to_id, data.from_type, data.to_type, data.repo_id);
+        .run(data.from_id, data.to_id, data.from_type, data.to_type, data.repo_id, targetRepoName);
     }
   }
 

--- a/tools/kanban-cli/src/db/repositories/repo-repository.ts
+++ b/tools/kanban-cli/src/db/repositories/repo-repository.ts
@@ -59,18 +59,17 @@ export class RepoRepository {
   }
 
   /**
-   * Return all registered repos.
+   * Return all registered repos, ordered by name.
    */
   findAll(): RepoRecord[] {
     return this.db
       .raw()
-      .prepare('SELECT * FROM repos')
+      .prepare('SELECT * FROM repos ORDER BY name')
       .all() as RepoRecord[];
   }
 
-  /**
-   * Find a repo by its name (case-sensitive).
-   */
+  /** Find a repo by its name (case-sensitive).
+   *  NOTE: repos.name uniqueness is enforced at the schema level (see schema.ts). */
   findByName(name: string): RepoRecord | null {
     const row = this.db
       .raw()

--- a/tools/kanban-cli/src/db/repositories/repo-repository.ts
+++ b/tools/kanban-cli/src/db/repositories/repo-repository.ts
@@ -57,4 +57,25 @@ export class RepoRepository {
       .get(id) as RepoRecord | undefined;
     return row ?? null;
   }
+
+  /**
+   * Return all registered repos.
+   */
+  findAll(): RepoRecord[] {
+    return this.db
+      .raw()
+      .prepare('SELECT * FROM repos')
+      .all() as RepoRecord[];
+  }
+
+  /**
+   * Find a repo by its name (case-sensitive).
+   */
+  findByName(name: string): RepoRecord | null {
+    const row = this.db
+      .raw()
+      .prepare('SELECT * FROM repos WHERE name = ?')
+      .get(name) as RepoRecord | undefined;
+    return row ?? null;
+  }
 }

--- a/tools/kanban-cli/src/db/repositories/ticket-repository.ts
+++ b/tools/kanban-cli/src/db/repositories/ticket-repository.ts
@@ -70,9 +70,15 @@ export class TicketRepository {
   }
 
   /**
-   * List all tickets for an epic.
+   * List all tickets for an epic, optionally scoped to a specific repo.
    */
-  listByEpic(epicId: string): TicketRow[] {
+  listByEpic(epicId: string, repoId?: number): TicketRow[] {
+    if (repoId !== undefined) {
+      return this.db
+        .raw()
+        .prepare('SELECT * FROM tickets WHERE epic_id = ? AND repo_id = ?')
+        .all(epicId, repoId) as TicketRow[];
+    }
     return this.db
       .raw()
       .prepare('SELECT * FROM tickets WHERE epic_id = ?')

--- a/tools/kanban-cli/src/db/repositories/types.ts
+++ b/tools/kanban-cli/src/db/repositories/types.ts
@@ -58,6 +58,7 @@ export interface DependencyRow {
   to_type: string;
   resolved: number;
   repo_id: number;
+  target_repo_name: string | null;
 }
 
 export interface SummaryRow {

--- a/tools/kanban-cli/src/db/schema.ts
+++ b/tools/kanban-cli/src/db/schema.ts
@@ -7,7 +7,7 @@ export const CREATE_REPOS_TABLE = `
 CREATE TABLE IF NOT EXISTS repos (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
   path TEXT UNIQUE NOT NULL,
-  name TEXT NOT NULL,
+  name TEXT UNIQUE NOT NULL,
   registered_at TEXT NOT NULL
 )`;
 
@@ -69,7 +69,8 @@ CREATE TABLE IF NOT EXISTS dependencies (
   from_type TEXT NOT NULL,
   to_type TEXT NOT NULL,
   resolved BOOLEAN DEFAULT 0,
-  repo_id INTEGER REFERENCES repos(id)
+  repo_id INTEGER REFERENCES repos(id),
+  target_repo_name TEXT
 )`;
 
 export const CREATE_SUMMARIES_TABLE = `
@@ -112,6 +113,8 @@ export const CREATE_TICKETS_JIRA_KEY_INDEX = `CREATE INDEX IF NOT EXISTS idx_tic
 export const CREATE_PARENT_TRACKING_CHILD_INDEX = `CREATE INDEX IF NOT EXISTS idx_parent_tracking_child ON parent_branch_tracking(child_stage_id)`;
 export const CREATE_PARENT_TRACKING_PARENT_INDEX = `CREATE INDEX IF NOT EXISTS idx_parent_tracking_parent ON parent_branch_tracking(parent_stage_id)`;
 
+export const CREATE_REPOS_NAME_UNIQUE_INDEX = `CREATE UNIQUE INDEX IF NOT EXISTS idx_repos_name ON repos(name)`;
+
 /**
  * ALTER TABLE migrations for adding columns to existing tables.
  * Each is wrapped in try/catch at execution time because SQLite throws
@@ -121,6 +124,7 @@ export const ALTER_TABLE_MIGRATIONS = [
   'ALTER TABLE stages ADD COLUMN is_draft BOOLEAN DEFAULT 0',
   'ALTER TABLE stages ADD COLUMN pending_merge_parents TEXT',
   'ALTER TABLE stages ADD COLUMN mr_target_branch TEXT',
+  'ALTER TABLE dependencies ADD COLUMN target_repo_name TEXT',
 ] as const;
 
 export const ALL_CREATE_STATEMENTS = [
@@ -136,4 +140,5 @@ export const ALL_CREATE_STATEMENTS = [
   CREATE_TICKETS_JIRA_KEY_INDEX,
   CREATE_PARENT_TRACKING_CHILD_INDEX,
   CREATE_PARENT_TRACKING_PARENT_INDEX,
+  CREATE_REPOS_NAME_UNIQUE_INDEX,
 ] as const;

--- a/tools/kanban-cli/src/db/schema.ts
+++ b/tools/kanban-cli/src/db/schema.ts
@@ -113,18 +113,23 @@ export const CREATE_TICKETS_JIRA_KEY_INDEX = `CREATE INDEX IF NOT EXISTS idx_tic
 export const CREATE_PARENT_TRACKING_CHILD_INDEX = `CREATE INDEX IF NOT EXISTS idx_parent_tracking_child ON parent_branch_tracking(child_stage_id)`;
 export const CREATE_PARENT_TRACKING_PARENT_INDEX = `CREATE INDEX IF NOT EXISTS idx_parent_tracking_parent ON parent_branch_tracking(parent_stage_id)`;
 
+// Migration: adds UNIQUE constraint on repos.name for existing databases
+// that were created before the column-level UNIQUE was added to CREATE_REPOS_TABLE.
+// For fresh databases this is a no-op (SQLite already creates an implicit unique index).
 export const CREATE_REPOS_NAME_UNIQUE_INDEX = `CREATE UNIQUE INDEX IF NOT EXISTS idx_repos_name ON repos(name)`;
 
 /**
- * ALTER TABLE migrations for adding columns to existing tables.
- * Each is wrapped in try/catch at execution time because SQLite throws
- * if the column already exists (no IF NOT EXISTS for ALTER TABLE ADD COLUMN).
+ * Migrations that may fail on existing databases and must be wrapped in
+ * try/catch at execution time.  Includes ALTER TABLE ADD COLUMN (SQLite
+ * throws if the column already exists) and CREATE UNIQUE INDEX (fails if
+ * existing data violates the constraint).
  */
 export const ALTER_TABLE_MIGRATIONS = [
   'ALTER TABLE stages ADD COLUMN is_draft BOOLEAN DEFAULT 0',
   'ALTER TABLE stages ADD COLUMN pending_merge_parents TEXT',
   'ALTER TABLE stages ADD COLUMN mr_target_branch TEXT',
   'ALTER TABLE dependencies ADD COLUMN target_repo_name TEXT',
+  CREATE_REPOS_NAME_UNIQUE_INDEX,
 ] as const;
 
 export const ALL_CREATE_STATEMENTS = [
@@ -140,5 +145,4 @@ export const ALL_CREATE_STATEMENTS = [
   CREATE_TICKETS_JIRA_KEY_INDEX,
   CREATE_PARENT_TRACKING_CHILD_INDEX,
   CREATE_PARENT_TRACKING_PARENT_INDEX,
-  CREATE_REPOS_NAME_UNIQUE_INDEX,
 ] as const;

--- a/tools/kanban-cli/src/parser/cross-repo-deps.ts
+++ b/tools/kanban-cli/src/parser/cross-repo-deps.ts
@@ -17,22 +17,30 @@ export type DependencyRef =
  * @param ref - Raw dependency string, e.g. `"STAGE-001-001-001"` or `"backend/STAGE-002-001-001"`
  */
 export function parseDependencyRef(ref: string): DependencyRef {
+  if (ref === '') {
+    throw new Error('Dependency reference cannot be empty');
+  }
   const slashIndex = ref.indexOf('/');
   if (slashIndex === -1) {
     return { type: 'local', itemId: ref };
   }
-  return {
-    type: 'cross-repo',
-    repoName: ref.slice(0, slashIndex),
-    itemId: ref.slice(slashIndex + 1),
-  };
+  const repoName = ref.slice(0, slashIndex);
+  const itemId = ref.slice(slashIndex + 1);
+  if (repoName === '') {
+    throw new Error('Invalid cross-repo dependency: empty repo name');
+  }
+  if (itemId === '') {
+    throw new Error('Invalid cross-repo dependency: empty item ID');
+  }
+  return { type: 'cross-repo', repoName, itemId };
 }
 
 /**
  * Check whether a dependency reference string is a cross-repo dependency.
  */
 export function isCrossRepoDep(ref: string): boolean {
-  return ref.includes('/');
+  const slashIndex = ref.indexOf('/');
+  return slashIndex > 0 && slashIndex < ref.length - 1;
 }
 
 /**

--- a/tools/kanban-cli/src/parser/cross-repo-deps.ts
+++ b/tools/kanban-cli/src/parser/cross-repo-deps.ts
@@ -1,0 +1,43 @@
+/**
+ * Result of parsing a dependency reference.
+ * - `local`: A dependency within the same repo (no slash in the ref).
+ * - `cross-repo`: A dependency in another repo, formatted as `repoName/itemId`.
+ */
+export type DependencyRef =
+  | { type: 'local'; itemId: string }
+  | { type: 'cross-repo'; repoName: string; itemId: string };
+
+/**
+ * Parse a dependency reference string.
+ *
+ * If the ref contains a `/`, it is treated as a cross-repo dependency
+ * where the part before the first `/` is the repo name and the rest
+ * is the item ID.
+ *
+ * @param ref - Raw dependency string, e.g. `"STAGE-001-001-001"` or `"backend/STAGE-002-001-001"`
+ */
+export function parseDependencyRef(ref: string): DependencyRef {
+  const slashIndex = ref.indexOf('/');
+  if (slashIndex === -1) {
+    return { type: 'local', itemId: ref };
+  }
+  return {
+    type: 'cross-repo',
+    repoName: ref.slice(0, slashIndex),
+    itemId: ref.slice(slashIndex + 1),
+  };
+}
+
+/**
+ * Check whether a dependency reference string is a cross-repo dependency.
+ */
+export function isCrossRepoDep(ref: string): boolean {
+  return ref.includes('/');
+}
+
+/**
+ * Format a cross-repo dependency reference from its parts.
+ */
+export function formatCrossRepoDep(repoName: string, itemId: string): string {
+  return `${repoName}/${itemId}`;
+}

--- a/tools/kanban-cli/src/repos/multi-repo.ts
+++ b/tools/kanban-cli/src/repos/multi-repo.ts
@@ -1,0 +1,173 @@
+import type { KanbanDatabase } from '../db/database.js';
+import type { RepoRecord } from '../types/work-items.js';
+import type { EpicRow, TicketRow, StageRow, DependencyRow } from '../db/repositories/types.js';
+import type { LoadConfigOptions } from '../config/loader.js';
+import type { SyncOptions, SyncResult } from '../sync/sync.js';
+import type { PipelineConfig } from '../types/pipeline.js';
+import { createRegistry } from './registry.js';
+import { RepoRepository } from '../db/repositories/repo-repository.js';
+import { EpicRepository } from '../db/repositories/epic-repository.js';
+import { TicketRepository } from '../db/repositories/ticket-repository.js';
+import { StageRepository } from '../db/repositories/stage-repository.js';
+import { DependencyRepository } from '../db/repositories/dependency-repository.js';
+import { loadConfig as defaultLoadConfig } from '../config/loader.js';
+import { syncRepo as defaultSyncRepo } from '../sync/sync.js';
+
+// ── Types ────────────────────────────────────────────────────────────
+
+export interface RepoInfo {
+  repoId: number;
+  repoName: string;
+  repoPath: string;
+}
+
+/** Row types extended with a `repo` field identifying the source repo. */
+export type EpicRowWithRepo = EpicRow & { repo: string };
+export type TicketRowWithRepo = TicketRow & { repo: string };
+export type StageRowWithRepo = StageRow & { repo: string };
+export type DependencyRowWithRepo = DependencyRow & { repo: string };
+
+export interface AggregatedData {
+  epics: EpicRowWithRepo[];
+  tickets: TicketRowWithRepo[];
+  stages: StageRowWithRepo[];
+  deps: DependencyRowWithRepo[];
+}
+
+/** Minimal interfaces for DI — only the methods we actually call. */
+export interface RepoRepoLike {
+  findByPath(repoPath: string): RepoRecord | null;
+  findById(id: number): RepoRecord | null;
+}
+
+export interface EpicRepoLike {
+  listByRepo(repoId: number): EpicRow[];
+}
+
+export interface TicketRepoLike {
+  listByRepo(repoId: number): TicketRow[];
+}
+
+export interface StageRepoLike {
+  listByRepo(repoId: number): StageRow[];
+}
+
+export interface DepRepoLike {
+  listByRepo(repoId: number): DependencyRow[];
+}
+
+export interface MultiRepoDeps {
+  registry: ReturnType<typeof createRegistry>;
+  db: KanbanDatabase;
+  loadConfig: (options?: LoadConfigOptions) => PipelineConfig;
+  syncRepo: (options: SyncOptions) => SyncResult;
+  /** Override individual repos for testing. */
+  repoRepo: RepoRepoLike;
+  epicRepo: EpicRepoLike;
+  ticketRepo: TicketRepoLike;
+  stageRepo: StageRepoLike;
+  depRepo: DepRepoLike;
+}
+
+// ── Factory ──────────────────────────────────────────────────────────
+
+export function createMultiRepoHelper(deps: Partial<MultiRepoDeps> = {}) {
+  const registry = deps.registry ?? createRegistry();
+  const db = deps.db;
+  const repoRepo: RepoRepoLike | undefined = deps.repoRepo ?? (db ? new RepoRepository(db) : undefined);
+  const epicRepo: EpicRepoLike | undefined = deps.epicRepo ?? (db ? new EpicRepository(db) : undefined);
+  const ticketRepo: TicketRepoLike | undefined = deps.ticketRepo ?? (db ? new TicketRepository(db) : undefined);
+  const stageRepo: StageRepoLike | undefined = deps.stageRepo ?? (db ? new StageRepository(db) : undefined);
+  const depRepo: DepRepoLike | undefined = deps.depRepo ?? (db ? new DependencyRepository(db) : undefined);
+  const loadConfigFn = deps.loadConfig ?? defaultLoadConfig;
+  const syncRepoFn = deps.syncRepo ?? defaultSyncRepo;
+
+  /**
+   * Load the registry, sync each repo, and return info for all synced repos.
+   *
+   * Flow:
+   * 1. Call registry.loadRepos() to get registered repo entries
+   * 2. For each repo: loadConfig({ repoPath }) then syncRepo({ repoPath, db, config })
+   * 3. Look up each repo's ID via repoRepo.findByPath(repoPath)
+   * 4. Return array of { repoId, repoName, repoPath }
+   */
+  function syncAllRepos(): RepoInfo[] {
+    if (!repoRepo || !db) {
+      throw new Error('db and repoRepo dependencies are required for syncAllRepos');
+    }
+
+    const entries = registry.loadRepos();
+    const results: RepoInfo[] = [];
+
+    for (const entry of entries) {
+      const config = loadConfigFn({ repoPath: entry.path });
+      syncRepoFn({ repoPath: entry.path, db, config });
+
+      const record = repoRepo.findByPath(entry.path);
+      if (record) {
+        results.push({
+          repoId: record.id,
+          repoName: record.name,
+          repoPath: record.path,
+        });
+      }
+    }
+
+    return results;
+  }
+
+  /**
+   * Query all repos by ID and aggregate their epics, tickets, stages, and deps.
+   * Adds a `repo` field to each row with the repo name.
+   *
+   * Flow:
+   * 1. For each repoId, query all repositories
+   * 2. Look up repo name via repoRepo.findById(repoId)
+   * 3. Add `repo: repoName` field to each item
+   * 4. Return aggregated { epics, tickets, stages, deps }
+   */
+  function loadAllRepoData(repoIds: number[]): AggregatedData {
+    const allEpics: EpicRowWithRepo[] = [];
+    const allTickets: TicketRowWithRepo[] = [];
+    const allStages: StageRowWithRepo[] = [];
+    const allDeps: DependencyRowWithRepo[] = [];
+
+    if (!epicRepo || !ticketRepo || !stageRepo || !depRepo) {
+      return { epics: allEpics, tickets: allTickets, stages: allStages, deps: allDeps };
+    }
+
+    for (const repoId of repoIds) {
+      const record = repoRepo?.findById(repoId) ?? null;
+      const repoName = record?.name ?? 'unknown';
+
+      const epics = epicRepo.listByRepo(repoId);
+      for (const epic of epics) {
+        allEpics.push({ ...epic, repo: repoName });
+      }
+
+      const tickets = ticketRepo.listByRepo(repoId);
+      for (const ticket of tickets) {
+        allTickets.push({ ...ticket, repo: repoName });
+      }
+
+      const stages = stageRepo.listByRepo(repoId);
+      for (const stage of stages) {
+        allStages.push({ ...stage, repo: repoName });
+      }
+
+      const depRows = depRepo.listByRepo(repoId);
+      for (const dep of depRows) {
+        allDeps.push({ ...dep, repo: repoName });
+      }
+    }
+
+    return {
+      epics: allEpics,
+      tickets: allTickets,
+      stages: allStages,
+      deps: allDeps,
+    };
+  }
+
+  return { syncAllRepos, loadAllRepoData };
+}

--- a/tools/kanban-cli/src/repos/registry.ts
+++ b/tools/kanban-cli/src/repos/registry.ts
@@ -1,0 +1,130 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { z } from 'zod';
+import { parse as parseYaml, stringify as yamlStringify } from 'yaml';
+
+// ── Schemas ──────────────────────────────────────────────────────────
+
+export const repoEntrySchema = z.object({
+  path: z.string().min(1),
+  name: z.string().min(1),
+  slack_webhook: z.string().url().optional(),
+});
+
+export const reposConfigSchema = z.object({
+  repos: z.array(repoEntrySchema).default([]),
+});
+
+// ── Types ────────────────────────────────────────────────────────────
+
+export type RepoEntry = z.infer<typeof repoEntrySchema>;
+
+export interface RegistryDeps {
+  readFile: (path: string) => string;
+  writeFile: (path: string, data: string) => void;
+  existsSync: (path: string) => boolean;
+  mkdirSync: (path: string, opts?: { recursive: boolean }) => void;
+  registryPath: string;
+}
+
+export interface RepoRegistry {
+  loadRepos(): RepoEntry[];
+  registerRepo(entry: RepoEntry): void;
+  unregisterRepo(name: string): void;
+  findByName(name: string): RepoEntry | null;
+}
+
+// ── Default deps ─────────────────────────────────────────────────────
+
+const DEFAULT_REGISTRY_PATH = path.join(
+  os.homedir(),
+  '.config',
+  'kanban-workflow',
+  'repos.yaml',
+);
+
+function defaultDeps(): RegistryDeps {
+  return {
+    readFile: (p: string) => fs.readFileSync(p, 'utf-8'),
+    writeFile: (p: string, data: string) => fs.writeFileSync(p, data, 'utf-8'),
+    existsSync: (p: string) => fs.existsSync(p),
+    mkdirSync: (p: string, opts?: { recursive: boolean }) =>
+      fs.mkdirSync(p, opts),
+    registryPath: DEFAULT_REGISTRY_PATH,
+  };
+}
+
+// ── Factory ──────────────────────────────────────────────────────────
+
+export function createRegistry(
+  overrides: Partial<RegistryDeps> = {},
+): RepoRegistry {
+  const deps: RegistryDeps = { ...defaultDeps(), ...overrides };
+
+  function loadRepos(): RepoEntry[] {
+    if (!deps.existsSync(deps.registryPath)) {
+      return [];
+    }
+
+    const raw = deps.readFile(deps.registryPath);
+    const parsed = parseYaml(raw);
+    const result = reposConfigSchema.safeParse(parsed);
+
+    if (!result.success) {
+      throw new Error(
+        `Invalid repos config at ${deps.registryPath}: ${result.error.issues.map((i) => i.message).join(', ')}`,
+      );
+    }
+
+    return result.data.repos;
+  }
+
+  function writeRepos(repos: RepoEntry[]): void {
+    const dir = path.dirname(deps.registryPath);
+    deps.mkdirSync(dir, { recursive: true });
+    const content = yamlStringify({ repos });
+    deps.writeFile(deps.registryPath, content);
+  }
+
+  function registerRepo(entry: RepoEntry): void {
+    // Validate the incoming entry against schema
+    const validated = repoEntrySchema.parse(entry);
+
+    const existing = loadRepos();
+
+    if (existing.some((r) => r.name === validated.name)) {
+      throw new Error(
+        `Duplicate name: repo "${validated.name}" is already registered`,
+      );
+    }
+
+    if (existing.some((r) => r.path === validated.path)) {
+      throw new Error(
+        `Duplicate path: "${validated.path}" is already registered`,
+      );
+    }
+
+    existing.push(validated);
+    writeRepos(existing);
+  }
+
+  function unregisterRepo(name: string): void {
+    const existing = loadRepos();
+    const index = existing.findIndex((r) => r.name === name);
+
+    if (index === -1) {
+      throw new Error(`Repo "${name}" not found`);
+    }
+
+    existing.splice(index, 1);
+    writeRepos(existing);
+  }
+
+  function findByName(name: string): RepoEntry | null {
+    const repos = loadRepos();
+    return repos.find((r) => r.name === name) ?? null;
+  }
+
+  return { loadRepos, registerRepo, unregisterRepo, findByName };
+}

--- a/tools/kanban-cli/src/sync/sync.ts
+++ b/tools/kanban-cli/src/sync/sync.ts
@@ -13,6 +13,7 @@ import {
   parseTicketFrontmatter,
   parseStageFrontmatter,
 } from '../parser/frontmatter.js';
+import { parseDependencyRef } from '../parser/cross-repo-deps.js';
 import { RepoRepository } from '../db/repositories/repo-repository.js';
 import { EpicRepository } from '../db/repositories/epic-repository.js';
 import { TicketRepository } from '../db/repositories/ticket-repository.js';
@@ -144,12 +145,12 @@ export function syncRepo(options: SyncOptions): SyncResult {
   }
 
   /**
-   * Check whether a dependency target is resolved (hard-resolution):
+   * Check whether a local dependency target is resolved (hard-resolution):
    * - Stage: resolved when its status is Complete
    * - Ticket: resolved when ALL stages in that ticket are Complete
    * - Epic: resolved when ALL stages across ALL tickets in that epic are Complete
    */
-  function isDependencyResolved(targetId: string): boolean {
+  function isLocalDependencyResolved(targetId: string): boolean {
     const targetType = getEntityType(targetId);
 
     if (targetType === 'stage') {
@@ -176,14 +177,72 @@ export function syncRepo(options: SyncOptions): SyncResult {
   }
 
   /**
+   * Check whether a cross-repo dependency target is resolved (hard-resolution).
+   * Queries the database since the target is in a different repo.
+   * Returns false if the target repo or item doesn't exist in the DB.
+   */
+  function isCrossRepoDependencyResolved(targetRepoName: string, targetId: string): boolean {
+    const targetRepo = repoRepo.findByName(targetRepoName);
+    if (!targetRepo) return false;
+
+    const targetType = getEntityType(targetId);
+    const targetRepoId = targetRepo.id;
+
+    if (targetType === 'stage') {
+      const stage = stageRepo.findById(targetId);
+      return stage !== null && stage.repo_id === targetRepoId && stage.status === COMPLETE_STATUS;
+    }
+
+    if (targetType === 'ticket') {
+      const stages = stageRepo.listByTicket(targetId, targetRepoId);
+      if (stages.length === 0) return false;
+      return stages.every((s) => s.status === COMPLETE_STATUS);
+    }
+
+    if (targetType === 'epic') {
+      const tickets = ticketRepo.listByEpic(targetId);
+      const repoTickets = tickets.filter((t) => t.repo_id === targetRepoId);
+      if (repoTickets.length === 0) return false;
+      return repoTickets.every((t) => {
+        const stages = stageRepo.listByTicket(t.id, targetRepoId);
+        if (stages.length === 0) return false;
+        return stages.every((s) => s.status === COMPLETE_STATUS);
+      });
+    }
+
+    return false;
+  }
+
+  /**
+   * Check whether a dependency target is resolved (hard-resolution).
+   * Dispatches to local or cross-repo resolution based on the raw dep ref.
+   */
+  function isDependencyResolved(depRef: string): boolean {
+    const parsed = parseDependencyRef(depRef);
+    if (parsed.type === 'local') {
+      return isLocalDependencyResolved(parsed.itemId);
+    }
+    return isCrossRepoDependencyResolved(parsed.repoName, parsed.itemId);
+  }
+
+  /**
    * Check whether a stage dependency target is soft-resolved.
    * Only applies to stage→stage dependencies.
    * Returns true if the target stage's status is 'PR Created' or 'Addressing Comments'.
    */
-  function isStageSoftResolved(stageId: string): boolean {
-    const status = stageStatusMap.get(stageId);
-    if (!status) return false;
-    return (SOFT_RESOLVE_STATUSES as readonly string[]).includes(status);
+  function isStageSoftResolved(depRef: string): boolean {
+    const parsed = parseDependencyRef(depRef);
+    if (parsed.type === 'local') {
+      const status = stageStatusMap.get(parsed.itemId);
+      if (!status) return false;
+      return (SOFT_RESOLVE_STATUSES as readonly string[]).includes(status);
+    }
+    // Cross-repo soft resolution: query the DB
+    const targetRepo = repoRepo.findByName(parsed.repoName);
+    if (!targetRepo) return false;
+    const stage = stageRepo.findById(parsed.itemId);
+    if (!stage || stage.repo_id !== targetRepo.id) return false;
+    return (SOFT_RESOLVE_STATUSES as readonly string[]).includes(stage.status ?? '');
   }
 
   /**
@@ -192,32 +251,39 @@ export function syncRepo(options: SyncOptions): SyncResult {
    * - For all other dep types (stage→ticket, stage→epic, ticket→ticket, epic→epic):
    *   returns true only if hard-resolved (Complete required)
    */
-  function isDependencySoftOrHardResolved(targetId: string): boolean {
-    if (isDependencyResolved(targetId)) return true;
+  function isDependencySoftOrHardResolved(depRef: string): boolean {
+    if (isDependencyResolved(depRef)) return true;
     // Soft-resolution only applies to stage→stage deps
-    const targetType = getEntityType(targetId);
+    const parsed = parseDependencyRef(depRef);
+    const targetType = getEntityType(parsed.itemId);
     if (targetType === 'stage') {
-      return isStageSoftResolved(targetId);
+      return isStageSoftResolved(depRef);
     }
     return false;
   }
 
   /**
    * Upsert a dependency and resolve it if the target is complete.
+   * Parses the depRef to handle both local and cross-repo dependencies.
    */
-  function upsertDependency(fromId: string, fromType: string, depId: string): void {
-    const toType = getEntityType(depId);
+  function upsertDependency(fromId: string, fromType: string, depRef: string): void {
+    const parsed = parseDependencyRef(depRef);
+    const targetId = parsed.itemId;
+    const toType = getEntityType(targetId);
+    const targetRepoName = parsed.type === 'cross-repo' ? parsed.repoName : null;
+
     depRepo.upsert({
       from_id: fromId,
-      to_id: depId,
+      to_id: targetId,
       from_type: fromType,
       to_type: toType,
       repo_id: repoId,
+      target_repo_name: targetRepoName,
     });
     result.dependencies++;
 
-    if (isDependencyResolved(depId)) {
-      depRepo.resolve(fromId, depId);
+    if (isDependencyResolved(depRef)) {
+      depRepo.resolve(fromId, targetId);
     }
   }
 
@@ -316,18 +382,23 @@ export function syncRepo(options: SyncOptions): SyncResult {
       // Build pending_merge_parents for soft-unblocked stages
       const pendingParents: PendingMergeParent[] = [];
       if (allSoftOrHardResolved) {
-        for (const depId of stage.depends_on) {
-          const depType = getEntityType(depId);
+        for (const depRef of stage.depends_on) {
+          const depParsed = parseDependencyRef(depRef);
+          const depType = getEntityType(depParsed.itemId);
           // Only stage→stage deps can be soft-resolved
-          if (depType === 'stage' && !isDependencyResolved(depId) && isStageSoftResolved(depId)) {
-            const parentStage = stageById.get(depId);
-            if (parentStage && parentStage.worktree_branch && parentStage.pr_url && parentStage.pr_number != null) {
-              pendingParents.push({
-                stage_id: depId,
-                branch: parentStage.worktree_branch,
-                pr_url: parentStage.pr_url,
-                pr_number: parentStage.pr_number,
-              });
+          if (depType === 'stage' && !isDependencyResolved(depRef) && isStageSoftResolved(depRef)) {
+            // For local deps, use the in-memory map; cross-repo soft parents
+            // are in another repo so we skip them for pending_merge_parents
+            if (depParsed.type === 'local') {
+              const parentStage = stageById.get(depParsed.itemId);
+              if (parentStage && parentStage.worktree_branch && parentStage.pr_url && parentStage.pr_number != null) {
+                pendingParents.push({
+                  stage_id: depParsed.itemId,
+                  branch: parentStage.worktree_branch,
+                  pr_url: parentStage.pr_url,
+                  pr_number: parentStage.pr_number,
+                });
+              }
             }
           }
         }

--- a/tools/kanban-cli/src/sync/sync.ts
+++ b/tools/kanban-cli/src/sync/sync.ts
@@ -13,7 +13,7 @@ import {
   parseTicketFrontmatter,
   parseStageFrontmatter,
 } from '../parser/frontmatter.js';
-import { parseDependencyRef } from '../parser/cross-repo-deps.js';
+import { parseDependencyRef, type DependencyRef } from '../parser/cross-repo-deps.js';
 import { RepoRepository } from '../db/repositories/repo-repository.js';
 import { EpicRepository } from '../db/repositories/epic-repository.js';
 import { TicketRepository } from '../db/repositories/ticket-repository.js';
@@ -200,10 +200,9 @@ export function syncRepo(options: SyncOptions): SyncResult {
     }
 
     if (targetType === 'epic') {
-      const tickets = ticketRepo.listByEpic(targetId);
-      const repoTickets = tickets.filter((t) => t.repo_id === targetRepoId);
-      if (repoTickets.length === 0) return false;
-      return repoTickets.every((t) => {
+      const tickets = ticketRepo.listByEpic(targetId, targetRepoId);
+      if (tickets.length === 0) return false;
+      return tickets.every((t) => {
         const stages = stageRepo.listByTicket(t.id, targetRepoId);
         if (stages.length === 0) return false;
         return stages.every((s) => s.status === COMPLETE_STATUS);
@@ -215,10 +214,9 @@ export function syncRepo(options: SyncOptions): SyncResult {
 
   /**
    * Check whether a dependency target is resolved (hard-resolution).
-   * Dispatches to local or cross-repo resolution based on the raw dep ref.
+   * Dispatches to local or cross-repo resolution based on parsed ref.
    */
-  function isDependencyResolved(depRef: string): boolean {
-    const parsed = parseDependencyRef(depRef);
+  function isDependencyResolved(parsed: DependencyRef): boolean {
     if (parsed.type === 'local') {
       return isLocalDependencyResolved(parsed.itemId);
     }
@@ -230,8 +228,7 @@ export function syncRepo(options: SyncOptions): SyncResult {
    * Only applies to stage→stage dependencies.
    * Returns true if the target stage's status is 'PR Created' or 'Addressing Comments'.
    */
-  function isStageSoftResolved(depRef: string): boolean {
-    const parsed = parseDependencyRef(depRef);
+  function isStageSoftResolved(parsed: DependencyRef): boolean {
     if (parsed.type === 'local') {
       const status = stageStatusMap.get(parsed.itemId);
       if (!status) return false;
@@ -251,23 +248,21 @@ export function syncRepo(options: SyncOptions): SyncResult {
    * - For all other dep types (stage→ticket, stage→epic, ticket→ticket, epic→epic):
    *   returns true only if hard-resolved (Complete required)
    */
-  function isDependencySoftOrHardResolved(depRef: string): boolean {
-    if (isDependencyResolved(depRef)) return true;
+  function isDependencySoftOrHardResolved(parsed: DependencyRef): boolean {
+    if (isDependencyResolved(parsed)) return true;
     // Soft-resolution only applies to stage→stage deps
-    const parsed = parseDependencyRef(depRef);
     const targetType = getEntityType(parsed.itemId);
     if (targetType === 'stage') {
-      return isStageSoftResolved(depRef);
+      return isStageSoftResolved(parsed);
     }
     return false;
   }
 
   /**
    * Upsert a dependency and resolve it if the target is complete.
-   * Parses the depRef to handle both local and cross-repo dependencies.
+   * Accepts a pre-parsed DependencyRef to avoid redundant parsing.
    */
-  function upsertDependency(fromId: string, fromType: string, depRef: string): void {
-    const parsed = parseDependencyRef(depRef);
+  function upsertDependency(fromId: string, fromType: string, parsed: DependencyRef): void {
     const targetId = parsed.itemId;
     const toType = getEntityType(targetId);
     const targetRepoName = parsed.type === 'cross-repo' ? parsed.repoName : null;
@@ -282,7 +277,7 @@ export function syncRepo(options: SyncOptions): SyncResult {
     });
     result.dependencies++;
 
-    if (isDependencyResolved(depRef)) {
+    if (isDependencyResolved(parsed)) {
       depRepo.resolve(fromId, targetId);
     }
   }
@@ -335,7 +330,8 @@ export function syncRepo(options: SyncOptions): SyncResult {
       });
 
       for (const depId of epic.depends_on) {
-        upsertDependency(epic.id, 'epic', depId);
+        const parsed = parseDependencyRef(depId);
+        upsertDependency(epic.id, 'epic', parsed);
       }
     }
     result.epics = parsedEpics.length;
@@ -356,21 +352,25 @@ export function syncRepo(options: SyncOptions): SyncResult {
       });
 
       for (const depId of ticket.depends_on) {
-        upsertDependency(ticket.id, 'ticket', depId);
+        const parsed = parseDependencyRef(depId);
+        upsertDependency(ticket.id, 'ticket', parsed);
       }
     }
     result.tickets = parsedTickets.length;
 
     // Upsert stages and create dependencies
     for (const stage of parsedStages) {
+      // Parse all dep refs once for this stage
+      const parsedDeps = stage.depends_on.map((depId) => parseDependencyRef(depId));
+
       // Create dependency records (supports stage→stage, stage→ticket, stage→epic)
-      for (const depId of stage.depends_on) {
-        upsertDependency(stage.id, 'stage', depId);
+      for (const parsed of parsedDeps) {
+        upsertDependency(stage.id, 'stage', parsed);
       }
 
       // Determine if all deps are soft-or-hard-resolved for kanban column
-      const allSoftOrHardResolved = stage.depends_on.length === 0 ||
-        stage.depends_on.every((depId) => isDependencySoftOrHardResolved(depId));
+      const allSoftOrHardResolved = parsedDeps.length === 0 ||
+        parsedDeps.every((parsed) => isDependencySoftOrHardResolved(parsed));
       const hasUnresolvedDeps = !allSoftOrHardResolved;
 
       const kanbanColumn = computeKanbanColumn({
@@ -382,11 +382,10 @@ export function syncRepo(options: SyncOptions): SyncResult {
       // Build pending_merge_parents for soft-unblocked stages
       const pendingParents: PendingMergeParent[] = [];
       if (allSoftOrHardResolved) {
-        for (const depRef of stage.depends_on) {
-          const depParsed = parseDependencyRef(depRef);
+        for (const depParsed of parsedDeps) {
           const depType = getEntityType(depParsed.itemId);
           // Only stage→stage deps can be soft-resolved
-          if (depType === 'stage' && !isDependencyResolved(depRef) && isStageSoftResolved(depRef)) {
+          if (depType === 'stage' && !isDependencyResolved(depParsed) && isStageSoftResolved(depParsed)) {
             // For local deps, use the in-memory map; cross-repo soft parents
             // are in another repo so we skip them for pending_merge_parents
             if (depParsed.type === 'local') {

--- a/tools/kanban-cli/tests/cli/commands/__helpers/mock-registry.ts
+++ b/tools/kanban-cli/tests/cli/commands/__helpers/mock-registry.ts
@@ -1,0 +1,23 @@
+import type { RegistryDeps } from '../../../../src/repos/registry.js';
+
+export interface MockDeps extends RegistryDeps {
+  _files: Map<string, string>;
+}
+
+export function makeDeps(): MockDeps {
+  const files = new Map<string, string>();
+  return {
+    registryPath: '/fake/.config/kanban-workflow/repos.yaml',
+    readFile: (p: string) => {
+      const content = files.get(p);
+      if (content === undefined) throw new Error(`ENOENT: ${p}`);
+      return content;
+    },
+    writeFile: (p: string, data: string) => {
+      files.set(p, data);
+    },
+    existsSync: (p: string) => files.has(p),
+    mkdirSync: () => {},
+    _files: files,
+  };
+}

--- a/tools/kanban-cli/tests/cli/commands/list-repos.test.ts
+++ b/tools/kanban-cli/tests/cli/commands/list-repos.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from 'vitest';
+import { stringify as yamlStringify } from 'yaml';
+import { createRegistry } from '../../../src/repos/registry.js';
+import type { RegistryDeps } from '../../../src/repos/registry.js';
+
+/**
+ * Tests for the list-repos command logic.
+ *
+ * The command is a thin wrapper around createRegistry().loadRepos().
+ * These tests verify: listing all repos, empty registry handling, and
+ * output structure.
+ */
+
+interface MockDeps extends RegistryDeps {
+  _files: Map<string, string>;
+}
+
+function makeDeps(): MockDeps {
+  const files = new Map<string, string>();
+  return {
+    registryPath: '/fake/.config/kanban-workflow/repos.yaml',
+    readFile: (p: string) => {
+      const content = files.get(p);
+      if (content === undefined) throw new Error(`ENOENT: ${p}`);
+      return content;
+    },
+    writeFile: (p: string, data: string) => {
+      files.set(p, data);
+    },
+    existsSync: (p: string) => files.has(p),
+    mkdirSync: () => {},
+    _files: files,
+  };
+}
+
+function yamlWith(repos: Array<Record<string, unknown>>): string {
+  return yamlStringify({ repos });
+}
+
+describe('list-repos command logic', () => {
+  it('lists all registered repos', () => {
+    const deps = makeDeps();
+    deps._files.set(
+      deps.registryPath,
+      yamlWith([
+        { path: '/projects/backend', name: 'backend' },
+        { path: '/projects/frontend', name: 'frontend' },
+        {
+          path: '/projects/infra',
+          name: 'infra',
+          slack_webhook: 'https://hooks.slack.com/services/T/B/x',
+        },
+      ]),
+    );
+
+    const registry = createRegistry(deps);
+    const repos = registry.loadRepos();
+
+    expect(repos).toHaveLength(3);
+    expect(repos[0].name).toBe('backend');
+    expect(repos[1].name).toBe('frontend');
+    expect(repos[2].name).toBe('infra');
+    expect(repos[2].slack_webhook).toBe('https://hooks.slack.com/services/T/B/x');
+  });
+
+  it('handles empty registry (no file)', () => {
+    const deps = makeDeps();
+    const registry = createRegistry(deps);
+
+    const repos = registry.loadRepos();
+    expect(repos).toEqual([]);
+  });
+
+  it('handles empty registry (empty file)', () => {
+    const deps = makeDeps();
+    deps._files.set(deps.registryPath, '');
+
+    const registry = createRegistry(deps);
+    const repos = registry.loadRepos();
+    expect(repos).toEqual([]);
+  });
+
+  it('generates expected output JSON shape', () => {
+    const deps = makeDeps();
+    deps._files.set(
+      deps.registryPath,
+      yamlWith([
+        { path: '/projects/backend', name: 'backend' },
+        {
+          path: '/projects/frontend',
+          name: 'frontend',
+          slack_webhook: 'https://hooks.slack.com/services/T/B/x',
+        },
+      ]),
+    );
+
+    const registry = createRegistry(deps);
+    const repos = registry.loadRepos();
+
+    // Replicate the command's output construction
+    const result = {
+      repos: repos.map((r) => ({
+        name: r.name,
+        path: r.path,
+        ...(r.slack_webhook ? { slack_webhook: r.slack_webhook } : {}),
+      })),
+      count: repos.length,
+    };
+
+    expect(result.count).toBe(2);
+    expect(result.repos[0]).toEqual({
+      name: 'backend',
+      path: '/projects/backend',
+    });
+    expect(result.repos[1]).toEqual({
+      name: 'frontend',
+      path: '/projects/frontend',
+      slack_webhook: 'https://hooks.slack.com/services/T/B/x',
+    });
+
+    // Verify JSON serialization round-trips correctly
+    const json = JSON.stringify(result);
+    const parsed = JSON.parse(json);
+    expect(parsed.count).toBe(2);
+    expect(parsed.repos).toHaveLength(2);
+  });
+
+  it('handles single repo', () => {
+    const deps = makeDeps();
+    deps._files.set(
+      deps.registryPath,
+      yamlWith([{ path: '/projects/solo', name: 'solo' }]),
+    );
+
+    const registry = createRegistry(deps);
+    const repos = registry.loadRepos();
+
+    const result = {
+      repos: repos.map((r) => ({
+        name: r.name,
+        path: r.path,
+        ...(r.slack_webhook ? { slack_webhook: r.slack_webhook } : {}),
+      })),
+      count: repos.length,
+    };
+
+    expect(result.count).toBe(1);
+    expect(result.repos[0].name).toBe('solo');
+  });
+});

--- a/tools/kanban-cli/tests/cli/commands/list-repos.test.ts
+++ b/tools/kanban-cli/tests/cli/commands/list-repos.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { stringify as yamlStringify } from 'yaml';
 import { createRegistry } from '../../../src/repos/registry.js';
-import type { RegistryDeps } from '../../../src/repos/registry.js';
+import { makeDeps } from './__helpers/mock-registry.js';
 
 /**
  * Tests for the list-repos command logic.
@@ -10,28 +10,6 @@ import type { RegistryDeps } from '../../../src/repos/registry.js';
  * These tests verify: listing all repos, empty registry handling, and
  * output structure.
  */
-
-interface MockDeps extends RegistryDeps {
-  _files: Map<string, string>;
-}
-
-function makeDeps(): MockDeps {
-  const files = new Map<string, string>();
-  return {
-    registryPath: '/fake/.config/kanban-workflow/repos.yaml',
-    readFile: (p: string) => {
-      const content = files.get(p);
-      if (content === undefined) throw new Error(`ENOENT: ${p}`);
-      return content;
-    },
-    writeFile: (p: string, data: string) => {
-      files.set(p, data);
-    },
-    existsSync: (p: string) => files.has(p),
-    mkdirSync: () => {},
-    _files: files,
-  };
-}
 
 function yamlWith(repos: Array<Record<string, unknown>>): string {
   return yamlStringify({ repos });

--- a/tools/kanban-cli/tests/cli/commands/register-repo.test.ts
+++ b/tools/kanban-cli/tests/cli/commands/register-repo.test.ts
@@ -2,9 +2,8 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { stringify as yamlStringify } from 'yaml';
 import { createRegistry } from '../../../src/repos/registry.js';
-import type { RegistryDeps } from '../../../src/repos/registry.js';
+import { makeDeps } from './__helpers/mock-registry.js';
 
 /**
  * Tests for the register-repo command logic.
@@ -20,28 +19,6 @@ import type { RegistryDeps } from '../../../src/repos/registry.js';
  * The registry itself is thoroughly tested in tests/repos/registry.test.ts.
  * These tests verify the integration flow the CLI command would perform.
  */
-
-interface MockDeps extends RegistryDeps {
-  _files: Map<string, string>;
-}
-
-function makeDeps(): MockDeps {
-  const files = new Map<string, string>();
-  return {
-    registryPath: '/fake/.config/kanban-workflow/repos.yaml',
-    readFile: (p: string) => {
-      const content = files.get(p);
-      if (content === undefined) throw new Error(`ENOENT: ${p}`);
-      return content;
-    },
-    writeFile: (p: string, data: string) => {
-      files.set(p, data);
-    },
-    existsSync: (p: string) => files.has(p),
-    mkdirSync: () => {},
-    _files: files,
-  };
-}
 
 describe('register-repo command logic', () => {
   let tmpDir: string;

--- a/tools/kanban-cli/tests/cli/commands/register-repo.test.ts
+++ b/tools/kanban-cli/tests/cli/commands/register-repo.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { stringify as yamlStringify } from 'yaml';
+import { createRegistry } from '../../../src/repos/registry.js';
+import type { RegistryDeps } from '../../../src/repos/registry.js';
+
+/**
+ * Tests for the register-repo command logic.
+ *
+ * Since the command is a thin Commander wrapper around createRegistry().registerRepo(),
+ * we test the core logic that the command exercises:
+ *   1. Path resolution and validation
+ *   2. Name defaulting to basename
+ *   3. Registry registerRepo call
+ *   4. Duplicate rejection
+ *   5. Non-existent path rejection
+ *
+ * The registry itself is thoroughly tested in tests/repos/registry.test.ts.
+ * These tests verify the integration flow the CLI command would perform.
+ */
+
+interface MockDeps extends RegistryDeps {
+  _files: Map<string, string>;
+}
+
+function makeDeps(): MockDeps {
+  const files = new Map<string, string>();
+  return {
+    registryPath: '/fake/.config/kanban-workflow/repos.yaml',
+    readFile: (p: string) => {
+      const content = files.get(p);
+      if (content === undefined) throw new Error(`ENOENT: ${p}`);
+      return content;
+    },
+    writeFile: (p: string, data: string) => {
+      files.set(p, data);
+    },
+    existsSync: (p: string) => files.has(p),
+    mkdirSync: () => {},
+    _files: files,
+  };
+}
+
+describe('register-repo command logic', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'register-repo-test-'));
+  });
+
+  it('registers a repo with explicit name', () => {
+    const deps = makeDeps();
+    const registry = createRegistry(deps);
+
+    registry.registerRepo({
+      path: '/projects/backend',
+      name: 'my-backend',
+    });
+
+    const repos = registry.loadRepos();
+    expect(repos).toHaveLength(1);
+    expect(repos[0].name).toBe('my-backend');
+    expect(repos[0].path).toBe('/projects/backend');
+  });
+
+  it('defaults name to path basename when not provided', () => {
+    // This tests the defaulting logic that the command uses:
+    // const name = options.name ?? path.basename(resolved);
+    const resolved = '/projects/my-cool-project';
+    const name = path.basename(resolved);
+    expect(name).toBe('my-cool-project');
+
+    const deps = makeDeps();
+    const registry = createRegistry(deps);
+    registry.registerRepo({ path: resolved, name });
+
+    const repos = registry.loadRepos();
+    expect(repos[0].name).toBe('my-cool-project');
+  });
+
+  it('registers a repo with slack_webhook', () => {
+    const deps = makeDeps();
+    const registry = createRegistry(deps);
+
+    registry.registerRepo({
+      path: '/projects/backend',
+      name: 'backend',
+      slack_webhook: 'https://hooks.slack.com/services/T/B/x',
+    });
+
+    const repos = registry.loadRepos();
+    expect(repos[0].slack_webhook).toBe('https://hooks.slack.com/services/T/B/x');
+  });
+
+  it('rejects non-existent path at filesystem level', () => {
+    // The command checks fs.existsSync(resolved) before calling registerRepo.
+    // Verify that a non-existent path would be caught.
+    const nonExistent = path.join(tmpDir, 'does-not-exist');
+    expect(fs.existsSync(nonExistent)).toBe(false);
+  });
+
+  it('rejects duplicate repo name', () => {
+    const deps = makeDeps();
+    const registry = createRegistry(deps);
+
+    registry.registerRepo({ path: '/projects/backend', name: 'backend' });
+
+    expect(() =>
+      registry.registerRepo({ path: '/projects/other', name: 'backend' }),
+    ).toThrow(/duplicate.*name/i);
+  });
+
+  it('rejects duplicate repo path', () => {
+    const deps = makeDeps();
+    const registry = createRegistry(deps);
+
+    registry.registerRepo({ path: '/projects/backend', name: 'backend' });
+
+    expect(() =>
+      registry.registerRepo({ path: '/projects/backend', name: 'other-name' }),
+    ).toThrow(/duplicate.*path/i);
+  });
+
+  it('resolves relative path correctly', () => {
+    // The command resolves paths with path.resolve().
+    // Verify relative path resolution works as expected.
+    const resolved = path.resolve('./relative/path');
+    expect(path.isAbsolute(resolved)).toBe(true);
+    expect(resolved).toContain('relative/path');
+  });
+
+  it('generates expected output JSON shape', () => {
+    // Verify the shape of the result object the command constructs
+    const name = 'backend';
+    const resolvedPath = '/projects/backend';
+    const slackWebhook = 'https://hooks.slack.com/services/T/B/x';
+    const syncResult = {
+      epics: 3,
+      tickets: 10,
+      stages: 25,
+      dependencies: 5,
+      errors: [] as string[],
+    };
+
+    const result = {
+      success: true,
+      repo: {
+        name,
+        path: resolvedPath,
+        slack_webhook: slackWebhook,
+      },
+      sync: {
+        epics: syncResult.epics,
+        tickets: syncResult.tickets,
+        stages: syncResult.stages,
+        dependencies: syncResult.dependencies,
+        errors: syncResult.errors,
+      },
+    };
+
+    expect(result.success).toBe(true);
+    expect(result.repo.name).toBe('backend');
+    expect(result.repo.path).toBe('/projects/backend');
+    expect(result.repo.slack_webhook).toBe(slackWebhook);
+    expect(result.sync.epics).toBe(3);
+    expect(result.sync.errors).toEqual([]);
+  });
+});

--- a/tools/kanban-cli/tests/cli/commands/unregister-repo.test.ts
+++ b/tools/kanban-cli/tests/cli/commands/unregister-repo.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { stringify as yamlStringify } from 'yaml';
 import { createRegistry } from '../../../src/repos/registry.js';
-import type { RegistryDeps } from '../../../src/repos/registry.js';
+import { makeDeps } from './__helpers/mock-registry.js';
 
 /**
  * Tests for the unregister-repo command logic.
@@ -10,28 +10,6 @@ import type { RegistryDeps } from '../../../src/repos/registry.js';
  * These tests verify the integration flow: looking up by name, removing, and
  * confirming output structure.
  */
-
-interface MockDeps extends RegistryDeps {
-  _files: Map<string, string>;
-}
-
-function makeDeps(): MockDeps {
-  const files = new Map<string, string>();
-  return {
-    registryPath: '/fake/.config/kanban-workflow/repos.yaml',
-    readFile: (p: string) => {
-      const content = files.get(p);
-      if (content === undefined) throw new Error(`ENOENT: ${p}`);
-      return content;
-    },
-    writeFile: (p: string, data: string) => {
-      files.set(p, data);
-    },
-    existsSync: (p: string) => files.has(p),
-    mkdirSync: () => {},
-    _files: files,
-  };
-}
 
 function yamlWith(repos: Array<Record<string, unknown>>): string {
   return yamlStringify({ repos });

--- a/tools/kanban-cli/tests/cli/commands/unregister-repo.test.ts
+++ b/tools/kanban-cli/tests/cli/commands/unregister-repo.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import { stringify as yamlStringify } from 'yaml';
+import { createRegistry } from '../../../src/repos/registry.js';
+import type { RegistryDeps } from '../../../src/repos/registry.js';
+
+/**
+ * Tests for the unregister-repo command logic.
+ *
+ * The command is a thin wrapper around createRegistry().unregisterRepo(name).
+ * These tests verify the integration flow: looking up by name, removing, and
+ * confirming output structure.
+ */
+
+interface MockDeps extends RegistryDeps {
+  _files: Map<string, string>;
+}
+
+function makeDeps(): MockDeps {
+  const files = new Map<string, string>();
+  return {
+    registryPath: '/fake/.config/kanban-workflow/repos.yaml',
+    readFile: (p: string) => {
+      const content = files.get(p);
+      if (content === undefined) throw new Error(`ENOENT: ${p}`);
+      return content;
+    },
+    writeFile: (p: string, data: string) => {
+      files.set(p, data);
+    },
+    existsSync: (p: string) => files.has(p),
+    mkdirSync: () => {},
+    _files: files,
+  };
+}
+
+function yamlWith(repos: Array<Record<string, unknown>>): string {
+  return yamlStringify({ repos });
+}
+
+describe('unregister-repo command logic', () => {
+  it('removes a registered repo by name', () => {
+    const deps = makeDeps();
+    deps._files.set(
+      deps.registryPath,
+      yamlWith([
+        { path: '/projects/backend', name: 'backend' },
+        { path: '/projects/frontend', name: 'frontend' },
+      ]),
+    );
+
+    const registry = createRegistry(deps);
+    registry.unregisterRepo('backend');
+
+    const repos = registry.loadRepos();
+    expect(repos).toHaveLength(1);
+    expect(repos[0].name).toBe('frontend');
+  });
+
+  it('errors on unknown repo name', () => {
+    const deps = makeDeps();
+    deps._files.set(
+      deps.registryPath,
+      yamlWith([{ path: '/projects/backend', name: 'backend' }]),
+    );
+
+    const registry = createRegistry(deps);
+    expect(() => registry.unregisterRepo('nonexistent')).toThrow(/not found/i);
+  });
+
+  it('errors when registry is empty', () => {
+    const deps = makeDeps();
+    // No file exists — empty registry
+    const registry = createRegistry(deps);
+    expect(() => registry.unregisterRepo('anything')).toThrow(/not found/i);
+  });
+
+  it('can unregister the last remaining repo', () => {
+    const deps = makeDeps();
+    deps._files.set(
+      deps.registryPath,
+      yamlWith([{ path: '/projects/backend', name: 'backend' }]),
+    );
+
+    const registry = createRegistry(deps);
+    registry.unregisterRepo('backend');
+
+    const repos = registry.loadRepos();
+    expect(repos).toHaveLength(0);
+  });
+
+  it('generates expected output JSON shape', () => {
+    const name = 'backend';
+    const result = {
+      success: true,
+      unregistered: name,
+    };
+
+    expect(result.success).toBe(true);
+    expect(result.unregistered).toBe('backend');
+    expect(JSON.stringify(result)).toContain('"unregistered":"backend"');
+  });
+});

--- a/tools/kanban-cli/tests/cli/logic/next.test.ts
+++ b/tools/kanban-cli/tests/cli/logic/next.test.ts
@@ -298,7 +298,7 @@ describe('buildNext', () => {
       expect(result.ready_stages.some((s) => s.id === 'S2')).toBe(true);
     });
 
-    it('--global output includes repos array', () => {
+    it('stages with repo field preserve repo in output', () => {
       const result = buildNext({
         config: testConfig,
         stages: [

--- a/tools/kanban-cli/tests/cli/logic/validate.test.ts
+++ b/tools/kanban-cli/tests/cli/logic/validate.test.ts
@@ -555,7 +555,7 @@ describe('validateWorkItems', () => {
       expect(result.errors[0].repo).toBe('repo1');
     });
 
-    it('global mode includes repos array in output', () => {
+    it('global mode accepts global flag without error', () => {
       const epic = makeEpic({ tickets: [], repo: 'repo1' });
 
       const result = validateWorkItems({

--- a/tools/kanban-cli/tests/cli/logic/validate.test.ts
+++ b/tools/kanban-cli/tests/cli/logic/validate.test.ts
@@ -455,4 +455,140 @@ describe('validateWorkItems', () => {
       expect(result.errors.filter((e) => e.field === 'jira_links')).toHaveLength(0);
     });
   });
+
+  // --- Global mode tests ---
+
+  describe('global mode', () => {
+    it('global mode validates all repos', () => {
+      const epic1 = makeEpic({ id: 'EPIC-REPO1', tickets: ['TICKET-REPO1-001'], repo: 'repo1' });
+      const ticket1 = makeTicket({ id: 'TICKET-REPO1-001', epic_id: 'EPIC-REPO1', stages: ['STAGE-REPO1-001'], repo: 'repo1' });
+      const stage1 = makeStage({ id: 'STAGE-REPO1-001', ticket_id: 'TICKET-REPO1-001', worktree_branch: 'branch-repo1', repo: 'repo1' });
+
+      const epic2 = makeEpic({ id: 'EPIC-REPO2', title: 'Feature', tickets: ['TICKET-REPO2-001'], repo: 'repo2' });
+      const ticket2 = makeTicket({ id: 'TICKET-REPO2-001', epic_id: 'EPIC-REPO2', stages: ['STAGE-REPO2-001'], repo: 'repo2' });
+      const stage2 = makeStage({ id: 'STAGE-REPO2-001', ticket_id: 'TICKET-REPO2-001', worktree_branch: 'branch-repo2', repo: 'repo2' });
+
+      const result = validateWorkItems({
+        epics: [epic1, epic2],
+        tickets: [ticket1, ticket2],
+        stages: [stage1, stage2],
+        dependencies: [],
+        allIds: new Set(['EPIC-REPO1', 'TICKET-REPO1-001', 'STAGE-REPO1-001', 'EPIC-REPO2', 'TICKET-REPO2-001', 'STAGE-REPO2-001']),
+        validStatuses: new Set(['Not Started', 'In Progress']),
+        global: true,
+      });
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('global mode reports error for reference to non-existent item', () => {
+      const epic = makeEpic({ depends_on: ['MISSING-ID'], repo: 'repo1' });
+
+      const result = validateWorkItems({
+        epics: [epic],
+        tickets: [],
+        stages: [],
+        dependencies: [],
+        allIds: new Set(['EPIC-001']),
+        validStatuses: new Set(['In Progress']),
+        global: true,
+      });
+      expect(result.valid).toBe(false);
+      const err = result.errors.find((e) => e.error.includes('MISSING-ID'));
+      expect(err).toBeDefined();
+      expect(err?.repo).toBe('repo1');
+    });
+
+    it('global mode detects cross-repo circular dependencies', () => {
+      const ticket1 = makeTicket({ id: 'T1', depends_on: ['T2'], repo: 'repo1', file_path: 't1.md' });
+      const ticket2 = makeTicket({ id: 'T2', depends_on: ['T1'], repo: 'repo2', file_path: 't2.md' });
+
+      const result = validateWorkItems({
+        epics: [],
+        tickets: [ticket1, ticket2],
+        stages: [],
+        dependencies: [
+          { from_id: 'T1', to_id: 'T2', resolved: false },
+          { from_id: 'T2', to_id: 'T1', resolved: false },
+        ],
+        allIds: new Set(['T1', 'T2']),
+        validStatuses: new Set(['In Progress']),
+        global: true,
+      });
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((e) => e.error.toLowerCase().includes('circular'))).toBe(true);
+    });
+
+    it('global mode enforces type rules across repos', () => {
+      const epic = makeEpic({ depends_on: ['STAGE-001-001-001'], repo: 'repo1' });
+      const stage = makeStage({ id: 'STAGE-001-001-001', repo: 'repo2' });
+
+      const result = validateWorkItems({
+        epics: [epic],
+        tickets: [],
+        stages: [stage],
+        dependencies: [],
+        allIds: new Set(['EPIC-001', 'STAGE-001-001-001']),
+        validStatuses: new Set(['Not Started', 'In Progress']),
+        global: true,
+      });
+      expect(result.valid).toBe(false);
+      const err = result.errors.find((e) => e.error.includes('cannot depend on'));
+      expect(err).toBeDefined();
+      expect(err?.repo).toBe('repo1');
+    });
+
+    it('global mode errors include repo field', () => {
+      const ticket = makeTicket({ title: '', repo: 'repo1' });
+
+      const result = validateWorkItems({
+        epics: [],
+        tickets: [ticket],
+        stages: [],
+        dependencies: [],
+        allIds: new Set(['TICKET-001-001']),
+        validStatuses: new Set(['In Progress']),
+        global: true,
+      });
+      expect(result.valid).toBe(false);
+      expect(result.errors.length).toBeGreaterThan(0);
+      expect(result.errors[0].repo).toBe('repo1');
+    });
+
+    it('global mode includes repos array in output', () => {
+      const epic = makeEpic({ tickets: [], repo: 'repo1' });
+
+      const result = validateWorkItems({
+        epics: [epic],
+        tickets: [],
+        stages: [],
+        dependencies: [],
+        allIds: new Set(['EPIC-001']),
+        validStatuses: new Set(['In Progress']),
+        global: true,
+      });
+      expect(result.valid).toBe(true);
+      // Note: repos array is added by the command, not by validateWorkItems
+      // This test verifies the input accepts global: true
+    });
+
+    it('without --global, cross-repo deps produce errors for unresolvable refs', () => {
+      const ticket = makeTicket({ depends_on: ['NONEXISTENT-ID'] });
+
+      const result = validateWorkItems({
+        epics: [],
+        tickets: [ticket],
+        stages: [],
+        dependencies: [],
+        allIds: new Set(['TICKET-001-001']),
+        validStatuses: new Set(['In Progress']),
+        global: false,
+      });
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((e) => e.error.includes('NONEXISTENT-ID'))).toBe(true);
+      // Error should not have repo field when global: false or not set
+      const err = result.errors.find((e) => e.error.includes('NONEXISTENT-ID'));
+      expect(err?.repo).toBeUndefined();
+    });
+  });
 });

--- a/tools/kanban-cli/tests/db/repositories.test.ts
+++ b/tools/kanban-cli/tests/db/repositories.test.ts
@@ -126,6 +126,45 @@ describe('Repositories', () => {
       const found = repos.findById(id1);
       expect(found!.name).toBe('new-name');
     });
+
+    it('findAll returns empty array when no repos exist', () => {
+      const repos = new RepoRepository(db);
+      expect(repos.findAll()).toEqual([]);
+    });
+
+    it('findAll returns all registered repos after multiple upserts', () => {
+      const repos = new RepoRepository(db);
+      repos.upsert('/repo/one', 'repo-one');
+      repos.upsert('/repo/two', 'repo-two');
+      repos.upsert('/repo/three', 'repo-three');
+      const all = repos.findAll();
+      expect(all).toHaveLength(3);
+      const names = all.map((r) => r.name).sort();
+      expect(names).toEqual(['repo-one', 'repo-three', 'repo-two']);
+    });
+
+    it('findByName returns null when name not found', () => {
+      const repos = new RepoRepository(db);
+      expect(repos.findByName('nonexistent')).toBeNull();
+    });
+
+    it('findByName returns correct repo when name matches', () => {
+      const repos = new RepoRepository(db);
+      repos.upsert('/my/repo', 'my-repo');
+      repos.upsert('/other/repo', 'other-repo');
+      const found = repos.findByName('my-repo');
+      expect(found).not.toBeNull();
+      expect(found!.name).toBe('my-repo');
+      expect(found!.path).toBe('/my/repo');
+    });
+
+    it('findByName is case-sensitive', () => {
+      const repos = new RepoRepository(db);
+      repos.upsert('/my/repo', 'My-Repo');
+      expect(repos.findByName('My-Repo')).not.toBeNull();
+      expect(repos.findByName('my-repo')).toBeNull();
+      expect(repos.findByName('MY-REPO')).toBeNull();
+    });
   });
 
   // ─── EpicRepository ──────────────────────────────────────────────

--- a/tools/kanban-cli/tests/db/repositories.test.ts
+++ b/tools/kanban-cli/tests/db/repositories.test.ts
@@ -132,14 +132,14 @@ describe('Repositories', () => {
       expect(repos.findAll()).toEqual([]);
     });
 
-    it('findAll returns all registered repos after multiple upserts', () => {
+    it('findAll returns all registered repos ordered by name', () => {
       const repos = new RepoRepository(db);
       repos.upsert('/repo/one', 'repo-one');
       repos.upsert('/repo/two', 'repo-two');
       repos.upsert('/repo/three', 'repo-three');
       const all = repos.findAll();
       expect(all).toHaveLength(3);
-      const names = all.map((r) => r.name).sort();
+      const names = all.map((r) => r.name);
       expect(names).toEqual(['repo-one', 'repo-three', 'repo-two']);
     });
 

--- a/tools/kanban-cli/tests/integration/multi-repo.test.ts
+++ b/tools/kanban-cli/tests/integration/multi-repo.test.ts
@@ -1,0 +1,639 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { KanbanDatabase } from '../../src/db/database.js';
+import { createRegistry } from '../../src/repos/registry.js';
+import { createMultiRepoHelper } from '../../src/repos/multi-repo.js';
+import { syncRepo } from '../../src/sync/sync.js';
+import { loadConfig } from '../../src/config/loader.js';
+import { buildBoard } from '../../src/cli/logic/board.js';
+import { buildNext } from '../../src/cli/logic/next.js';
+import { buildGraph } from '../../src/cli/logic/graph.js';
+import { validateWorkItems } from '../../src/cli/logic/validate.js';
+import { RepoRepository } from '../../src/db/repositories/repo-repository.js';
+import { EpicRepository } from '../../src/db/repositories/epic-repository.js';
+import { TicketRepository } from '../../src/db/repositories/ticket-repository.js';
+import { StageRepository } from '../../src/db/repositories/stage-repository.js';
+import { DependencyRepository } from '../../src/db/repositories/dependency-repository.js';
+import { StateMachine } from '../../src/engine/state-machine.js';
+
+// Test fixtures
+let tmpDir: string;
+let repoAPath: string;
+let repoBPath: string;
+let registryPath: string;
+let dbPath: string;
+let db: KanbanDatabase;
+
+const pipelineConfig = {
+  workflow: {
+    entry_phase: 'Design',
+    phases: [
+      { name: 'Design', skill: 'phase-design', status: 'Design', transitions_to: ['Build'] },
+      { name: 'Build', skill: 'phase-build', status: 'Build', transitions_to: ['Finalize'] },
+      { name: 'Finalize', skill: 'phase-finalize', status: 'Finalize', transitions_to: ['PR Created', 'Done'] },
+      { name: 'PR Created', resolver: 'pr-status', status: 'PR Created', transitions_to: ['Done', 'Addressing Comments'] },
+      { name: 'Addressing Comments', skill: 'review-cycle', status: 'Addressing Comments', transitions_to: ['PR Created'] },
+    ],
+  },
+};
+
+/**
+ * Create a temporary directory structure for a repo
+ */
+function createRepoStructure(repoPath: string, repoName: string): void {
+  const epicsDir = path.join(repoPath, 'epics');
+  fs.mkdirSync(epicsDir, { recursive: true });
+
+  // Create config file
+  const configContent = `workflow:
+  entry_phase: Design
+  phases:
+    - name: Design
+      skill: phase-design
+      status: Design
+      transitions_to:
+        - Build
+    - name: Build
+      skill: phase-build
+      status: Build
+      transitions_to:
+        - Finalize
+    - name: Finalize
+      skill: phase-finalize
+      status: Finalize
+      transitions_to:
+        - PR Created
+        - Done
+    - name: PR Created
+      resolver: pr-status
+      status: PR Created
+      transitions_to:
+        - Done
+        - Addressing Comments
+    - name: Addressing Comments
+      skill: review-cycle
+      status: Addressing Comments
+      transitions_to:
+        - PR Created
+`;
+
+  fs.writeFileSync(path.join(repoPath, '.kanban-workflow.yaml'), configContent);
+
+  // Initialize git repo (required by sync)
+  try {
+    require('child_process').execSync('git init -q && git commit -q --allow-empty -m "init"', { cwd: repoPath });
+  } catch {
+    // Ignore if git is not available
+  }
+}
+
+/**
+ * Create an epic file
+ */
+function createEpic(repoPath: string, epicId: string, title: string, status: string, dependencies: string[] = []): string {
+  const epicDir = path.join(repoPath, 'epics', `${epicId}-${title.toLowerCase().replace(/ /g, '-')}`);
+  fs.mkdirSync(epicDir, { recursive: true });
+
+  const content = `---
+id: ${epicId}
+title: ${title}
+status: ${status}
+tickets: []
+depends_on: ${JSON.stringify(dependencies)}
+---
+## Overview
+${title} epic description.
+`;
+
+  const filePath = path.join(epicDir, `${epicId}.md`);
+  fs.writeFileSync(filePath, content);
+  return epicDir;
+}
+
+/**
+ * Create a ticket file
+ */
+function createTicket(
+  epicDir: string,
+  ticketId: string,
+  title: string,
+  status: string,
+  epicId: string,
+  stageIds: string[] = [],
+  dependencies: string[] = [],
+): string {
+  const ticketDir = path.join(epicDir, `${ticketId}-${title.toLowerCase().replace(/ /g, '-')}`);
+  fs.mkdirSync(ticketDir, { recursive: true });
+
+  const content = `---
+id: ${ticketId}
+epic: ${epicId}
+title: ${title}
+status: ${status}
+source: local
+stages: ${JSON.stringify(stageIds)}
+depends_on: ${JSON.stringify(dependencies)}
+---
+## Overview
+${title} ticket description.
+`;
+
+  const filePath = path.join(ticketDir, `${ticketId}.md`);
+  fs.writeFileSync(filePath, content);
+  return ticketDir;
+}
+
+/**
+ * Create a stage file
+ */
+function createStage(
+  ticketDir: string,
+  stageId: string,
+  title: string,
+  status: string,
+  ticketId: string,
+  epicId: string,
+  dependencies: string[] = [],
+): string {
+  const content = `---
+id: ${stageId}
+ticket: ${ticketId}
+epic: ${epicId}
+title: ${title}
+status: ${status}
+session_active: false
+refinement_type:
+  - frontend
+depends_on: ${JSON.stringify(dependencies)}
+priority: 0
+---
+## Overview
+${title} stage description.
+`;
+
+  const filePath = path.join(ticketDir, `${stageId}.md`);
+  fs.writeFileSync(filePath, content);
+  return filePath;
+}
+
+describe('multi-repo integration', () => {
+  beforeEach(() => {
+    // Create temp directories
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kanban-multi-repo-test-'));
+    repoAPath = path.join(tmpDir, 'repo-a');
+    repoBPath = path.join(tmpDir, 'repo-b');
+    registryPath = path.join(tmpDir, 'repos.yaml');
+    dbPath = path.join(tmpDir, 'kanban.db');
+
+    fs.mkdirSync(repoAPath);
+    fs.mkdirSync(repoBPath);
+
+    // Create database
+    db = new KanbanDatabase(dbPath);
+
+    // Setup repo A: Auth system with 1 epic, 1 ticket, 1 stage
+    createRepoStructure(repoAPath, 'repo-a');
+    const epicADir = createEpic(repoAPath, 'EPIC-001', 'Auth System', 'Design');
+    const ticketADir = createTicket(epicADir, 'TICKET-001-001', 'Login Feature', 'Design', 'EPIC-001', ['STAGE-001-001-001']);
+    createStage(ticketADir, 'STAGE-001-001-001', 'Login Form UI', 'Design', 'TICKET-001-001', 'EPIC-001');
+
+    // Setup repo B: API system with 1 epic, 1 ticket, 1 stage that depends on repo A stage
+    createRepoStructure(repoBPath, 'repo-b');
+    const epicBDir = createEpic(repoBPath, 'EPIC-002', 'API Endpoints', 'Design');
+    const ticketBDir = createTicket(epicBDir, 'TICKET-002-001', 'User Endpoints', 'Design', 'EPIC-002', ['STAGE-002-001-001']);
+    // Cross-repo dependency: repo B's stage depends on repo A's stage (format: repoName/itemId)
+    createStage(ticketBDir, 'STAGE-002-001-001', 'GET /users endpoint', 'Design', 'TICKET-002-001', 'EPIC-002', ['repo-a/STAGE-001-001-001']);
+
+    // Register both repos
+    const registry = createRegistry({
+      registryPath,
+      readFile: (p: string) => fs.readFileSync(p, 'utf-8'),
+      writeFile: (p: string, data: string) => fs.writeFileSync(p, data, 'utf-8'),
+      existsSync: (p: string) => fs.existsSync(p),
+      mkdirSync: (p: string, opts?: { recursive: boolean }) => fs.mkdirSync(p, opts),
+    });
+
+    registry.registerRepo({ path: repoAPath, name: 'repo-a' });
+    registry.registerRepo({ path: repoBPath, name: 'repo-b' });
+  });
+
+  afterEach(() => {
+    db.close();
+    if (fs.existsSync(tmpDir)) {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('registers and syncs two repos successfully', () => {
+    const configA = loadConfig({ repoPath: repoAPath });
+    const resultA = syncRepo({ repoPath: repoAPath, db, config: configA });
+
+    const configB = loadConfig({ repoPath: repoBPath });
+    const resultB = syncRepo({ repoPath: repoBPath, db, config: configB });
+
+    // Verify sync results
+    expect(resultA.epics).toBe(1);
+    expect(resultA.tickets).toBe(1);
+    expect(resultA.stages).toBe(1);
+    expect(resultA.errors).toEqual([]);
+
+    expect(resultB.epics).toBe(1);
+    expect(resultB.tickets).toBe(1);
+    expect(resultB.stages).toBe(1);
+    expect(resultB.errors).toEqual([]);
+
+    // Verify repos are in database
+    const repoRepo = new RepoRepository(db);
+    const repoA = repoRepo.findByPath(repoAPath);
+    const repoB = repoRepo.findByPath(repoBPath);
+
+    expect(repoA).not.toBeNull();
+    expect(repoB).not.toBeNull();
+    expect(repoA!.name).toBe('repo-a');
+    expect(repoB!.name).toBe('repo-b');
+  });
+
+  it('global board shows stages from both repos', () => {
+    // Sync both repos
+    const configA = loadConfig({ repoPath: repoAPath });
+    syncRepo({ repoPath: repoAPath, db, config: configA });
+
+    const configB = loadConfig({ repoPath: repoBPath });
+    syncRepo({ repoPath: repoBPath, db, config: configB });
+
+    // Query data
+    const repoRepo = new RepoRepository(db);
+    const epicRepo = new EpicRepository(db);
+    const ticketRepo = new TicketRepository(db);
+    const stageRepo = new StageRepository(db);
+    const depRepo = new DependencyRepository(db);
+
+    const repoA = repoRepo.findByPath(repoAPath)!;
+    const repoB = repoRepo.findByPath(repoBPath)!;
+
+    // Aggregate data from both repos
+    const epics = [
+      ...epicRepo.listByRepo(repoA.id).map((e) => ({ ...e, repo: 'repo-a' })),
+      ...epicRepo.listByRepo(repoB.id).map((e) => ({ ...e, repo: 'repo-b' })),
+    ];
+    const tickets = [
+      ...ticketRepo.listByRepo(repoA.id).map((t) => ({ ...t, repo: 'repo-a' })),
+      ...ticketRepo.listByRepo(repoB.id).map((t) => ({ ...t, repo: 'repo-b' })),
+    ];
+    const stages = [
+      ...stageRepo.listByRepo(repoA.id).map((s) => ({ ...s, repo: 'repo-a' })),
+      ...stageRepo.listByRepo(repoB.id).map((s) => ({ ...s, repo: 'repo-b' })),
+    ];
+    const deps = [
+      ...depRepo.listByRepo(repoA.id).map((d) => ({ ...d, repo: 'repo-a' })),
+      ...depRepo.listByRepo(repoB.id).map((d) => ({ ...d, repo: 'repo-b' })),
+    ];
+
+    // Build global board
+    const board = buildBoard({
+      config: pipelineConfig,
+      repoPath: 'global',
+      epics: [],
+      tickets,
+      stages,
+      dependencies: deps,
+      global: true,
+      repos: ['repo-a', 'repo-b'],
+    });
+
+    // Verify both repos' stages appear
+    const allStages = Object.values(board.columns).flat().filter((item) => item.type === 'stage');
+    expect(allStages).toHaveLength(2);
+
+    const stageIds = allStages.map((s) => s.id);
+    expect(stageIds).toContain('STAGE-001-001-001');
+    expect(stageIds).toContain('STAGE-002-001-001');
+
+    // Verify repo field is set
+    const stageA = allStages.find((s) => s.id === 'STAGE-001-001-001') as any;
+    const stageB = allStages.find((s) => s.id === 'STAGE-002-001-001') as any;
+    expect(stageA.repo).toBe('repo-a');
+    expect(stageB.repo).toBe('repo-b');
+
+    // Verify global metadata
+    expect(board.repos).toEqual(['repo-a', 'repo-b']);
+  });
+
+  it('global next excludes cross-repo blocked stages', () => {
+    // Sync both repos
+    const configA = loadConfig({ repoPath: repoAPath });
+    syncRepo({ repoPath: repoAPath, db, config: configA });
+
+    const configB = loadConfig({ repoPath: repoBPath });
+    syncRepo({ repoPath: repoBPath, db, config: configB });
+
+    // Query data
+    const repoRepo = new RepoRepository(db);
+    const stageRepo = new StageRepository(db);
+    const ticketRepo = new TicketRepository(db);
+    const depRepo = new DependencyRepository(db);
+
+    const repoA = repoRepo.findByPath(repoAPath)!;
+    const repoB = repoRepo.findByPath(repoBPath)!;
+
+    // Get stages and dependencies
+    const stages = [
+      ...stageRepo.listByRepo(repoA.id).map((s) => ({ ...s, repo: 'repo-a' })),
+      ...stageRepo.listByRepo(repoB.id).map((s) => ({ ...s, repo: 'repo-b' })),
+    ];
+
+    const tickets = [
+      ...ticketRepo.listByRepo(repoA.id),
+      ...ticketRepo.listByRepo(repoB.id),
+    ];
+
+    const deps = [
+      ...depRepo.listByRepo(repoA.id).map((d) => ({ ...d, repo: 'repo-a' })),
+      ...depRepo.listByRepo(repoB.id).map((d) => ({ ...d, repo: 'repo-b' })),
+    ];
+
+    // Build next (repo B's stage should be blocked by unresolved dep on repo A's stage)
+    const next = buildNext({
+      config: pipelineConfig,
+      stages,
+      dependencies: deps,
+      tickets,
+      max: 10,
+    });
+
+    // Repo A's stage (STAGE-001-001-001) should be ready (no unresolved deps)
+    // Repo B's stage (STAGE-002-001-001) should be blocked
+    expect(next.ready_stages.map((s) => s.id)).toContain('STAGE-001-001-001');
+    expect(next.ready_stages.map((s) => s.id)).not.toContain('STAGE-002-001-001');
+    expect(next.blocked_count).toBeGreaterThan(0);
+  });
+
+  it('global reflects cross-repo dependency resolution', () => {
+    // Sync both repos
+    const configA = loadConfig({ repoPath: repoAPath });
+    syncRepo({ repoPath: repoAPath, db, config: configA });
+
+    const configB = loadConfig({ repoPath: repoBPath });
+    syncRepo({ repoPath: repoBPath, db, config: configB });
+
+    // Query data
+    const repoRepo = new RepoRepository(db);
+    const depRepo = new DependencyRepository(db);
+
+    const repoA = repoRepo.findByPath(repoAPath)!;
+    const repoB = repoRepo.findByPath(repoBPath)!;
+
+    // Get initial state
+    const depsBefore = [
+      ...depRepo.listByRepo(repoA.id),
+      ...depRepo.listByRepo(repoB.id),
+    ];
+
+    // Verify cross-repo dependency exists and is unresolved initially
+    const crossRepoDepBefore = depsBefore.find(
+      (d) => d.from_id === 'STAGE-002-001-001' && d.to_id === 'STAGE-001-001-001',
+    );
+    expect(crossRepoDepBefore).toBeDefined();
+    expect(!crossRepoDepBefore?.resolved).toBe(true); // resolved is 0 (falsy)
+
+    // Now mark it as resolved by updating the dependency
+    db.raw().prepare(`
+      UPDATE dependencies
+      SET resolved = 1
+      WHERE from_id = ? AND to_id = ?
+    `).run('STAGE-002-001-001', 'STAGE-001-001-001');
+
+    // Query updated data
+    const depsAfter = [
+      ...depRepo.listByRepo(repoA.id),
+      ...depRepo.listByRepo(repoB.id),
+    ];
+
+    // Verify dependency is now resolved in database
+    const crossRepoDepAfter = depsAfter.find(
+      (d) => d.from_id === 'STAGE-002-001-001' && d.to_id === 'STAGE-001-001-001',
+    );
+    expect(crossRepoDepAfter?.resolved).toBeTruthy();
+
+    // Verify both repos have accessible data
+    expect(depsAfter.length).toBeGreaterThan(0);
+    expect(depsAfter.some((d) => d.from_id === 'STAGE-002-001-001')).toBe(true);
+  });
+
+  it('global graph includes cross-repo edges', () => {
+    // Sync both repos
+    const configA = loadConfig({ repoPath: repoAPath });
+    syncRepo({ repoPath: repoAPath, db, config: configA });
+
+    const configB = loadConfig({ repoPath: repoBPath });
+    syncRepo({ repoPath: repoBPath, db, config: configB });
+
+    // Query data
+    const repoRepo = new RepoRepository(db);
+    const epicRepo = new EpicRepository(db);
+    const ticketRepo = new TicketRepository(db);
+    const stageRepo = new StageRepository(db);
+    const depRepo = new DependencyRepository(db);
+
+    const repoA = repoRepo.findByPath(repoAPath)!;
+    const repoB = repoRepo.findByPath(repoBPath)!;
+
+    // Aggregate data with repo field
+    const epics = [
+      ...epicRepo.listByRepo(repoA.id).map((e) => ({ ...e, repo: 'repo-a' })),
+      ...epicRepo.listByRepo(repoB.id).map((e) => ({ ...e, repo: 'repo-b' })),
+    ];
+    const tickets = [
+      ...ticketRepo.listByRepo(repoA.id).map((t) => ({ ...t, repo: 'repo-a' })),
+      ...ticketRepo.listByRepo(repoB.id).map((t) => ({ ...t, repo: 'repo-b' })),
+    ];
+    const stages = [
+      ...stageRepo.listByRepo(repoA.id).map((s) => ({ ...s, repo: 'repo-a' })),
+      ...stageRepo.listByRepo(repoB.id).map((s) => ({ ...s, repo: 'repo-b' })),
+    ];
+    const deps = [
+      ...depRepo.listByRepo(repoA.id).map((d) => ({ ...d, repo: 'repo-a' })),
+      ...depRepo.listByRepo(repoB.id).map((d) => ({ ...d, repo: 'repo-b' })),
+    ];
+
+    // Build graph
+    const graph = buildGraph({
+      epics,
+      tickets,
+      stages,
+      dependencies: deps,
+      global: true,
+      repos: ['repo-a', 'repo-b'],
+    });
+
+    // Verify nodes from both repos
+    expect(graph.nodes).toHaveLength(6); // 2 epics + 2 tickets + 2 stages
+
+    const epicsInGraph = graph.nodes.filter((n) => n.type === 'epic');
+    expect(epicsInGraph.some((e) => e.repo === 'repo-a')).toBe(true);
+    expect(epicsInGraph.some((e) => e.repo === 'repo-b')).toBe(true);
+
+    // Verify cross-repo edge exists (from B's stage to A's stage)
+    const crossRepoEdges = graph.edges.filter((e) => e.cross_repo);
+    expect(crossRepoEdges.length).toBeGreaterThan(0);
+
+    // The dependency is: STAGE-002-001-001 depends_on STAGE-001-001-001
+    // So the edge should be from STAGE-002-001-001 to STAGE-001-001-001
+    const stageDep = graph.edges.find(
+      (e) => e.from === 'STAGE-002-001-001' && e.to === 'STAGE-001-001-001',
+    );
+    expect(stageDep).toBeDefined();
+    expect(stageDep?.cross_repo).toBe(true);
+
+    // Verify repos field
+    expect(graph.repos).toEqual(['repo-a', 'repo-b']);
+  });
+
+  it('global validate detects cross-repo reference errors', () => {
+    // Sync both repos
+    const configA = loadConfig({ repoPath: repoAPath });
+    syncRepo({ repoPath: repoAPath, db, config: configA });
+
+    const configB = loadConfig({ repoPath: repoBPath });
+    syncRepo({ repoPath: repoBPath, db, config: configB });
+
+    // Query data
+    const repoRepo = new RepoRepository(db);
+    const epicRepo = new EpicRepository(db);
+    const ticketRepo = new TicketRepository(db);
+    const stageRepo = new StageRepository(db);
+
+    const repoA = repoRepo.findByPath(repoAPath)!;
+    const repoB = repoRepo.findByPath(repoBPath)!;
+
+    // Create validate input
+    const epics = [
+      ...epicRepo.listByRepo(repoA.id).map((e) => ({
+        id: e.id,
+        title: e.title,
+        status: e.status,
+        jira_key: e.jira_key,
+        tickets: [],
+        depends_on: [],
+        file_path: e.file_path,
+        repo: 'repo-a',
+      })),
+      ...epicRepo.listByRepo(repoB.id).map((e) => ({
+        id: e.id,
+        title: e.title,
+        status: e.status,
+        jira_key: e.jira_key,
+        tickets: [],
+        depends_on: [],
+        file_path: e.file_path,
+        repo: 'repo-b',
+      })),
+    ];
+
+    const tickets = [
+      ...ticketRepo.listByRepo(repoA.id).map((t) => ({
+        id: t.id,
+        epic_id: t.epic_id,
+        title: t.title,
+        status: t.status,
+        jira_key: t.jira_key,
+        source: t.source,
+        stages: t.id === 'TICKET-001-001' ? ['STAGE-001-001-001'] : [],
+        depends_on: [],
+        jira_links: [],
+        file_path: t.file_path,
+        repo: 'repo-a',
+      })),
+      ...ticketRepo.listByRepo(repoB.id).map((t) => ({
+        id: t.id,
+        epic_id: t.epic_id,
+        title: t.title,
+        status: t.status,
+        jira_key: t.jira_key,
+        source: t.source,
+        stages: t.id === 'TICKET-002-001' ? ['STAGE-002-001-001'] : [],
+        depends_on: [],
+        jira_links: [],
+        file_path: t.file_path,
+        repo: 'repo-b',
+      })),
+    ];
+
+    const stages = [
+      ...stageRepo.listByRepo(repoA.id).map((s) => ({
+        id: s.id,
+        ticket_id: s.ticket_id,
+        epic_id: s.epic_id,
+        title: s.title,
+        status: s.status,
+        refinement_type: s.refinement_type,
+        worktree_branch: s.worktree_branch || '',
+        priority: s.priority,
+        due_date: s.due_date,
+        session_active: s.session_active,
+        depends_on: [],
+        pending_merge_parents: [],
+        is_draft: s.is_draft === 1,
+        file_path: s.file_path,
+        repo: 'repo-a',
+      })),
+      ...stageRepo.listByRepo(repoB.id).map((s) => ({
+        id: s.id,
+        ticket_id: s.ticket_id,
+        epic_id: s.epic_id,
+        title: s.title,
+        status: s.status,
+        refinement_type: s.refinement_type,
+        worktree_branch: s.worktree_branch || '',
+        priority: s.priority,
+        due_date: s.due_date,
+        session_active: s.session_active,
+        depends_on: [],
+        pending_merge_parents: [],
+        is_draft: s.is_draft === 1,
+        file_path: s.file_path,
+        repo: 'repo-b',
+      })),
+    ];
+
+    // Build set of all IDs and valid statuses
+    const allIds = new Set<string>();
+    for (const e of epics) allIds.add(e.id);
+    for (const t of tickets) allIds.add(t.id);
+    for (const s of stages) allIds.add(s.id);
+
+    const sm = StateMachine.fromConfig(pipelineConfig);
+    const validStatuses = new Set(sm.getAllStatuses());
+
+    // Test with valid data
+    const result = validateWorkItems({
+      epics,
+      tickets,
+      stages,
+      dependencies: [],
+      allIds,
+      validStatuses,
+      global: true,
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+
+    // Now test with invalid cross-repo reference
+    const epicWithBadDep = { ...epics[0], depends_on: ['NONEXISTENT-999'] };
+    const invalidResult = validateWorkItems({
+      epics: [epicWithBadDep, ...epics.slice(1)],
+      tickets,
+      stages,
+      dependencies: [],
+      allIds,
+      validStatuses,
+      global: true,
+    });
+
+    expect(invalidResult.valid).toBe(false);
+    expect(invalidResult.errors.some((e) => e.error.includes('does not exist'))).toBe(true);
+  });
+});

--- a/tools/kanban-cli/tests/parser/cross-repo-deps.test.ts
+++ b/tools/kanban-cli/tests/parser/cross-repo-deps.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseDependencyRef,
+  isCrossRepoDep,
+  formatCrossRepoDep,
+} from '../../src/parser/cross-repo-deps.js';
+
+describe('parseDependencyRef', () => {
+  it('parses a local dependency (no slash)', () => {
+    const result = parseDependencyRef('STAGE-001-001-001');
+    expect(result).toEqual({ type: 'local', itemId: 'STAGE-001-001-001' });
+  });
+
+  it('parses a cross-repo stage dependency', () => {
+    const result = parseDependencyRef('backend/STAGE-002-001-001');
+    expect(result).toEqual({
+      type: 'cross-repo',
+      repoName: 'backend',
+      itemId: 'STAGE-002-001-001',
+    });
+  });
+
+  it('parses a cross-repo ticket dependency', () => {
+    const result = parseDependencyRef('backend/TICKET-002-001');
+    expect(result).toEqual({
+      type: 'cross-repo',
+      repoName: 'backend',
+      itemId: 'TICKET-002-001',
+    });
+  });
+
+  it('handles repo names with hyphens', () => {
+    const result = parseDependencyRef('my-service/EPIC-003');
+    expect(result).toEqual({
+      type: 'cross-repo',
+      repoName: 'my-service',
+      itemId: 'EPIC-003',
+    });
+  });
+});
+
+describe('isCrossRepoDep', () => {
+  it('returns false for a local dependency', () => {
+    expect(isCrossRepoDep('STAGE-001-001-001')).toBe(false);
+  });
+
+  it('returns true for a cross-repo dependency', () => {
+    expect(isCrossRepoDep('backend/STAGE-002-001-001')).toBe(true);
+  });
+
+  it('returns true for a cross-repo ticket dependency', () => {
+    expect(isCrossRepoDep('backend/TICKET-002-001')).toBe(true);
+  });
+});
+
+describe('formatCrossRepoDep', () => {
+  it('formats a cross-repo dependency string', () => {
+    expect(formatCrossRepoDep('backend', 'STAGE-001')).toBe('backend/STAGE-001');
+  });
+
+  it('roundtrips through parseDependencyRef', () => {
+    const formatted = formatCrossRepoDep('backend', 'STAGE-001');
+    const parsed = parseDependencyRef(formatted);
+    expect(parsed).toEqual({
+      type: 'cross-repo',
+      repoName: 'backend',
+      itemId: 'STAGE-001',
+    });
+  });
+});

--- a/tools/kanban-cli/tests/parser/cross-repo-deps.test.ts
+++ b/tools/kanban-cli/tests/parser/cross-repo-deps.test.ts
@@ -37,6 +37,31 @@ describe('parseDependencyRef', () => {
       itemId: 'EPIC-003',
     });
   });
+
+  it('throws on empty string', () => {
+    expect(() => parseDependencyRef('')).toThrow('Dependency reference cannot be empty');
+  });
+
+  it('throws on leading slash (empty repo name)', () => {
+    expect(() => parseDependencyRef('/STAGE-001')).toThrow(
+      'Invalid cross-repo dependency: empty repo name',
+    );
+  });
+
+  it('throws on trailing slash (empty item ID)', () => {
+    expect(() => parseDependencyRef('backend/')).toThrow(
+      'Invalid cross-repo dependency: empty item ID',
+    );
+  });
+
+  it('splits on first slash only (multiple slashes)', () => {
+    const result = parseDependencyRef('org/backend/STAGE-001');
+    expect(result).toEqual({
+      type: 'cross-repo',
+      repoName: 'org',
+      itemId: 'backend/STAGE-001',
+    });
+  });
 });
 
 describe('isCrossRepoDep', () => {
@@ -50,6 +75,18 @@ describe('isCrossRepoDep', () => {
 
   it('returns true for a cross-repo ticket dependency', () => {
     expect(isCrossRepoDep('backend/TICKET-002-001')).toBe(true);
+  });
+
+  it('returns false for empty string', () => {
+    expect(isCrossRepoDep('')).toBe(false);
+  });
+
+  it('returns false for leading slash (empty repo name)', () => {
+    expect(isCrossRepoDep('/STAGE-001')).toBe(false);
+  });
+
+  it('returns false for trailing slash (empty item ID)', () => {
+    expect(isCrossRepoDep('backend/')).toBe(false);
   });
 });
 

--- a/tools/kanban-cli/tests/repos/multi-repo.test.ts
+++ b/tools/kanban-cli/tests/repos/multi-repo.test.ts
@@ -1,0 +1,402 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createMultiRepoHelper } from '../../src/repos/multi-repo.js';
+import type { MultiRepoDeps } from '../../src/repos/multi-repo.js';
+import type { RepoEntry } from '../../src/repos/registry.js';
+import type { RepoRecord } from '../../src/types/work-items.js';
+import type { KanbanDatabase } from '../../src/db/database.js';
+import type { EpicRow, TicketRow, StageRow, DependencyRow } from '../../src/db/repositories/types.js';
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+function makeRepoEntry(overrides: Partial<RepoEntry> = {}): RepoEntry {
+  return {
+    path: '/projects/backend',
+    name: 'backend',
+    ...overrides,
+  };
+}
+
+function makeRepoRecord(overrides: Partial<RepoRecord> = {}): RepoRecord {
+  return {
+    id: 1,
+    path: '/projects/backend',
+    name: 'backend',
+    registered_at: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function makeEpicRow(overrides: Partial<EpicRow> = {}): EpicRow {
+  return {
+    id: 'EPIC-001',
+    repo_id: 1,
+    title: 'Test Epic',
+    status: 'Open',
+    jira_key: null,
+    file_path: '/projects/backend/epics/001/epic.md',
+    last_synced: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function makeTicketRow(overrides: Partial<TicketRow> = {}): TicketRow {
+  return {
+    id: 'TICKET-001',
+    epic_id: 'EPIC-001',
+    repo_id: 1,
+    title: 'Test Ticket',
+    status: 'Open',
+    jira_key: null,
+    source: 'local',
+    has_stages: 1,
+    file_path: '/projects/backend/epics/001/tickets/001.md',
+    last_synced: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function makeStageRow(overrides: Partial<StageRow> = {}): StageRow {
+  return {
+    id: 'EPIC-001-TICKET-001-S1',
+    ticket_id: 'TICKET-001',
+    epic_id: 'EPIC-001',
+    repo_id: 1,
+    title: 'Test Stage',
+    status: 'Not Started',
+    kanban_column: 'backlog',
+    refinement_type: '[]',
+    worktree_branch: null,
+    pr_url: null,
+    pr_number: null,
+    priority: 0,
+    due_date: null,
+    session_active: 0,
+    locked_at: null,
+    locked_by: null,
+    is_draft: 0,
+    pending_merge_parents: null,
+    mr_target_branch: null,
+    file_path: '/projects/backend/epics/001/tickets/001/stages/S1.md',
+    last_synced: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function makeDependencyRow(overrides: Partial<DependencyRow> = {}): DependencyRow {
+  return {
+    id: 1,
+    from_id: 'EPIC-001-TICKET-001-S2',
+    to_id: 'EPIC-001-TICKET-001-S1',
+    from_type: 'stage',
+    to_type: 'stage',
+    resolved: 0,
+    repo_id: 1,
+    target_repo_name: null,
+    ...overrides,
+  };
+}
+
+/** Stub KanbanDatabase — syncRepo is mocked so the DB is never used directly. */
+const mockDb = {} as KanbanDatabase;
+
+/**
+ * Build mock deps with sensible defaults. Each dep can be overridden.
+ */
+function makeDeps(overrides: Partial<MultiRepoDeps> = {}): MultiRepoDeps {
+  return {
+    registry: {
+      loadRepos: vi.fn().mockReturnValue([]),
+      registerRepo: vi.fn(),
+      unregisterRepo: vi.fn(),
+      findByName: vi.fn().mockReturnValue(null),
+    },
+    db: mockDb,
+    repoRepo: {
+      findByPath: vi.fn().mockReturnValue(null),
+      findById: vi.fn().mockReturnValue(null),
+    },
+    epicRepo: {
+      listByRepo: vi.fn().mockReturnValue([]),
+    },
+    ticketRepo: {
+      listByRepo: vi.fn().mockReturnValue([]),
+    },
+    stageRepo: {
+      listByRepo: vi.fn().mockReturnValue([]),
+    },
+    depRepo: {
+      listByRepo: vi.fn().mockReturnValue([]),
+    },
+    loadConfig: vi.fn().mockReturnValue({ workflow: { phases: [] } }),
+    syncRepo: vi.fn(),
+    ...overrides,
+  };
+}
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+describe('createMultiRepoHelper', () => {
+  // ── syncAllRepos ─────────────────────────────────────────────────
+
+  describe('syncAllRepos()', () => {
+    it('syncs each registered repo', () => {
+      const repos: RepoEntry[] = [
+        makeRepoEntry({ path: '/projects/backend', name: 'backend' }),
+        makeRepoEntry({ path: '/projects/frontend', name: 'frontend' }),
+      ];
+
+      const syncRepoFn = vi.fn();
+      const loadConfigFn = vi.fn().mockReturnValue({ workflow: { phases: [] } });
+
+      const deps = makeDeps({
+        registry: {
+          loadRepos: vi.fn().mockReturnValue(repos),
+          registerRepo: vi.fn(),
+          unregisterRepo: vi.fn(),
+          findByName: vi.fn().mockReturnValue(null),
+        },
+        repoRepo: {
+          findByPath: vi.fn()
+            .mockReturnValueOnce(makeRepoRecord({ id: 1, path: '/projects/backend', name: 'backend' }))
+            .mockReturnValueOnce(makeRepoRecord({ id: 2, path: '/projects/frontend', name: 'frontend' })),
+          findById: vi.fn(),
+        },
+        loadConfig: loadConfigFn,
+        syncRepo: syncRepoFn,
+      });
+
+      const helper = createMultiRepoHelper(deps);
+      helper.syncAllRepos();
+
+      expect(syncRepoFn).toHaveBeenCalledTimes(2);
+      expect(syncRepoFn).toHaveBeenCalledWith(
+        expect.objectContaining({ repoPath: '/projects/backend', db: mockDb }),
+      );
+      expect(syncRepoFn).toHaveBeenCalledWith(
+        expect.objectContaining({ repoPath: '/projects/frontend', db: mockDb }),
+      );
+      expect(loadConfigFn).toHaveBeenCalledTimes(2);
+      expect(loadConfigFn).toHaveBeenCalledWith({ repoPath: '/projects/backend' });
+      expect(loadConfigFn).toHaveBeenCalledWith({ repoPath: '/projects/frontend' });
+    });
+
+    it('returns correct repo info list', () => {
+      const repos: RepoEntry[] = [
+        makeRepoEntry({ path: '/projects/backend', name: 'backend' }),
+        makeRepoEntry({ path: '/projects/frontend', name: 'frontend' }),
+      ];
+
+      const deps = makeDeps({
+        registry: {
+          loadRepos: vi.fn().mockReturnValue(repos),
+          registerRepo: vi.fn(),
+          unregisterRepo: vi.fn(),
+          findByName: vi.fn().mockReturnValue(null),
+        },
+        repoRepo: {
+          findByPath: vi.fn()
+            .mockReturnValueOnce(makeRepoRecord({ id: 1, path: '/projects/backend', name: 'backend' }))
+            .mockReturnValueOnce(makeRepoRecord({ id: 2, path: '/projects/frontend', name: 'frontend' })),
+          findById: vi.fn(),
+        },
+      });
+
+      const helper = createMultiRepoHelper(deps);
+      const result = helper.syncAllRepos();
+
+      expect(result).toEqual([
+        { repoId: 1, repoName: 'backend', repoPath: '/projects/backend' },
+        { repoId: 2, repoName: 'frontend', repoPath: '/projects/frontend' },
+      ]);
+    });
+
+    it('handles empty registry (returns [])', () => {
+      const deps = makeDeps({
+        registry: {
+          loadRepos: vi.fn().mockReturnValue([]),
+          registerRepo: vi.fn(),
+          unregisterRepo: vi.fn(),
+          findByName: vi.fn().mockReturnValue(null),
+        },
+      });
+
+      const helper = createMultiRepoHelper(deps);
+      const result = helper.syncAllRepos();
+
+      expect(result).toEqual([]);
+      expect(deps.syncRepo).not.toHaveBeenCalled();
+    });
+
+    it('skips repos not found in database after sync', () => {
+      const repos: RepoEntry[] = [
+        makeRepoEntry({ path: '/projects/backend', name: 'backend' }),
+        makeRepoEntry({ path: '/projects/missing', name: 'missing' }),
+      ];
+
+      const deps = makeDeps({
+        registry: {
+          loadRepos: vi.fn().mockReturnValue(repos),
+          registerRepo: vi.fn(),
+          unregisterRepo: vi.fn(),
+          findByName: vi.fn().mockReturnValue(null),
+        },
+        repoRepo: {
+          findByPath: vi.fn()
+            .mockReturnValueOnce(makeRepoRecord({ id: 1, path: '/projects/backend', name: 'backend' }))
+            .mockReturnValueOnce(null), // missing repo
+          findById: vi.fn(),
+        },
+      });
+
+      const helper = createMultiRepoHelper(deps);
+      const result = helper.syncAllRepos();
+
+      // Only backend is in the result
+      expect(result).toEqual([
+        { repoId: 1, repoName: 'backend', repoPath: '/projects/backend' },
+      ]);
+    });
+  });
+
+  // ── loadAllRepoData ──────────────────────────────────────────────
+
+  describe('loadAllRepoData()', () => {
+    it('aggregates data from multiple repos', () => {
+      const deps = makeDeps({
+        repoRepo: {
+          findByPath: vi.fn(),
+          findById: vi.fn()
+            .mockReturnValueOnce(makeRepoRecord({ id: 1, name: 'backend' }))
+            .mockReturnValueOnce(makeRepoRecord({ id: 2, name: 'frontend' })),
+        },
+        epicRepo: {
+          listByRepo: vi.fn()
+            .mockReturnValueOnce([makeEpicRow({ id: 'EPIC-001', repo_id: 1 })])
+            .mockReturnValueOnce([makeEpicRow({ id: 'EPIC-002', repo_id: 2 })]),
+        },
+        ticketRepo: {
+          listByRepo: vi.fn()
+            .mockReturnValueOnce([makeTicketRow({ id: 'TICKET-001', repo_id: 1 })])
+            .mockReturnValueOnce([makeTicketRow({ id: 'TICKET-002', repo_id: 2 })]),
+        },
+        stageRepo: {
+          listByRepo: vi.fn()
+            .mockReturnValueOnce([makeStageRow({ id: 'S1', repo_id: 1 })])
+            .mockReturnValueOnce([makeStageRow({ id: 'S2', repo_id: 2 })]),
+        },
+        depRepo: {
+          listByRepo: vi.fn()
+            .mockReturnValueOnce([makeDependencyRow({ id: 1, repo_id: 1 })])
+            .mockReturnValueOnce([makeDependencyRow({ id: 2, repo_id: 2 })]),
+        },
+      });
+
+      const helper = createMultiRepoHelper(deps);
+      const result = helper.loadAllRepoData([1, 2]);
+
+      expect(result.epics).toHaveLength(2);
+      expect(result.tickets).toHaveLength(2);
+      expect(result.stages).toHaveLength(2);
+      expect(result.deps).toHaveLength(2);
+    });
+
+    it('adds repo field to each item', () => {
+      const deps = makeDeps({
+        repoRepo: {
+          findByPath: vi.fn(),
+          findById: vi.fn()
+            .mockReturnValueOnce(makeRepoRecord({ id: 1, name: 'backend' }))
+            .mockReturnValueOnce(makeRepoRecord({ id: 2, name: 'frontend' })),
+        },
+        epicRepo: {
+          listByRepo: vi.fn()
+            .mockReturnValueOnce([makeEpicRow({ id: 'EPIC-001', repo_id: 1 })])
+            .mockReturnValueOnce([makeEpicRow({ id: 'EPIC-002', repo_id: 2 })]),
+        },
+        ticketRepo: {
+          listByRepo: vi.fn()
+            .mockReturnValueOnce([makeTicketRow({ id: 'TICKET-001', repo_id: 1 })])
+            .mockReturnValueOnce([]),
+        },
+        stageRepo: {
+          listByRepo: vi.fn()
+            .mockReturnValueOnce([makeStageRow({ id: 'S1', repo_id: 1 })])
+            .mockReturnValueOnce([]),
+        },
+        depRepo: {
+          listByRepo: vi.fn()
+            .mockReturnValueOnce([])
+            .mockReturnValueOnce([makeDependencyRow({ id: 1, repo_id: 2 })]),
+        },
+      });
+
+      const helper = createMultiRepoHelper(deps);
+      const result = helper.loadAllRepoData([1, 2]);
+
+      // Epics
+      expect(result.epics[0].repo).toBe('backend');
+      expect(result.epics[1].repo).toBe('frontend');
+
+      // Tickets
+      expect(result.tickets[0].repo).toBe('backend');
+
+      // Stages
+      expect(result.stages[0].repo).toBe('backend');
+
+      // Deps
+      expect(result.deps[0].repo).toBe('frontend');
+    });
+
+    it('returns empty arrays for unsynced repos (not found in DB)', () => {
+      const deps = makeDeps({
+        repoRepo: {
+          findByPath: vi.fn(),
+          findById: vi.fn().mockReturnValue(null), // repo not found
+        },
+        epicRepo: { listByRepo: vi.fn().mockReturnValue([]) },
+        ticketRepo: { listByRepo: vi.fn().mockReturnValue([]) },
+        stageRepo: { listByRepo: vi.fn().mockReturnValue([]) },
+        depRepo: { listByRepo: vi.fn().mockReturnValue([]) },
+      });
+
+      const helper = createMultiRepoHelper(deps);
+      const result = helper.loadAllRepoData([99]);
+
+      expect(result.epics).toEqual([]);
+      expect(result.tickets).toEqual([]);
+      expect(result.stages).toEqual([]);
+      expect(result.deps).toEqual([]);
+    });
+
+    it('handles empty repoIds array', () => {
+      const deps = makeDeps();
+      const helper = createMultiRepoHelper(deps);
+      const result = helper.loadAllRepoData([]);
+
+      expect(result.epics).toEqual([]);
+      expect(result.tickets).toEqual([]);
+      expect(result.stages).toEqual([]);
+      expect(result.deps).toEqual([]);
+    });
+
+    it('uses "unknown" for repos not found by ID', () => {
+      const deps = makeDeps({
+        repoRepo: {
+          findByPath: vi.fn(),
+          findById: vi.fn().mockReturnValue(null),
+        },
+        epicRepo: {
+          listByRepo: vi.fn().mockReturnValue([makeEpicRow({ id: 'EPIC-001', repo_id: 99 })]),
+        },
+        ticketRepo: { listByRepo: vi.fn().mockReturnValue([]) },
+        stageRepo: { listByRepo: vi.fn().mockReturnValue([]) },
+        depRepo: { listByRepo: vi.fn().mockReturnValue([]) },
+      });
+
+      const helper = createMultiRepoHelper(deps);
+      const result = helper.loadAllRepoData([99]);
+
+      expect(result.epics[0].repo).toBe('unknown');
+    });
+  });
+});

--- a/tools/kanban-cli/tests/repos/registry.test.ts
+++ b/tools/kanban-cli/tests/repos/registry.test.ts
@@ -1,0 +1,263 @@
+import { describe, it, expect } from 'vitest';
+import { stringify as yamlStringify } from 'yaml';
+import { createRegistry } from '../../src/repos/registry.js';
+import type { RepoEntry, RegistryDeps } from '../../src/repos/registry.js';
+
+/** Helper: build a mock deps object backed by an in-memory "filesystem". */
+function makeDeps(overrides: Partial<RegistryDeps> = {}): RegistryDeps {
+  const files = new Map<string, string>();
+  let dirCreated = false;
+
+  return {
+    registryPath: '/fake/.config/kanban-workflow/repos.yaml',
+    readFile: (p: string) => {
+      const content = files.get(p);
+      if (content === undefined) throw new Error(`ENOENT: ${p}`);
+      return content;
+    },
+    writeFile: (p: string, data: string) => {
+      files.set(p, data);
+    },
+    existsSync: (p: string) => files.has(p),
+    mkdirSync: (_p: string, _opts?: { recursive: boolean }) => {
+      dirCreated = true;
+    },
+    // Expose internals for assertions
+    _files: files,
+    _dirCreated: () => dirCreated,
+    ...overrides,
+  } as RegistryDeps & { _files: Map<string, string>; _dirCreated: () => boolean };
+}
+
+function yamlWith(repos: Array<Record<string, unknown>>): string {
+  return yamlStringify({ repos });
+}
+
+describe('createRegistry', () => {
+  // ── loadRepos ──────────────────────────────────────────────────────
+
+  describe('loadRepos()', () => {
+    it('returns empty array when file does not exist', () => {
+      const deps = makeDeps();
+      const registry = createRegistry(deps);
+
+      const result = registry.loadRepos();
+      expect(result).toEqual([]);
+    });
+
+    it('parses valid YAML with multiple repos', () => {
+      const deps = makeDeps();
+      (deps as any)._files.set(
+        deps.registryPath,
+        yamlWith([
+          { path: '/projects/backend', name: 'backend' },
+          { path: '/projects/frontend', name: 'frontend' },
+        ]),
+      );
+
+      const registry = createRegistry(deps);
+      const result = registry.loadRepos();
+
+      expect(result).toHaveLength(2);
+      expect(result[0]).toEqual({ path: '/projects/backend', name: 'backend' });
+      expect(result[1]).toEqual({ path: '/projects/frontend', name: 'frontend' });
+    });
+
+    it('throws on invalid YAML (missing name)', () => {
+      const deps = makeDeps();
+      (deps as any)._files.set(
+        deps.registryPath,
+        yamlWith([{ path: '/projects/backend' }]),
+      );
+
+      const registry = createRegistry(deps);
+      expect(() => registry.loadRepos()).toThrow();
+    });
+
+    it('throws on invalid YAML (missing path)', () => {
+      const deps = makeDeps();
+      (deps as any)._files.set(
+        deps.registryPath,
+        yamlWith([{ name: 'backend' }]),
+      );
+
+      const registry = createRegistry(deps);
+      expect(() => registry.loadRepos()).toThrow();
+    });
+
+    it('parses repos with optional slack_webhook', () => {
+      const deps = makeDeps();
+      (deps as any)._files.set(
+        deps.registryPath,
+        yamlWith([
+          {
+            path: '/projects/backend',
+            name: 'backend',
+            slack_webhook: 'https://hooks.slack.com/services/T/B/x',
+          },
+          { path: '/projects/frontend', name: 'frontend' },
+        ]),
+      );
+
+      const registry = createRegistry(deps);
+      const result = registry.loadRepos();
+
+      expect(result[0].slack_webhook).toBe('https://hooks.slack.com/services/T/B/x');
+      expect(result[1].slack_webhook).toBeUndefined();
+    });
+
+    it('rejects invalid slack_webhook URL', () => {
+      const deps = makeDeps();
+      (deps as any)._files.set(
+        deps.registryPath,
+        yamlWith([
+          {
+            path: '/projects/backend',
+            name: 'backend',
+            slack_webhook: 'not-a-url',
+          },
+        ]),
+      );
+
+      const registry = createRegistry(deps);
+      expect(() => registry.loadRepos()).toThrow();
+    });
+  });
+
+  // ── registerRepo ───────────────────────────────────────────────────
+
+  describe('registerRepo()', () => {
+    it('adds entry to file and creates dir if needed', () => {
+      const deps = makeDeps();
+      const registry = createRegistry(deps);
+
+      registry.registerRepo({ path: '/projects/backend', name: 'backend' });
+
+      // File should exist now
+      expect(deps.existsSync(deps.registryPath)).toBe(true);
+      // Dir should have been created
+      expect((deps as any)._dirCreated()).toBe(true);
+
+      const result = registry.loadRepos();
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({ path: '/projects/backend', name: 'backend' });
+    });
+
+    it('appends to existing repos', () => {
+      const deps = makeDeps();
+      (deps as any)._files.set(
+        deps.registryPath,
+        yamlWith([{ path: '/projects/backend', name: 'backend' }]),
+      );
+
+      const registry = createRegistry(deps);
+      registry.registerRepo({ path: '/projects/frontend', name: 'frontend' });
+
+      const result = registry.loadRepos();
+      expect(result).toHaveLength(2);
+      expect(result[1].name).toBe('frontend');
+    });
+
+    it('rejects duplicate name', () => {
+      const deps = makeDeps();
+      (deps as any)._files.set(
+        deps.registryPath,
+        yamlWith([{ path: '/projects/backend', name: 'backend' }]),
+      );
+
+      const registry = createRegistry(deps);
+      expect(() =>
+        registry.registerRepo({ path: '/projects/other', name: 'backend' }),
+      ).toThrow(/duplicate.*name/i);
+    });
+
+    it('rejects duplicate path', () => {
+      const deps = makeDeps();
+      (deps as any)._files.set(
+        deps.registryPath,
+        yamlWith([{ path: '/projects/backend', name: 'backend' }]),
+      );
+
+      const registry = createRegistry(deps);
+      expect(() =>
+        registry.registerRepo({ path: '/projects/backend', name: 'other' }),
+      ).toThrow(/duplicate.*path/i);
+    });
+  });
+
+  // ── unregisterRepo ─────────────────────────────────────────────────
+
+  describe('unregisterRepo()', () => {
+    it('removes entry by name', () => {
+      const deps = makeDeps();
+      (deps as any)._files.set(
+        deps.registryPath,
+        yamlWith([
+          { path: '/projects/backend', name: 'backend' },
+          { path: '/projects/frontend', name: 'frontend' },
+        ]),
+      );
+
+      const registry = createRegistry(deps);
+      registry.unregisterRepo('backend');
+
+      const result = registry.loadRepos();
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe('frontend');
+    });
+
+    it('throws when name not found', () => {
+      const deps = makeDeps();
+      (deps as any)._files.set(
+        deps.registryPath,
+        yamlWith([{ path: '/projects/backend', name: 'backend' }]),
+      );
+
+      const registry = createRegistry(deps);
+      expect(() => registry.unregisterRepo('nonexistent')).toThrow(
+        /not found/i,
+      );
+    });
+  });
+
+  // ── findByName ─────────────────────────────────────────────────────
+
+  describe('findByName()', () => {
+    it('returns matching entry', () => {
+      const deps = makeDeps();
+      (deps as any)._files.set(
+        deps.registryPath,
+        yamlWith([
+          { path: '/projects/backend', name: 'backend' },
+          { path: '/projects/frontend', name: 'frontend' },
+        ]),
+      );
+
+      const registry = createRegistry(deps);
+      const entry = registry.findByName('frontend');
+
+      expect(entry).toEqual({ path: '/projects/frontend', name: 'frontend' });
+    });
+
+    it('returns null when no match', () => {
+      const deps = makeDeps();
+      (deps as any)._files.set(
+        deps.registryPath,
+        yamlWith([{ path: '/projects/backend', name: 'backend' }]),
+      );
+
+      const registry = createRegistry(deps);
+      const entry = registry.findByName('nonexistent');
+
+      expect(entry).toBeNull();
+    });
+
+    it('returns null when file does not exist', () => {
+      const deps = makeDeps();
+      const registry = createRegistry(deps);
+
+      const entry = registry.findByName('anything');
+      expect(entry).toBeNull();
+    });
+  });
+});

--- a/tools/mcp-server/src/state.ts
+++ b/tools/mcp-server/src/state.ts
@@ -41,6 +41,7 @@ export interface MockPage {
 
 export interface SlackNotification {
   message: string;
+  webhook_url?: string;
   stage?: string;
   title?: string;
   ticket?: string;

--- a/tools/mcp-server/tests/slack.test.ts
+++ b/tools/mcp-server/tests/slack.test.ts
@@ -219,6 +219,135 @@ describe('Slack tools', () => {
     });
   });
 
+  describe('handleSlackNotify — webhook_url override', () => {
+    describe('mock mode', () => {
+      let mockState: MockState;
+      let deps: SlackToolDeps;
+
+      beforeEach(() => {
+        process.env.KANBAN_MOCK = 'true';
+        mockState = new MockState();
+        deps = { mockState };
+      });
+
+      it('stores webhook_url in MockState notification', async () => {
+        const args = {
+          message: 'test notification',
+          webhook_url: 'https://hooks.slack.com/services/T111/B111/override',
+        };
+        await handleSlackNotify(args, deps);
+
+        const notifications = mockState.getNotifications();
+        expect(notifications).toHaveLength(1);
+        expect(notifications[0].webhook_url).toBe(
+          'https://hooks.slack.com/services/T111/B111/override',
+        );
+        expect(notifications[0].message).toBe('test notification');
+      });
+
+      it('works without webhook_url (existing behavior unchanged)', async () => {
+        await handleSlackNotify({ message: 'no override' }, deps);
+
+        const notifications = mockState.getNotifications();
+        expect(notifications).toHaveLength(1);
+        expect(notifications[0].webhook_url).toBeUndefined();
+        expect(notifications[0].message).toBe('no override');
+      });
+    });
+
+    describe('real mode', () => {
+      let mockFetch: ReturnType<typeof vi.fn>;
+
+      beforeEach(() => {
+        delete process.env.KANBAN_MOCK;
+        mockFetch = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+      });
+
+      it('webhook_url override sends to specified URL', async () => {
+        const deps: SlackToolDeps = {
+          mockState: null,
+          webhookUrl: 'https://hooks.slack.com/services/T000/B000/global',
+          fetch: mockFetch as unknown as typeof globalThis.fetch,
+        };
+        await handleSlackNotify(
+          {
+            message: 'test',
+            webhook_url: 'https://hooks.slack.com/services/T111/B111/override',
+          },
+          deps,
+        );
+
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+        const [url] = mockFetch.mock.calls[0];
+        expect(url).toBe('https://hooks.slack.com/services/T111/B111/override');
+      });
+
+      it('webhook_url takes precedence over global webhook', async () => {
+        const deps: SlackToolDeps = {
+          mockState: null,
+          webhookUrl: 'https://hooks.slack.com/services/T000/B000/global',
+          fetch: mockFetch as unknown as typeof globalThis.fetch,
+        };
+        await handleSlackNotify(
+          {
+            message: 'test',
+            webhook_url: 'https://hooks.slack.com/services/T222/B222/repo-specific',
+          },
+          deps,
+        );
+
+        const [url] = mockFetch.mock.calls[0];
+        expect(url).toBe('https://hooks.slack.com/services/T222/B222/repo-specific');
+        expect(url).not.toBe('https://hooks.slack.com/services/T000/B000/global');
+      });
+
+      it('without webhook_url, uses global webhookUrl (existing behavior)', async () => {
+        const deps: SlackToolDeps = {
+          mockState: null,
+          webhookUrl: 'https://hooks.slack.com/services/T000/B000/global',
+          fetch: mockFetch as unknown as typeof globalThis.fetch,
+        };
+        await handleSlackNotify({ message: 'test' }, deps);
+
+        const [url] = mockFetch.mock.calls[0];
+        expect(url).toBe('https://hooks.slack.com/services/T000/B000/global');
+      });
+
+      it('webhook_url without global webhookUrl still sends successfully', async () => {
+        const deps: SlackToolDeps = {
+          mockState: null,
+          fetch: mockFetch as unknown as typeof globalThis.fetch,
+        };
+        const result = await handleSlackNotify(
+          {
+            message: 'test',
+            webhook_url: 'https://hooks.slack.com/services/T333/B333/only-override',
+          },
+          deps,
+        );
+
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+        const [url] = mockFetch.mock.calls[0];
+        expect(url).toBe('https://hooks.slack.com/services/T333/B333/only-override');
+        const data = parseResult(result);
+        expect(data).toContain('sent');
+      });
+
+      it('neither webhook_url nor global webhookUrl skips silently', async () => {
+        const deps: SlackToolDeps = {
+          mockState: null,
+          fetch: mockFetch as unknown as typeof globalThis.fetch,
+        };
+        const result = await handleSlackNotify({ message: 'test' }, deps);
+
+        expect(mockFetch).not.toHaveBeenCalled();
+        const data = parseResult(result);
+        expect(data).toContain('skipped');
+        expect(data).toContain('no webhook URL');
+      });
+    });
+  });
+
   describe('registerSlackTools', () => {
     it('registers 1 tool on the server without error', () => {
       const server = new McpServer({ name: 'test-server', version: '0.0.1' });


### PR DESCRIPTION
## Summary

- Add multi-repo support with shared SQLite database and `repos.yaml` registry
- New CLI commands: `register-repo`, `unregister-repo`, `list-repos`
- Add `--global` flag to `board`, `next`, `graph`, and `validate` commands for cross-repo aggregation
- Implement cross-repo dependency resolution (hard + soft) in sync engine using `repoName/ITEM-ID` format
- Add per-repo Slack webhook routing via `webhook_url` override in MCP `slack_notify` tool
- 888 tests across 58 test files, including end-to-end integration tests with two repos

## Test plan
- [x] All 888 unit + integration tests pass (`npm run verify`)
- [x] Integration tests exercise full sync → DB → logic pipeline with two real repos
- [x] Cross-repo dependency resolution tested end-to-end (YAML file update → sync → resolution)
- [x] Two-stage code review (spec + quality) completed for every task
- [ ] Manual testing with real multi-repo setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)