### PR TITLE
fix: remove timing-based subagent positional fallback (Gap #2)

### DIFF
--- a/tools/web-server/src/server/services/subagent-resolver.ts
+++ b/tools/web-server/src/server/services/subagent-resolver.ts
@@ -116,34 +116,14 @@ export async function resolveSubagents(
     }
   }
 
-  // Phase C: Positional fallback -- match remaining by chronological order.
-  // TODO: This timing-based fallback is risky — it can produce incorrect links when
-  // multiple unmatched subagents exist, because positional order is not a reliable
-  // proxy for task identity. Replace with structural matching (e.g. subagent init
-  // message containing the task call ID) once that data is available in JSONL.
+  // Phase C: Emit warnings for any subagents that could not be matched.
+  // The timing-based positional fallback was removed because it silently picked
+  // the wrong subagent when two processes started within the same timing window.
   const stillUnmatchedAgents = agents.filter((a) => !matchedAgentIds.has(a.agentId));
-  const stillUnmatchedTasks = unmatchedTasks.filter((t) => !matchedTaskIds.has(t.callId));
-
-  // Sort both by timestamp
-  stillUnmatchedAgents.sort((a, b) => {
-    const aTime = a.messages[0]?.timestamp?.getTime() ?? 0;
-    const bTime = b.messages[0]?.timestamp?.getTime() ?? 0;
-    return aTime - bTime;
-  });
-  stillUnmatchedTasks.sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
-
-  for (let i = 0; i < stillUnmatchedAgents.length; i++) {
-    const agent = stillUnmatchedAgents[i];
-    // Guard: skip agents that were already linked in a previous phase to prevent
-    // duplicate Process entries in the output array.
-    if (matchedAgentIds.has(agent.agentId)) continue;
-    const task = stillUnmatchedTasks[i]; // May be undefined if more agents than tasks
-    processes.push(
-      buildProcess(agent, {
-        parentTaskId: task?.callId,
-        description: task?.description,
-        subagentType: task?.subagentType,
-      }),
+  for (const agent of stillUnmatchedAgents) {
+    console.warn(
+      `[subagent-resolver] Could not resolve subagent ${agent.agentId} to any task call. ` +
+        `It will be omitted from the process list.`,
     );
   }
 

--- a/tools/web-server/tests/server/services/session-integration.test.ts
+++ b/tools/web-server/tests/server/services/session-integration.test.ts
@@ -222,12 +222,9 @@ describe('Session Integration', () => {
     expect(session.metrics.duration).toBe(15_000);
     expect(session.metrics.totalCost).toBeGreaterThanOrEqual(0);
 
-    // Subagents: agent-sub1.jsonl should be discovered (legacy structure)
-    expect(session.subagents.length).toBe(1);
-    expect(session.subagents[0].id).toBe('sub1');
-    expect(session.subagents[0].metrics.inputTokens).toBe(50);
-    expect(session.subagents[0].metrics.outputTokens).toBe(25);
-    expect(session.subagents[0].durationMs).toBe(2_000);
+    // Subagents: agent-sub1.jsonl is discovered but cannot be matched to a Task call
+    // in the parent session (no toolUseResult or description link), so it is omitted.
+    expect(session.subagents.length).toBe(0);
 
     // Last message is assistant → not ongoing
     expect(session.isOngoing).toBe(false);
@@ -304,8 +301,8 @@ describe('Session Integration', () => {
       expect(body.metrics.toolCallCount).toBe(1);
       expect(body.metrics.duration).toBe(15_000);
 
-      expect(body.subagents.length).toBe(1);
-      expect(body.subagents[0].id).toBe('sub1');
+      // sub1 has no Task call link in parent — omitted by resolver
+      expect(body.subagents.length).toBe(0);
       expect(body.isOngoing).toBe(false);
     });
 
@@ -333,19 +330,15 @@ describe('Session Integration', () => {
       expect(body.turnCount).toBe(2);
     });
 
-    it('GET .../subagents/sub1 returns the resolved subagent', async () => {
+    it('GET .../subagents/sub1 returns 404 (sub1 has no Task call link in parent)', async () => {
       const response = await app.inject({
         method: 'GET',
         url: `/api/sessions/test-project/${sessionId}/subagents/sub1`,
       });
 
-      expect(response.statusCode).toBe(200);
+      expect(response.statusCode).toBe(404);
       const body = response.json();
-
-      expect(body.id).toBe('sub1');
-      expect(body.metrics.inputTokens).toBe(50);
-      expect(body.metrics.outputTokens).toBe(25);
-      expect(body.durationMs).toBe(2_000);
+      expect(body.error).toBe('Subagent not found');
     });
 
     it('GET .../subagents/nonexistent returns 404', async () => {

--- a/tools/web-server/tests/server/services/subagent-resolver.test.ts
+++ b/tools/web-server/tests/server/services/subagent-resolver.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import { mkdtempSync, mkdirSync, writeFileSync, cpSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
@@ -158,7 +158,7 @@ describe('SubagentResolver', () => {
       expect(result[0].description).toBe('Search files');
     });
 
-    it('uses positional fallback for unmatched agents', async () => {
+    it('omits unmatched agents and emits a warning', async () => {
       const tmpDir = createTempProject();
       const subagentDir = join(tmpDir, 'test-session', 'subagents');
       mkdirSync(subagentDir, { recursive: true });
@@ -167,7 +167,7 @@ describe('SubagentResolver', () => {
         join(subagentDir, 'agent-abc123.jsonl'),
       );
 
-      // Parent has a task call but NO toolUseResult linking
+      // Parent has a task call but NO toolUseResult linking and no description match
       const parentMessages: ParsedMessage[] = [
         {
           uuid: 'a1',
@@ -190,12 +190,16 @@ describe('SubagentResolver', () => {
         },
       ] as ParsedMessage[];
 
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       const result = await resolveSubagents(parentMessages, {
         projectDir: tmpDir,
         sessionId: 'test-session',
       });
-      expect(result).toHaveLength(1);
-      expect(result[0].parentTaskId).toBe('toolu_unlinked');
+      expect(result).toHaveLength(0);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Could not resolve subagent abc123'),
+      );
+      warnSpy.mockRestore();
     });
 
     it('detects parallel subagents (start times within 100ms)', async () => {
@@ -385,7 +389,43 @@ describe('SubagentResolver', () => {
         .concat('\n');
       writeFileSync(join(subagentDir, 'agent-ongoing1.jsonl'), ongoingAgent);
 
-      const result = await resolveSubagents([], {
+      // Provide a parent message with a result-based link so ongoing1 is matched via Phase A
+      const parentMessages: ParsedMessage[] = [
+        {
+          uuid: 'p1',
+          parentUuid: null,
+          type: 'assistant',
+          timestamp: new Date('2026-02-25T09:59:59Z'),
+          isSidechain: false,
+          isMeta: false,
+          content: [],
+          toolCalls: [
+            {
+              id: 'toolu_ongoing_task',
+              name: 'Task',
+              input: { description: 'Read file' },
+              isTask: true,
+              taskDescription: 'Read file',
+            },
+          ],
+          toolResults: [],
+        },
+        {
+          uuid: 'p2',
+          parentUuid: 'p1',
+          type: 'tool',
+          timestamp: new Date('2026-02-25T10:00:02Z'),
+          isSidechain: false,
+          isMeta: false,
+          content: '',
+          toolCalls: [],
+          toolResults: [],
+          sourceToolUseID: 'toolu_ongoing_task',
+          toolUseResult: { agentId: 'ongoing1' },
+        },
+      ] as unknown as ParsedMessage[];
+
+      const result = await resolveSubagents(parentMessages, {
         projectDir: tmpDir,
         sessionId: 'test-session',
       });


### PR DESCRIPTION
Removes the timing-based positional fallback in subagent-resolver.ts that could silently match the wrong subagent when two processes start within 100ms of each other. Replaced with a console.warn for diagnostic visibility.

## Changes
- `tools/web-server/src/server/services/subagent-resolver.ts` lines 119-148: removed Phase C positional fallback (sort-by-timestamp + index-aligned zip); replaced with a `console.warn` loop over unmatched agents
- `tools/web-server/tests/server/services/subagent-resolver.test.ts`: renamed "uses positional fallback" test to "omits unmatched agents and emits a warning"; asserts empty result and spy on `console.warn`; fixed "detects ongoing subagent" to supply a result-based parent link so Phase A matching covers `isOngoing`
- `tools/web-server/tests/server/services/session-integration.test.ts`: updated three assertions that expected `subagents.length === 1` for `sub1` (which has no Task call link in the parent) to expect `0`; updated `GET .../subagents/sub1` test to expect 404

## Test plan
- [x] npm run lint passes
- [x] npm run test passes (840 tests)