### PR TITLE
feat(mcp-server): add DISABLE_SLACK guard for test mode

### DIFF
--- a/tools/mcp-server/src/tools/slack.ts
+++ b/tools/mcp-server/src/tools/slack.ts
@@ -56,6 +56,12 @@ export async function handleSlackNotify(
     return successResult('Slack notification skipped: mock mode but no state available');
   }
 
+  // DISABLE_SLACK guard: skip real HTTP call in test environments
+  if (process.env.DISABLE_SLACK === 'true') {
+    console.warn('[slack] DISABLE_SLACK=true: skipping real Slack webhook call');
+    return successResult('Slack notification skipped: DISABLE_SLACK is set');
+  }
+
   // Real mode: resolve webhook URL (per-repo override > global default)
   const resolvedWebhookUrl = args.webhook_url || deps.webhookUrl;
   if (!resolvedWebhookUrl) {

--- a/tools/mcp-server/tests/slack.test.ts
+++ b/tools/mcp-server/tests/slack.test.ts
@@ -390,6 +390,39 @@ describe('Slack tools', () => {
     });
   });
 
+  describe('handleSlackNotify — DISABLE_SLACK guard', () => {
+    let mockFetch: ReturnType<typeof vi.fn>;
+    let savedDisableSlack: string | undefined;
+
+    beforeEach(() => {
+      delete process.env.KANBAN_MOCK;
+      savedDisableSlack = process.env.DISABLE_SLACK;
+      process.env.DISABLE_SLACK = 'true';
+      mockFetch = vi.fn();
+    });
+
+    afterEach(() => {
+      if (savedDisableSlack === undefined) {
+        delete process.env.DISABLE_SLACK;
+      } else {
+        process.env.DISABLE_SLACK = savedDisableSlack;
+      }
+    });
+
+    it('returns success without making an HTTP call when DISABLE_SLACK=true', async () => {
+      const deps: SlackToolDeps = {
+        mockState: null,
+        webhookUrl: 'https://hooks.slack.com/services/T000/B000/xxx',
+        fetch: mockFetch as unknown as typeof globalThis.fetch,
+      };
+      const result = await handleSlackNotify({ message: 'test' }, deps);
+      expect(mockFetch).not.toHaveBeenCalled();
+      expect(result.isError).toBeUndefined();
+      const data = parseResult(result);
+      expect(data).toContain('DISABLE_SLACK');
+    });
+  });
+
   describe('registerSlackTools', () => {
     it('registers 1 tool on the server without error', () => {
       const server = new McpServer({ name: 'test-server', version: '0.0.1' });


### PR DESCRIPTION
Closes #9

Adds `DISABLE_SLACK=true` environment variable guard to skip real Slack webhook calls in test mode, following the same pattern as `DISABLE_JIRA`. Includes a test that verifies the guard prevents real HTTP calls when enabled.