### PR TITLE
fix: prevent subagent from linking to multiple chunks (Gap #3)

### DIFF
--- a/tools/web-server/src/server/services/session-pipeline.ts
+++ b/tools/web-server/src/server/services/session-pipeline.ts
@@ -134,6 +134,7 @@ function linkSubagentsToChunks(chunks: Chunk[], subagents: Process[]): void {
   if (subagents.length === 0) return;
 
   const linkedSubagentIds = new Set<string>();
+  const orphanedSubagents: Process[] = [];
 
   for (const chunk of chunks) {
     if (chunk.type !== 'ai') continue;
@@ -155,6 +156,10 @@ function linkSubagentsToChunks(chunks: Chunk[], subagents: Process[]): void {
 
     // Primary linking: match by parentTaskId
     for (const subagent of subagents) {
+      if (linkedSubagentIds.has(subagent.id)) {
+        orphanedSubagents.push(subagent);
+        continue;
+      }
       if (subagent.parentTaskId && chunkTaskIds.has(subagent.parentTaskId)) {
         enhanced.subagents.push(subagent);
         linkedSubagentIds.add(subagent.id);


### PR DESCRIPTION
## Summary

- Adds a `linkedSubagentIds.has(subagent.id)` guard at the top of the primary linking loop in `linkSubagentsToChunks` so a subagent that has already been linked to a chunk is skipped on subsequent chunk iterations.
- Adds an `orphanedSubagents: Process[]` array (defined before the loop) that collects subagents skipped by the guard, providing a diagnostic handle for future logging or inspection.

## Changes

- `tools/web-server/src/server/services/session-pipeline.ts`: 5 lines added in `linkSubagentsToChunks` (lines 137, 159–162).

## Test plan

- [x] `npm run lint` passes (tsc --noEmit, zero errors)
- [x] `npm run test` passes (842 tests, 69 test files)
- [ ] Manual verification: confirm a subagent with a parentTaskId matching two chunks only appears once in the first matching chunk's `subagents` array

🤖 Generated with [Claude Code](https://claude.com/claude-code)