### PR TITLE
fix(web-server): advance file offset atomically after emit in catchUpScan

### DIFF
--- a/tools/web-server/src/server/services/file-watcher.ts
+++ b/tools/web-server/src/server/services/file-watcher.ts
@@ -273,6 +273,9 @@ export class FileWatcher extends EventEmitter {
           filePath: fullPath,
           isSubagent: parsed.isSubagent,
         } satisfies FileChangeEvent);
+        // Atomically advance the offset only after a successful emit so
+        // subsequent catch-up scans do not re-emit the same byte range.
+        this.setOffset(fullPath, entryStat.size);
       }
     }
   }


### PR DESCRIPTION
## Summary

`setOffset()` was never called in the `catchUpScan` code path. The file offset remained at 0 after every scan, so on the next scan cycle the **same byte range was re-emitted** — causing duplicate `file-change` events and redundant session re-parses on every scan interval.

**Fix:** advance the offset to `entryStat.size` immediately after the `file-change` event is successfully emitted. The offset only advances when new bytes actually exist (`entryStat.size > currentOffset`), and only after the emit succeeds — making the advance atomic with the decision to emit.

This fixes the SSE over-emission issue noted in the Stage 9 handoff ("SSE lag... worth investigating if it feels excessive").

## Root cause from analysis

From `llm/stage9-session-display-analysis.md` (Gap #5):
> `setOffset()` and parsing are separate operations. If parse fails but offset was already updated, next parse starts mid-stream.

The actual finding was stronger: the offset was **never** being updated in this path, not just "updated too early."

## Test plan

- [x] 840/840 tests pass in `tools/web-server`
- [x] `tsc --noEmit` clean
- [ ] Manual: verify session page no longer shows redundant reloads on idle sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)