### PR TITLE
feat: Jira integration test setup (Issue #5)

### DIFF
--- a/scripts/test-setup/README.md
+++ b/scripts/test-setup/README.md
@@ -1,0 +1,48 @@
+# Jira Integration Test Setup
+
+Scripts for seeding and tearing down Jira test data used in integration tests.
+
+## Required Environment Variables
+
+| Variable        | Description                                      | Example                              |
+| --------------- | ------------------------------------------------ | ------------------------------------ |
+| `JIRA_BASE_URL` | Your Atlassian instance base URL                 | `https://yourorg.atlassian.net`      |
+| `JIRA_EMAIL`    | Atlassian account email                          | `you@example.com`                    |
+| `JIRA_TOKEN`    | [Atlassian API token](https://id.atlassian.com/manage-profile/security/api-tokens) | `ATATTxxx...` |
+| `JIRA_PROJECT`  | Jira project key to create issues in             | `TEST`                               |
+
+### Optional
+
+| Variable               | Description                                               |
+| ---------------------- | --------------------------------------------------------- |
+| `JIRA_CONFLUENCE_URL`  | A Confluence page URL to attach as a remote link to the seeded epic |
+
+## Seed
+
+Creates one Epic with label `kanban-test`, three child tickets (To Do / In Progress / Done), and a comment on the first ticket.
+
+```bash
+npx ts-node scripts/test-setup/jira-seed.ts
+```
+
+Issue keys are printed to stdout and written to `.jira-seed-state.json` in the current directory.
+
+## Teardown
+
+Deletes all seeded issues. Reads keys from `.jira-seed-state.json` by default, or accepts keys as CLI arguments.
+
+```bash
+# Using state file written by seed script
+npx ts-node scripts/test-setup/jira-teardown.ts
+
+# Passing keys explicitly
+npx ts-node scripts/test-setup/jira-teardown.ts PROJ-123 PROJ-124 PROJ-125
+```
+
+The state file (`.jira-seed-state.json`) is deleted after a successful teardown.
+
+## Notes
+
+- Both scripts use Basic Auth (`JIRA_EMAIL:JIRA_TOKEN` base64-encoded) against the Jira REST API v3.
+- Deleting issues requires the "Delete Issues" project permission in Jira. If you see HTTP 403 errors during teardown, check your API token's permissions.
+- Status transitions depend on your project's workflow. If a target status is unavailable, a warning is logged and the script continues.

--- a/scripts/test-setup/jira-seed.ts
+++ b/scripts/test-setup/jira-seed.ts
@@ -1,0 +1,376 @@
+#!/usr/bin/env npx tsx
+
+/**
+ * jira-seed.ts — Create test Jira tickets for integration testing.
+ *
+ * Creates:
+ *   - 1 Epic with the label "kanban-test"
+ *   - 3 child tickets in various statuses (To Do, In Progress, Done)
+ *   - 1 comment on the first child ticket
+ *   - 1 remote Confluence link on the epic (if JIRA_CONFLUENCE_URL is set)
+ *
+ * Outputs created issue keys to stdout and writes them to .jira-seed-state.json
+ * in the current working directory for use by jira-teardown.ts.
+ *
+ * Required env vars:
+ *   JIRA_BASE_URL  — e.g. https://yourorg.atlassian.net
+ *   JIRA_EMAIL     — Atlassian account email
+ *   JIRA_TOKEN     — Atlassian API token
+ *   JIRA_PROJECT   — Jira project key, e.g. TEST
+ *
+ * Optional env vars:
+ *   JIRA_CONFLUENCE_URL — A Confluence page URL to attach as a remote link to the epic
+ *
+ * Usage:
+ *   npx ts-node scripts/test-setup/jira-seed.ts
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+// ─── Credentials ─────────────────────────────────────────────────────────────
+
+interface JiraCredentials {
+  baseUrl: string;
+  email: string;
+  token: string;
+  project: string;
+}
+
+function getCredentials(): JiraCredentials {
+  const baseUrl = process.env.JIRA_BASE_URL;
+  const email = process.env.JIRA_EMAIL;
+  const token = process.env.JIRA_TOKEN;
+  const project = process.env.JIRA_PROJECT;
+
+  const missing: string[] = [];
+  if (!baseUrl) missing.push('JIRA_BASE_URL');
+  if (!email) missing.push('JIRA_EMAIL');
+  if (!token) missing.push('JIRA_TOKEN');
+  if (!project) missing.push('JIRA_PROJECT');
+
+  if (missing.length > 0) {
+    console.error(`Missing required environment variables: ${missing.join(', ')}`);
+    process.exit(1);
+  }
+
+  return { baseUrl: baseUrl!, email: email!, token: token!, project: project! };
+}
+
+// ─── HTTP helper ─────────────────────────────────────────────────────────────
+
+function encodeAuth(email: string, token: string): string {
+  return Buffer.from(`${email}:${token}`).toString('base64');
+}
+
+async function jiraFetch(
+  creds: JiraCredentials,
+  method: string,
+  apiPath: string,
+  body?: unknown,
+): Promise<{ status: number; data: any }> {
+  const url = `${creds.baseUrl}${apiPath}`;
+  const headers: Record<string, string> = {
+    Authorization: `Basic ${encodeAuth(creds.email, creds.token)}`,
+    Accept: 'application/json',
+  };
+  if (body !== undefined) {
+    headers['Content-Type'] = 'application/json';
+  }
+
+  const response = await fetch(url, {
+    method,
+    headers,
+    ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+  });
+
+  const status = response.status;
+
+  if (status === 204) {
+    return { status, data: undefined };
+  }
+
+  const text = await response.text();
+  let data: any;
+  try {
+    data = JSON.parse(text);
+  } catch {
+    data = text;
+  }
+
+  return { status, data };
+}
+
+// ─── Jira API helpers ─────────────────────────────────────────────────────────
+
+/**
+ * Resolve the issue type ID for "Epic" in the given project.
+ * Falls back to using the name string directly if the metadata endpoint fails.
+ */
+async function resolveEpicIssueTypeId(creds: JiraCredentials): Promise<string> {
+  const result = await jiraFetch(
+    creds,
+    'GET',
+    `/rest/api/3/issue/createmeta?projectKeys=${encodeURIComponent(creds.project)}&expand=projects.issuetypes`,
+  );
+
+  if (result.status === 200) {
+    const projects: any[] = result.data?.projects ?? [];
+    for (const proj of projects) {
+      const types: any[] = proj.issuetypes ?? [];
+      const epic = types.find((t: any) => t.name === 'Epic');
+      if (epic) {
+        return epic.id as string;
+      }
+    }
+  }
+
+  // Fall back: return the name; Jira accepts name in issuetype.name field
+  return 'Epic';
+}
+
+/**
+ * Create a Jira issue. Returns the created issue key.
+ */
+async function createIssue(
+  creds: JiraCredentials,
+  fields: Record<string, unknown>,
+): Promise<string> {
+  const result = await jiraFetch(creds, 'POST', '/rest/api/3/issue', { fields });
+
+  if (result.status < 200 || result.status >= 300) {
+    const detail = typeof result.data === 'object'
+      ? JSON.stringify(result.data)
+      : String(result.data);
+    throw new Error(`Failed to create issue (HTTP ${result.status}): ${detail}`);
+  }
+
+  return result.data.key as string;
+}
+
+/**
+ * Transition a ticket to a target status by name (case-insensitive).
+ */
+async function transitionIssue(
+  creds: JiraCredentials,
+  key: string,
+  targetStatus: string,
+): Promise<void> {
+  const transitionsResult = await jiraFetch(
+    creds,
+    'GET',
+    `/rest/api/3/issue/${encodeURIComponent(key)}/transitions`,
+  );
+
+  if (transitionsResult.status < 200 || transitionsResult.status >= 300) {
+    throw new Error(`Failed to get transitions for ${key}: HTTP ${transitionsResult.status}`);
+  }
+
+  const transitions: Array<{ id: string; name: string }> =
+    transitionsResult.data?.transitions ?? [];
+  const targetLower = targetStatus.toLowerCase();
+  const match = transitions.find((t) => t.name.toLowerCase() === targetLower);
+
+  if (!match) {
+    const available = transitions.map((t) => t.name).join(', ');
+    // Non-fatal: log warning and continue — test environments vary in available transitions
+    console.warn(
+      `  [warn] No transition to "${targetStatus}" available for ${key}. Available: ${available || 'none'}`,
+    );
+    return;
+  }
+
+  const doTransition = await jiraFetch(
+    creds,
+    'POST',
+    `/rest/api/3/issue/${encodeURIComponent(key)}/transitions`,
+    { transition: { id: match.id } },
+  );
+
+  if (doTransition.status < 200 || doTransition.status >= 300) {
+    throw new Error(
+      `Failed to transition ${key} to "${targetStatus}": HTTP ${doTransition.status}`,
+    );
+  }
+}
+
+/**
+ * Add a plain-text comment to a Jira issue using ADF format.
+ */
+async function addComment(
+  creds: JiraCredentials,
+  key: string,
+  commentText: string,
+): Promise<string> {
+  const body = {
+    body: {
+      version: 1,
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [{ type: 'text', text: commentText }],
+        },
+      ],
+    },
+  };
+
+  const result = await jiraFetch(
+    creds,
+    'POST',
+    `/rest/api/3/issue/${encodeURIComponent(key)}/comment`,
+    body,
+  );
+
+  if (result.status < 200 || result.status >= 300) {
+    throw new Error(`Failed to add comment to ${key}: HTTP ${result.status}`);
+  }
+
+  return result.data.id as string;
+}
+
+/**
+ * Add a remote (Confluence) link to a Jira issue.
+ */
+async function addRemoteLink(
+  creds: JiraCredentials,
+  key: string,
+  url: string,
+  title: string,
+): Promise<void> {
+  const body = {
+    object: { url, title, icon: { url16x16: '', title } },
+  };
+
+  const result = await jiraFetch(
+    creds,
+    'POST',
+    `/rest/api/3/issue/${encodeURIComponent(key)}/remotelink`,
+    body,
+  );
+
+  if (result.status < 200 || result.status >= 300) {
+    console.warn(`  [warn] Failed to add remote link to ${key}: HTTP ${result.status}`);
+  }
+}
+
+// ─── State file ───────────────────────────────────────────────────────────────
+
+const STATE_FILE = path.join(process.cwd(), '.jira-seed-state.json');
+
+interface SeedState {
+  createdAt: string;
+  epicKey: string;
+  ticketKeys: string[];
+  allKeys: string[];
+}
+
+function writeStateFile(state: SeedState): void {
+  fs.writeFileSync(STATE_FILE, JSON.stringify(state, null, 2), 'utf-8');
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  const creds = getCredentials();
+  const ts = Date.now();
+  const label = 'kanban-test';
+
+  console.log(`Seeding Jira test data in project ${creds.project}...`);
+
+  // 1. Resolve Epic issue type
+  console.log('  Resolving Epic issue type...');
+  const epicTypeId = await resolveEpicIssueTypeId(creds);
+
+  // 2. Create Epic
+  console.log('  Creating Epic...');
+  const epicKey = await createIssue(creds, {
+    project: { key: creds.project },
+    summary: `[kanban-test] Test Epic ${ts}`,
+    description: {
+      version: 1,
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            { type: 'text', text: 'Integration test epic created by jira-seed.ts' },
+          ],
+        },
+      ],
+    },
+    issuetype: epicTypeId.length < 10 ? { id: epicTypeId } : { name: 'Epic' },
+    labels: [label],
+  });
+  console.log(`    Created epic: ${epicKey}`);
+
+  // 3. Create 3 child tickets
+  const ticketSpecs = [
+    { summary: `[kanban-test] Todo ticket ${ts}`, targetStatus: null },
+    { summary: `[kanban-test] In Progress ticket ${ts}`, targetStatus: 'In Progress' },
+    { summary: `[kanban-test] Done ticket ${ts}`, targetStatus: 'Done' },
+  ];
+
+  const ticketKeys: string[] = [];
+
+  for (const spec of ticketSpecs) {
+    console.log(`  Creating ticket: ${spec.summary}...`);
+    const key = await createIssue(creds, {
+      project: { key: creds.project },
+      summary: spec.summary,
+      issuetype: { name: 'Story' },
+      labels: [label],
+      parent: { key: epicKey },
+    });
+    console.log(`    Created ticket: ${key}`);
+    ticketKeys.push(key);
+
+    if (spec.targetStatus) {
+      console.log(`    Transitioning ${key} to "${spec.targetStatus}"...`);
+      await transitionIssue(creds, key, spec.targetStatus);
+    }
+  }
+
+  // 4. Add comment to first ticket
+  const firstTicket = ticketKeys[0];
+  if (firstTicket) {
+    console.log(`  Adding comment to ${firstTicket}...`);
+    await addComment(
+      creds,
+      firstTicket,
+      'Integration test comment added by jira-seed.ts. Safe to delete.',
+    );
+  }
+
+  // 5. Add Confluence remote link to epic (optional)
+  const confluenceUrl = process.env.JIRA_CONFLUENCE_URL;
+  if (confluenceUrl) {
+    console.log(`  Adding Confluence remote link to ${epicKey}...`);
+    await addRemoteLink(creds, epicKey, confluenceUrl, 'Test Confluence Page');
+  }
+
+  // 6. Write state file and print summary
+  const allKeys = [epicKey, ...ticketKeys];
+  const state: SeedState = {
+    createdAt: new Date().toISOString(),
+    epicKey,
+    ticketKeys,
+    allKeys,
+  };
+  writeStateFile(state);
+
+  console.log('\nSeed complete.');
+  console.log(`Epic:    ${epicKey}`);
+  console.log(`Tickets: ${ticketKeys.join(', ')}`);
+  console.log(`State written to: ${STATE_FILE}`);
+  console.log('\nCreated issue keys (for teardown):');
+  for (const key of allKeys) {
+    console.log(`  ${key}`);
+  }
+}
+
+main().catch((err: unknown) => {
+  const message = err instanceof Error ? err.message : String(err);
+  console.error(`Error: ${message}`);
+  process.exit(1);
+});

