### PR TITLE
fix(orchestrator): resolve TypeScript errors and missing mock methods from Stage 10b

### DIFF
--- a/tools/orchestrator/src/approval-service.ts
+++ b/tools/orchestrator/src/approval-service.ts
@@ -64,7 +64,7 @@ export class ApprovalService extends EventEmitter implements ProtocolHandler {
         createdAt: Date.now(),
       };
       this.pending.set(requestId, entry);
-      this.emit('question-requested', entry);
+      this.emit('question-requested', entry as PendingQuestion & { type: 'question' });
     } else {
       const entry: PendingEntry = {
         type: 'approval',
@@ -75,7 +75,7 @@ export class ApprovalService extends EventEmitter implements ProtocolHandler {
         createdAt: Date.now(),
       };
       this.pending.set(requestId, entry);
-      this.emit('approval-requested', entry);
+      this.emit('approval-requested', entry as PendingApproval & { type: 'approval' });
     }
   }
 

--- a/tools/orchestrator/src/loop.ts
+++ b/tools/orchestrator/src/loop.ts
@@ -274,7 +274,7 @@ export function createOrchestrator(config: OrchestratorConfig, deps: Orchestrato
       peer.sendUserMessage(message);
     } else {
       // Queue message if peer not yet available
-      messageQueue.enqueue(stageId, message);
+      messageQueue.queue(stageId, message);
     }
   };
 

--- a/tools/orchestrator/src/protocol-peer.ts
+++ b/tools/orchestrator/src/protocol-peer.ts
@@ -115,7 +115,7 @@ export class ProtocolPeer {
             break;
           }
           case 'result': {
-            handler.handleResult(msg as ResultMessage);
+            handler.handleResult(msg as unknown as ResultMessage);
             break;
           }
           // All other message types (assistant, system, etc.) are streaming

--- a/tools/orchestrator/tests/integration/insights-threshold-flow.test.ts
+++ b/tools/orchestrator/tests/integration/insights-threshold-flow.test.ts
@@ -107,6 +107,17 @@ function makeSessionExecutor(): SessionExecutor & {
     spawn: vi.fn(async (): Promise<SessionResult> => ({ exitCode: 0, durationMs: 1000 })),
     getActiveSessions: vi.fn(() => []),
     killAll: vi.fn(),
+    getPeer: vi.fn(() => undefined),
+    getApprovalService: vi.fn(() => ({
+      on: vi.fn(), emit: vi.fn(),
+      handleControlRequest: vi.fn(), handleCancelRequest: vi.fn(),
+      handleResult: vi.fn(), setCurrentStageId: vi.fn(),
+    })) as SessionExecutor['getApprovalService'],
+    getMessageQueue: vi.fn(() => ({
+      queue: vi.fn(), take: vi.fn(() => undefined),
+      peek: vi.fn(() => undefined), has: vi.fn(() => false), delete: vi.fn(),
+    })) as SessionExecutor['getMessageQueue'],
+    buildSpawnArgs: vi.fn(() => []),
   };
 }
 

--- a/tools/orchestrator/tests/loop.test.ts
+++ b/tools/orchestrator/tests/loop.test.ts
@@ -115,6 +115,10 @@ function makeMockDeps(): {
     spawn: ReturnType<typeof vi.fn>;
     getActiveSessions: ReturnType<typeof vi.fn>;
     killAll: ReturnType<typeof vi.fn>;
+    getPeer: ReturnType<typeof vi.fn>;
+    getApprovalService: ReturnType<typeof vi.fn>;
+    getMessageQueue: ReturnType<typeof vi.fn>;
+    buildSpawnArgs: ReturnType<typeof vi.fn>;
   };
   logger: {
     info: ReturnType<typeof vi.fn>;
@@ -159,6 +163,17 @@ function makeMockDeps(): {
     spawn: vi.fn(async (): Promise<SessionResult> => ({ exitCode: 0, durationMs: 1000 })),
     getActiveSessions: vi.fn(() => []),
     killAll: vi.fn(),
+    getPeer: vi.fn(() => undefined),
+    getApprovalService: vi.fn(() => ({
+      on: vi.fn(), emit: vi.fn(),
+      handleControlRequest: vi.fn(), handleCancelRequest: vi.fn(),
+      handleResult: vi.fn(), setCurrentStageId: vi.fn(),
+    })),
+    getMessageQueue: vi.fn(() => ({
+      queue: vi.fn(), take: vi.fn(() => undefined),
+      peek: vi.fn(() => undefined), has: vi.fn(() => false), delete: vi.fn(),
+    })),
+    buildSpawnArgs: vi.fn(() => []),
   };
 
   const loggerMock = {


### PR DESCRIPTION
## Summary

Fixes four pre-existing issues in the orchestrator introduced by Stage 10b that only manifested after installing dependencies (`npm install` had not been run). All 551 tests now pass and `tsc --noEmit` is clean.

### Issues fixed

**Type errors (`tsc --noEmit`)**
- `approval-service.ts` — Narrowed `emit()` call types to satisfy the discriminated-union event map (`question-requested` / `approval-requested`)
- `loop.ts` — Renamed `.enqueue()` → `.queue()` to match the `MessageQueue` interface (tsc caught the typo)
- `protocol-peer.ts` — Cast `msg` through `unknown` before asserting `ResultMessage` (overlapping record type)

**Test fixture gaps**
- `loop.test.ts` and `integration/insights-threshold-flow.test.ts` — Added missing `SessionExecutor` mock methods (`getPeer`, `getApprovalService`, `getMessageQueue`, `buildSpawnArgs`) that Stage 10b added to the interface but that were not reflected in the test mocks

### Verification

```
Test Files  34 passed (34)
Tests       551 passed (551)
```

## Test plan

- [x] `npm run verify` passes in `tools/orchestrator` (551/551 tests, tsc clean)
- [ ] No functional changes — all fixes are type narrowing or method renaming matching existing intent

🤖 Generated with [Claude Code](https://claude.com/claude-code)