### PR TITLE
fix: guard against undefined chunk timestamp in session-pipeline (Gap #6)

### DIFF
--- a/tools/web-server/src/server/services/session-pipeline.ts
+++ b/tools/web-server/src/server/services/session-pipeline.ts
@@ -172,7 +172,13 @@ function linkSubagentsToChunks(chunks: Chunk[], subagents: Process[]): void {
 
       const startTime = chunk.messages[0]?.timestamp;
       const endTime = chunk.messages[chunk.messages.length - 1]?.timestamp;
-      if (!startTime || !endTime) continue;
+      if (!startTime || !endTime) {
+        console.warn(
+          '[session-pipeline] chunk missing timestamp — skipping timing-based subagent link for chunk',
+          { chunkType: chunk.type, messageCount: chunk.messages.length },
+        );
+        continue;
+      }
 
       if (subagent.startTime >= startTime && subagent.startTime <= endTime) {
         const enhanced = chunk as EnhancedAIChunk;


### PR DESCRIPTION
Prevents silent subagent tree loss when chunk.messages[0].timestamp is undefined. Emits a diagnostic warning rather than silently skipping.

## Changes
- session-pipeline.ts lines ~173-179: timestamp guard with console.warn

## Test plan
- [ ] npm run lint passes
- [ ] npm run test passes