--- a/scripts/test-setup/jira-teardown.ts
+++ b/scripts/test-setup/jira-teardown.ts
@@ -1,0 +1,199 @@
+#!/usr/bin/env npx tsx
+
+/**
+ * jira-teardown.ts — Delete test Jira tickets created by jira-seed.ts.
+ *
+ * Accepts issue keys two ways (checked in order):
+ *   1. CLI arguments:   npx ts-node scripts/test-setup/jira-teardown.ts PROJ-1 PROJ-2
+ *   2. State file:      reads .jira-seed-state.json in the current working directory
+ *
+ * Required env vars:
+ *   JIRA_BASE_URL  — e.g. https://yourorg.atlassian.net
+ *   JIRA_EMAIL     — Atlassian account email
+ *   JIRA_TOKEN     — Atlassian API token
+ *
+ * Usage:
+ *   npx ts-node scripts/test-setup/jira-teardown.ts
+ *   npx ts-node scripts/test-setup/jira-teardown.ts PROJ-123 PROJ-124 PROJ-125
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+// ─── Credentials ─────────────────────────────────────────────────────────────
+
+interface JiraCredentials {
+  baseUrl: string;
+  email: string;
+  token: string;
+}
+
+function getCredentials(): JiraCredentials {
+  const baseUrl = process.env.JIRA_BASE_URL;
+  const email = process.env.JIRA_EMAIL;
+  const token = process.env.JIRA_TOKEN;
+
+  const missing: string[] = [];
+  if (!baseUrl) missing.push('JIRA_BASE_URL');
+  if (!email) missing.push('JIRA_EMAIL');
+  if (!token) missing.push('JIRA_TOKEN');
+
+  if (missing.length > 0) {
+    console.error(`Missing required environment variables: ${missing.join(', ')}`);
+    process.exit(1);
+  }
+
+  return { baseUrl: baseUrl!, email: email!, token: token! };
+}
+
+// ─── HTTP helper ─────────────────────────────────────────────────────────────
+
+function encodeAuth(email: string, token: string): string {
+  return Buffer.from(`${email}:${token}`).toString('base64');
+}
+
+async function jiraFetch(
+  creds: JiraCredentials,
+  method: string,
+  apiPath: string,
+): Promise<{ status: number; data: any }> {
+  const url = `${creds.baseUrl}${apiPath}`;
+  const headers: Record<string, string> = {
+    Authorization: `Basic ${encodeAuth(creds.email, creds.token)}`,
+    Accept: 'application/json',
+  };
+
+  const response = await fetch(url, { method, headers });
+  const status = response.status;
+
+  if (status === 204) {
+    return { status, data: undefined };
+  }
+
+  const text = await response.text();
+  let data: any;
+  try {
+    data = JSON.parse(text);
+  } catch {
+    data = text;
+  }
+
+  return { status, data };
+}
+
+// ─── State file ───────────────────────────────────────────────────────────────
+
+const STATE_FILE = path.join(process.cwd(), '.jira-seed-state.json');
+
+interface SeedState {
+  createdAt: string;
+  epicKey: string;
+  ticketKeys: string[];
+  allKeys: string[];
+}
+
+function readStateFile(): SeedState | null {
+  if (!fs.existsSync(STATE_FILE)) {
+    return null;
+  }
+  try {
+    const raw = fs.readFileSync(STATE_FILE, 'utf-8');
+    return JSON.parse(raw) as SeedState;
+  } catch {
+    console.error(`Failed to parse state file at ${STATE_FILE}`);
+    return null;
+  }
+}
+
+function deleteStateFile(): void {
+  if (fs.existsSync(STATE_FILE)) {
+    fs.unlinkSync(STATE_FILE);
+    console.log(`Deleted state file: ${STATE_FILE}`);
+  }
+}
+
+// ─── Delete helper ────────────────────────────────────────────────────────────
+
+/**
+ * Delete a single Jira issue. Logs the result without throwing —
+ * a 404 means it was already gone, which is acceptable for teardown.
+ */
+async function deleteIssue(creds: JiraCredentials, key: string): Promise<void> {
+  const result = await jiraFetch(
+    creds,
+    'DELETE',
+    `/rest/api/3/issue/${encodeURIComponent(key)}?deleteSubtasks=true`,
+  );
+
+  if (result.status === 204 || result.status === 200) {
+    console.log(`  Deleted: ${key}`);
+  } else if (result.status === 404) {
+    console.log(`  Already gone (404): ${key}`);
+  } else if (result.status === 403) {
+    console.error(`  Permission denied deleting ${key} (HTTP 403). Check your API token permissions.`);
+  } else {
+    const detail = typeof result.data === 'object'
+      ? JSON.stringify(result.data)
+      : String(result.data);
+    console.error(`  Failed to delete ${key} (HTTP ${result.status}): ${detail}`);
+  }
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  const creds = getCredentials();
+
+  // Resolve keys: CLI args take precedence over state file
+  const cliKeys = process.argv.slice(2).filter((a) => /^[A-Z][A-Z0-9]+-\d+$/.test(a));
+  let keys: string[];
+
+  if (cliKeys.length > 0) {
+    keys = cliKeys;
+    console.log(`Using ${keys.length} key(s) from CLI arguments.`);
+  } else {
+    const state = readStateFile();
+    if (!state) {
+      console.error(
+        `No issue keys provided and no state file found at ${STATE_FILE}.\n` +
+        `Usage: npx ts-node scripts/test-setup/jira-teardown.ts [KEY1 KEY2 ...]`,
+      );
+      process.exit(1);
+    }
+    keys = state.allKeys;
+    console.log(`Using ${keys.length} key(s) from state file (seeded at ${state.createdAt}).`);
+  }
+
+  if (keys.length === 0) {
+    console.log('No keys to delete. Nothing to do.');
+    return;
+  }
+
+  console.log(`\nDeleting ${keys.length} issue(s)...`);
+
+  // Delete child tickets first, then the epic to avoid dependency errors
+  const epicPattern = /^[A-Z][A-Z0-9]+-\d+$/;
+  // Heuristic: delete in reverse order (tickets were created after the epic)
+  const ordered = [...keys].reverse();
+
+  for (const key of ordered) {
+    if (!epicPattern.test(key)) {
+      console.warn(`  Skipping invalid key format: ${key}`);
+      continue;
+    }
+    await deleteIssue(creds, key);
+  }
+
+  // Clean up state file if it exists and we used it
+  if (cliKeys.length === 0) {
+    deleteStateFile();
+  }
+
+  console.log('\nTeardown complete.');
+}
+
+main().catch((err: unknown) => {
+  const message = err instanceof Error ? err.message : String(err);
+  console.error(`Error: ${message}`);
+  process.exit(1);
+});


### PR DESCRIPTION
Closes #5

Adds seed and teardown scripts for Jira integration testing.

## Deliverables
- scripts/test-setup/jira-seed.ts
- scripts/test-setup/jira-teardown.ts
- scripts/test-setup/README.md

## Usage
npx ts-node scripts/test-setup/jira-seed.ts
npx ts-node scripts/test-setup/jira-teardown.ts