### PR TITLE
fix(chunk-builder): keep messages with tool_result blocks in ai buffer

### DIFF
--- a/tools/web-server/src/server/services/chunk-builder.ts
+++ b/tools/web-server/src/server/services/chunk-builder.ts
@@ -119,6 +119,11 @@ export function classifyMessage(msg: ParsedMessage): MessageCategory {
         return 'ai';
       }
 
+      const hasToolResult = blocks.some((block) => block.type === 'tool_result');
+      if (hasToolResult) {
+        // Any message containing tool_result blocks belongs in the AI buffer
+        return 'ai';
+      }
       const hasUserContent = blocks.some(
         (block) => block.type === 'text' || block.type === 'image',
       );

--- a/tools/web-server/tests/server/services/chunk-builder.test.ts
+++ b/tools/web-server/tests/server/services/chunk-builder.test.ts
@@ -230,7 +230,7 @@ describe('ChunkBuilder', () => {
       expect(classifyMessage(msg)).toBe('user');
     });
 
-    it('classifies non-isMeta user message with both text and tool_result blocks as "user"', () => {
+    it('classifies non-isMeta user message with both text and tool_result blocks as "ai"', () => {
       const msg = {
         type: 'user',
         isMeta: false,
@@ -241,7 +241,7 @@ describe('ChunkBuilder', () => {
         toolCalls: [],
         toolResults: [],
       } as unknown as ParsedMessage;
-      expect(classifyMessage(msg)).toBe('user');
+      expect(classifyMessage(msg)).toBe('ai');
     });
   });
 


### PR DESCRIPTION
Fix Gap #8: messages with both text content and tool_result blocks were being classified as user, causing tool results to render out of order. Now any message containing tool_result blocks stays in the ai buffer.