### PR TITLE
fix(mcp-server): add .mcp.json.example + fix test to pass on fresh clone

### DIFF
--- a/.mcp.json.example
+++ b/.mcp.json.example
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "kanban": {
+      "command": "npx",
+      "args": ["tsx", "tools/mcp-server/src/index.ts"],
+      "env": {
+        "DISABLE_JIRA": "false"
+      }
+    }
+  }
+}

--- a/tools/mcp-server/tests/mcp-json.test.ts
+++ b/tools/mcp-server/tests/mcp-json.test.ts
@@ -3,12 +3,23 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 
 /**
- * Tests that .mcp.json at the project root is valid and has the expected
+ * Tests that the MCP config at the project root is valid and has the expected
  * structure for Claude Code to discover the kanban MCP server.
+ *
+ * Resolution order:
+ *   1. .mcp.json       — local config created by running scripts/install.sh (gitignored)
+ *   2. .mcp.json.example — committed template; always present in the repo
+ *
+ * A fresh clone (before running install.sh) will test .mcp.json.example.
+ * After running install.sh, .mcp.json is created and takes precedence.
  */
 describe('.mcp.json', () => {
   const projectRoot = path.resolve(import.meta.dirname, '..', '..', '..');
-  const mcpJsonPath = path.join(projectRoot, '.mcp.json');
+  const mcpJsonPath = (() => {
+    const localPath = path.join(projectRoot, '.mcp.json');
+    const examplePath = path.join(projectRoot, '.mcp.json.example');
+    return fs.existsSync(localPath) ? localPath : examplePath;
+  })();
 
   it('exists at the project root', () => {
     expect(fs.existsSync(mcpJsonPath)).toBe(true);


### PR DESCRIPTION
## Summary

- `.mcp.json` is gitignored (may contain user-specific env vars) but `mcp-json.test.ts` was hardcoded to look for `.mcp.json`, causing 4 test failures on any fresh clone
- Adds `.mcp.json.example` to the repo as the committed configuration template
- Updates the test to resolve `.mcp.json` first (created by `scripts/install.sh`), falling back to `.mcp.json.example` (always present in the repo)

## Test plan

- [x] 173/173 tests pass in `tools/mcp-server` on a fresh clone without `.mcp.json` (verified locally)
- [ ] After running `scripts/install.sh` (PR #41): `.mcp.json` is created and the test still passes
- [ ] `.mcp.json.example` has the correct command (`npx tsx tools/mcp-server/src/index.ts`) and env shape

## Follow-up

PR #41 (`scripts/install.sh`) should be updated to copy `.mcp.json.example` → `.mcp.json` during setup. Tracked in the install script PR description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)