### PR TITLE
feat: Slack integration test setup (Issue #9)

### DIFF
--- a/scripts/test-setup/slack-setup.md
+++ b/scripts/test-setup/slack-setup.md
@@ -1,0 +1,116 @@
+# Slack Integration Setup
+
+This guide explains how to configure Slack notifications for the claude-code-workflow MCP server
+and how to verify the integration using the verification script.
+
+## Required Environment Variables
+
+| Variable               | Required | Description                                                                 |
+| ---------------------- | -------- | --------------------------------------------------------------------------- |
+| `WORKFLOW_SLACK_WEBHOOK` | Yes    | Incoming webhook URL for posting workflow notifications                     |
+| `SLACK_BOT_TOKEN`      | Optional | Bot token (`xoxb-...`) — enables message delivery verification              |
+| `SLACK_CHANNEL_ID`     | Optional | Channel ID (e.g. `C0123456789`) — used alongside `SLACK_BOT_TOKEN`         |
+
+`SLACK_BOT_TOKEN` and `SLACK_CHANNEL_ID` are only needed if you want the verification script to
+confirm that the message actually arrived in the channel. The webhook alone is sufficient for
+normal operation.
+
+## Creating a Slack App and Incoming Webhook
+
+1. Go to [https://api.slack.com/apps](https://api.slack.com/apps) and click **Create New App**.
+2. Choose **From scratch**, give it a name (e.g. `Claude Workflow`), and select your workspace.
+3. In the left sidebar, click **Incoming Webhooks** and toggle **Activate Incoming Webhooks** on.
+4. Click **Add New Webhook to Workspace**.
+5. Select the target channel (see naming convention below) and click **Allow**.
+6. Copy the generated webhook URL — it starts with `https://hooks.slack.com/services/...`.
+7. Set `WORKFLOW_SLACK_WEBHOOK` to that URL in your environment (`.env`, shell profile, or CI secrets).
+
+## Test Channel Naming Convention
+
+Use `#claude-workflow-test` as the dedicated test channel. This keeps automated integration
+test messages separate from production workflow notifications.
+
+Create the channel in Slack before configuring the webhook so you can select it in step 4 above.
+
+## Adding Optional Bot Token (for delivery verification)
+
+If you want the verification script to confirm message delivery:
+
+1. In your Slack app settings, click **OAuth & Permissions** in the left sidebar.
+2. Under **Bot Token Scopes**, add:
+   - `channels:history` (for public channels)
+   - `groups:history` (for private channels)
+   - `chat:write` (optional, not required for verification)
+3. Click **Install to Workspace** (or **Reinstall** if already installed).
+4. Copy the **Bot User OAuth Token** (`xoxb-...`).
+5. Find your channel ID: right-click the channel in Slack → **View channel details** → copy the
+   ID at the bottom (format: `C0123456789`).
+6. Set `SLACK_BOT_TOKEN` and `SLACK_CHANNEL_ID` in your environment.
+7. Invite the bot to the channel: `/invite @<your-app-name>` in the channel.
+
+## Running the Verification Script
+
+Webhook-only (confirms Slack accepts the message):
+
+```bash
+WORKFLOW_SLACK_WEBHOOK=https://hooks.slack.com/services/... \
+  npx ts-node scripts/test-setup/slack-verify.ts
+```
+
+With delivery verification (confirms the message appeared in the channel):
+
+```bash
+WORKFLOW_SLACK_WEBHOOK=https://hooks.slack.com/services/... \
+SLACK_BOT_TOKEN=xoxb-... \
+SLACK_CHANNEL_ID=C0123456789 \
+  npx ts-node scripts/test-setup/slack-verify.ts
+```
+
+A successful run exits with code `0` and prints:
+
+```
+Slack integration verification
+==============================
+Webhook URL : https://hooks.slack.com/services/...
+Marker      : 2024-01-15T12:34:56.789Z
+
+Step 1: Posting test message via webhook...
+  Webhook accepted the message (HTTP 200, body "ok").
+
+Step 2: Verifying message delivery via conversations.history...
+  Waiting 3000ms before checking message history...
+  Message confirmed in channel history.
+
+Verification complete. Slack integration is working.
+```
+
+## Troubleshooting
+
+**Message not appearing in Slack**
+
+- Verify `WORKFLOW_SLACK_WEBHOOK` is the correct URL and has not been revoked.
+- Check the Slack app is still installed to the workspace (**App Settings → Install App**).
+- Confirm the webhook is pointing to the right channel.
+
+**HTTP 403 / 404 from webhook**
+
+- The webhook URL was deleted or the app was uninstalled. Regenerate it in the app settings.
+
+**`conversations.history` returns `channel_not_found`**
+
+- `SLACK_CHANNEL_ID` is wrong, or the bot has not been invited to the channel.
+- Run `/invite @<your-app-name>` inside the target channel.
+
+**`conversations.history` returns `missing_scope`**
+
+- The bot token is missing `channels:history` (public) or `groups:history` (private) scope.
+- Add the scope under **OAuth & Permissions** and reinstall the app.
+
+**Test message found in wrong channel**
+
+- The webhook and `SLACK_CHANNEL_ID` point to different channels. Update one to match the other.
+
+**`DISABLE_SLACK=true` in environment**
+
+- The MCP server skips real webhook calls when this variable is set. Unset it before running the
+  verification script.

--- a/scripts/test-setup/slack-verify.ts
+++ b/scripts/test-setup/slack-verify.ts
@@ -1,0 +1,179 @@
+#!/usr/bin/env ts-node
+/**
+ * Slack integration verification script.
+ *
+ * Usage:
+ *   WORKFLOW_SLACK_WEBHOOK=https://hooks.slack.com/... npx ts-node scripts/test-setup/slack-verify.ts
+ *
+ * Optional (message delivery verification via conversations.history):
+ *   SLACK_BOT_TOKEN=xoxb-... SLACK_CHANNEL_ID=C... npx ts-node scripts/test-setup/slack-verify.ts
+ */
+
+const MARKER_PREFIX = '[claude-workflow-test]';
+const TIMEOUT_MS = 10_000;
+const POLL_DELAY_MS = 3_000; // wait before checking history
+
+function abortSignal(): AbortSignal {
+  return AbortSignal.timeout(TIMEOUT_MS);
+}
+
+async function postTestMessage(webhookUrl: string, marker: string): Promise<void> {
+  const payload = {
+    text: `${MARKER_PREFIX} Integration test ping - ${marker}`,
+    blocks: [
+      {
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: `*${MARKER_PREFIX} Integration test ping*\n\nTimestamp: \`${marker}\`\n_This message was sent by the claude-code-workflow verification script. Safe to ignore._`,
+        },
+      },
+    ],
+  };
+
+  const response = await fetch(webhookUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+    signal: abortSignal(),
+  });
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => '(no body)');
+    throw new Error(`Webhook POST failed: HTTP ${response.status} — ${body}`);
+  }
+
+  // Slack webhook returns plain "ok" on success
+  const body = await response.text();
+  if (body.trim() !== 'ok') {
+    throw new Error(`Unexpected webhook response: ${body}`);
+  }
+}
+
+interface SlackMessage {
+  text: string;
+  ts: string;
+}
+
+interface ConversationsHistoryResponse {
+  ok: boolean;
+  messages?: SlackMessage[];
+  error?: string;
+}
+
+async function verifyMessageArrived(
+  botToken: string,
+  channelId: string,
+  marker: string,
+): Promise<void> {
+  console.log(`  Waiting ${POLL_DELAY_MS}ms before checking message history...`);
+  await new Promise((resolve) => setTimeout(resolve, POLL_DELAY_MS));
+
+  const url = new URL('https://slack.com/api/conversations.history');
+  url.searchParams.set('channel', channelId);
+  url.searchParams.set('limit', '20');
+
+  const response = await fetch(url.toString(), {
+    headers: { Authorization: `Bearer ${botToken}` },
+    signal: abortSignal(),
+  });
+
+  if (!response.ok) {
+    throw new Error(`conversations.history request failed: HTTP ${response.status}`);
+  }
+
+  const data: ConversationsHistoryResponse = (await response.json()) as ConversationsHistoryResponse;
+
+  if (!data.ok) {
+    throw new Error(`conversations.history API error: ${data.error ?? 'unknown'}`);
+  }
+
+  const messages = data.messages ?? [];
+  const found = messages.some((m) => m.text?.includes(marker));
+
+  if (!found) {
+    throw new Error(
+      `Test message with marker "${marker}" not found in the last ${messages.length} messages.\n` +
+        'The webhook POST succeeded but the message may not have reached the expected channel,\n' +
+        'or SLACK_CHANNEL_ID points to a different channel than the webhook target.',
+    );
+  }
+
+  console.log('  Message confirmed in channel history.');
+}
+
+async function main(): Promise<void> {
+  const webhookUrl = process.env.WORKFLOW_SLACK_WEBHOOK;
+  const botToken = process.env.SLACK_BOT_TOKEN;
+  const channelId = process.env.SLACK_CHANNEL_ID;
+
+  if (!webhookUrl) {
+    console.error('ERROR: WORKFLOW_SLACK_WEBHOOK environment variable is not set.');
+    console.error('');
+    console.error('Usage:');
+    console.error('  WORKFLOW_SLACK_WEBHOOK=https://hooks.slack.com/... npx ts-node scripts/test-setup/slack-verify.ts');
+    process.exit(1);
+  }
+
+  if (!webhookUrl.startsWith('https://')) {
+    console.error('ERROR: WORKFLOW_SLACK_WEBHOOK must be an https:// URL.');
+    process.exit(1);
+  }
+
+  const timestamp = new Date().toISOString();
+  const marker = timestamp;
+
+  console.log('Slack integration verification');
+  console.log('==============================');
+  console.log(`Webhook URL : ${webhookUrl.substring(0, 50)}...`);
+  console.log(`Marker      : ${marker}`);
+  console.log('');
+
+  // Step 1: Post test message via webhook
+  console.log('Step 1: Posting test message via webhook...');
+  try {
+    await postTestMessage(webhookUrl, marker);
+    console.log('  Webhook accepted the message (HTTP 200, body "ok").');
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`  FAILED: ${message}`);
+    console.error('');
+    console.error('Troubleshooting:');
+    console.error('  - Verify the webhook URL is still active in your Slack app settings.');
+    console.error('  - Ensure the Slack app is still installed to the workspace.');
+    process.exit(1);
+  }
+
+  // Step 2 (optional): Verify via conversations.history
+  if (botToken && channelId) {
+    console.log('');
+    console.log('Step 2: Verifying message delivery via conversations.history...');
+    console.log(`  Channel ID  : ${channelId}`);
+    try {
+      await verifyMessageArrived(botToken, channelId, marker);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(`  FAILED: ${message}`);
+      console.error('');
+      console.error('Troubleshooting:');
+      console.error('  - Confirm SLACK_CHANNEL_ID matches the channel the webhook posts to.');
+      console.error('  - Ensure the bot token has the channels:history (or groups:history) scope.');
+      console.error('  - Check that the bot is a member of the channel.');
+      process.exit(1);
+    }
+  } else {
+    console.log('');
+    console.log('Step 2: Skipped (SLACK_BOT_TOKEN and/or SLACK_CHANNEL_ID not set).');
+    console.log('  Set both to enable message delivery verification.');
+  }
+
+  console.log('');
+  console.log('Verification complete. Slack integration is working.');
+  process.exit(0);
+}
+
+main().catch((err: unknown) => {
+  const message = err instanceof Error ? err.message : String(err);
+  console.error(`Unexpected error: ${message}`);
+  process.exit(1);
+});


### PR DESCRIPTION
Closes #9

Adds Slack test verification script and setup documentation.

## Deliverables
- scripts/test-setup/slack-verify.ts — posts and optionally verifies test message via conversations.history
- scripts/test-setup/slack-setup.md — Slack app setup guide

## Usage
WORKFLOW_SLACK_WEBHOOK=https://... npx ts-node scripts/test-setup/slack-verify.ts