### PR TITLE
feat: wire Slack notification triggers in orchestrator

### DIFF
--- a/tools/orchestrator/src/config.ts
+++ b/tools/orchestrator/src/config.ts
@@ -97,5 +97,6 @@ export async function loadOrchestratorConfig(
     pipelineConfig,
     workflowEnv,
     mock: cliOptions.mock === true,
+    slackWebhookUrl: env['WORKFLOW_SLACK_WEBHOOK'] || undefined,
   };
 }

--- a/tools/orchestrator/src/loop.ts
+++ b/tools/orchestrator/src/loop.ts
@@ -24,6 +24,7 @@ import type { LearningsResult } from './insights-threshold.js';
 import { SessionRegistry } from './session-registry.js';
 import { createWsServer } from './ws-server.js';
 import type { WsServerHandle } from './ws-server.js';
+import { slackNotify } from './slack-notify.js';
 
 export interface Orchestrator {
   start(): Promise<void>;
@@ -168,7 +169,19 @@ function buildCronScheduler(
       enabled: pollConfig.enabled,
       intervalMs: pollConfig.interval_seconds * 1000,
       async execute(): Promise<void> {
-        await poller.poll(config.repoPath);
+        const pollResults = await poller.poll(config.repoPath);
+        if (config.slackWebhookUrl) {
+          for (const r of pollResults) {
+            if (r.action === 'new_comments') {
+              slackNotify({
+                title: 'MR Comments Need Addressing',
+                message: `New review comments on stage \`${r.stageId}\` — ${r.newUnresolvedCount ?? 0} unresolved thread(s)`,
+                stage: r.stageId,
+                url: r.prUrl,
+              }, config.slackWebhookUrl).catch(() => {});
+            }
+          }
+        }
         await chainManager.checkParentChains(config.repoPath);
       },
     });
@@ -266,6 +279,24 @@ export function createOrchestrator(config: OrchestratorConfig, deps: Orchestrato
   // Get shared approval service and message queue from session executor
   const approvalService = sessionExecutor.getApprovalService();
   const messageQueue = sessionExecutor.getMessageQueue();
+
+  // Wire Slack notifications for user-input events
+  if (config.slackWebhookUrl) {
+    approvalService.on('question-requested', (entry) => {
+      slackNotify({
+        title: 'User Input Required',
+        message: `Claude is waiting for a response in stage \`${entry.stageId}\``,
+        stage: entry.stageId,
+      }, config.slackWebhookUrl!).catch(() => {});
+    });
+    approvalService.on('approval-requested', (entry) => {
+      slackNotify({
+        title: 'Tool Approval Required',
+        message: `Claude is requesting approval to use \`${entry.toolName}\` in stage \`${entry.stageId}\``,
+        stage: entry.stageId,
+      }, config.slackWebhookUrl!).catch(() => {});
+    });
+  }
 
   // Create callbacks for inbound WS messages
   const onSendMessage = (stageId: string, message: string) => {
@@ -388,6 +419,20 @@ export function createOrchestrator(config: OrchestratorConfig, deps: Orchestrato
       } catch (err) {
         logger.error('Exit gate failed', { stageId, error: (err as Error).message });
       }
+    }
+
+    // Notify Slack when a PR is created
+    if (statusAfter === 'PR Created' && config.slackWebhookUrl) {
+      try {
+        const fm = await readFrontmatter(workerInfo.stageFilePath);
+        slackNotify({
+          title: 'MR Created',
+          message: `A merge request was created for stage \`${stageId}\``,
+          stage: stageId,
+          ticket: fm.data.ticket as string | undefined,
+          url: fm.data.pr_url as string | undefined,
+        }, config.slackWebhookUrl).catch(() => {});
+      } catch { /* non-fatal */ }
     }
 
     // Check for queued follow-up messages and log them

--- a/tools/orchestrator/src/slack-notify.ts
+++ b/tools/orchestrator/src/slack-notify.ts
@@ -1,0 +1,55 @@
+/**
+ * Minimal Slack webhook notifier for the orchestrator.
+ * Extracted from mcp-server to avoid a cross-package dependency.
+ */
+
+export interface SlackNotifyArgs {
+  title?: string;
+  message: string;
+  stage?: string;
+  ticket?: string;
+  url?: string;
+}
+
+/**
+ * Send a Slack notification via webhook.
+ * Silently skips if DISABLE_SLACK=true.
+ * Always resolves (never rejects) — failures are non-fatal.
+ */
+export async function slackNotify(
+  args: SlackNotifyArgs,
+  webhookUrl: string,
+): Promise<void> {
+  if (process.env.DISABLE_SLACK === 'true') {
+    return;
+  }
+
+  const lines: string[] = [];
+  lines.push(`*${args.title ?? 'Workflow Notification'}*`);
+  lines.push('');
+  lines.push(args.message);
+  if (args.stage) lines.push(`*Stage:* ${args.stage}`);
+  if (args.ticket) lines.push(`*Ticket:* ${args.ticket}`);
+  if (args.url) lines.push(`<${args.url}|View MR/PR>`);
+
+  const payload = {
+    text: args.message,
+    blocks: [
+      {
+        type: 'section' as const,
+        text: { type: 'mrkdwn' as const, text: lines.join('\n') },
+      },
+    ],
+  };
+
+  try {
+    await fetch(webhookUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+      signal: AbortSignal.timeout(10_000),
+    });
+  } catch {
+    // Non-fatal: swallow errors silently
+  }
+}

--- a/tools/orchestrator/src/types.ts
+++ b/tools/orchestrator/src/types.ts
@@ -21,4 +21,5 @@ export interface OrchestratorConfig {
   workflowEnv: Record<string, string>;
   mock: boolean;
   wsPort?: number; // WebSocket port for session broadcasting; default undefined (disabled)
+  slackWebhookUrl?: string; // Slack incoming webhook URL for notifications; default undefined (disabled)
 }

--- a/tools/orchestrator/tests/loop.test.ts
+++ b/tools/orchestrator/tests/loop.test.ts
@@ -1,11 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { PipelineConfig, CronConfig } from 'kanban-cli';
+
+// Mock slackNotify so tests never make real HTTP calls
+vi.mock('../src/slack-notify.js', () => ({
+  slackNotify: vi.fn().mockResolvedValue(undefined),
+}));
 import {
   createOrchestrator,
   lookupSkillName,
   resolveStageFilePath,
   type OrchestratorDeps,
 } from '../src/loop.js';
+import { slackNotify } from '../src/slack-notify.js';
 import type { OrchestratorConfig, WorkerInfo } from '../src/types.js';
 import type { Discovery, DiscoveryResult, ReadyStage } from '../src/discovery.js';
 import type { Locker } from '../src/locking.js';
@@ -1603,6 +1609,125 @@ describe('createOrchestrator', () => {
       // This should not throw or bind any port
       const orchestrator = createOrchestrator(config, deps);
       expect(orchestrator).toBeDefined();
+    });
+  });
+
+  describe('Slack notifications', () => {
+    beforeEach(() => {
+      vi.mocked(slackNotify).mockClear();
+    });
+
+    it('calls slackNotify when question-requested fires and slackWebhookUrl is set', () => {
+      const { deps, sessionExecutor } = makeMockDeps();
+
+      let questionListener: ((entry: { stageId: string; requestId: string }) => void) | undefined;
+      sessionExecutor.getApprovalService.mockReturnValue({
+        on: vi.fn((event: string, listener: (entry: { stageId: string; requestId: string }) => void) => {
+          if (event === 'question-requested') questionListener = listener;
+        }),
+        emit: vi.fn(),
+        handleControlRequest: vi.fn(),
+        handleCancelRequest: vi.fn(),
+        handleResult: vi.fn(),
+        setCurrentStageId: vi.fn(),
+      });
+
+      const config = makeConfig({ once: true, slackWebhookUrl: 'https://hooks.slack.com/test' });
+      createOrchestrator(config, deps);
+
+      expect(questionListener).toBeDefined();
+      questionListener!({ stageId: 'STAGE-001-001-001', requestId: 'req-1' });
+
+      expect(slackNotify).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'User Input Required',
+          stage: 'STAGE-001-001-001',
+        }),
+        'https://hooks.slack.com/test',
+      );
+    });
+
+    it('calls slackNotify when approval-requested fires and slackWebhookUrl is set', () => {
+      const { deps, sessionExecutor } = makeMockDeps();
+
+      let approvalListener: ((entry: { stageId: string; requestId: string; toolName: string }) => void) | undefined;
+      sessionExecutor.getApprovalService.mockReturnValue({
+        on: vi.fn((event: string, listener: (entry: { stageId: string; requestId: string; toolName: string }) => void) => {
+          if (event === 'approval-requested') approvalListener = listener;
+        }),
+        emit: vi.fn(),
+        handleControlRequest: vi.fn(),
+        handleCancelRequest: vi.fn(),
+        handleResult: vi.fn(),
+        setCurrentStageId: vi.fn(),
+      });
+
+      const config = makeConfig({ once: true, slackWebhookUrl: 'https://hooks.slack.com/test' });
+      createOrchestrator(config, deps);
+
+      expect(approvalListener).toBeDefined();
+      approvalListener!({ stageId: 'STAGE-001-001-001', requestId: 'req-2', toolName: 'bash' });
+
+      expect(slackNotify).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'Tool Approval Required',
+          stage: 'STAGE-001-001-001',
+        }),
+        'https://hooks.slack.com/test',
+      );
+    });
+
+    it('does not register approval service listeners when slackWebhookUrl is not set', () => {
+      const { deps, sessionExecutor } = makeMockDeps();
+      const onMock = vi.fn();
+      sessionExecutor.getApprovalService.mockReturnValue({
+        on: onMock,
+        emit: vi.fn(),
+        handleControlRequest: vi.fn(),
+        handleCancelRequest: vi.fn(),
+        handleResult: vi.fn(),
+        setCurrentStageId: vi.fn(),
+      });
+
+      const config = makeConfig({ once: true }); // no slackWebhookUrl
+      createOrchestrator(config, deps);
+
+      expect(onMock).not.toHaveBeenCalledWith('question-requested', expect.any(Function));
+      expect(onMock).not.toHaveBeenCalledWith('approval-requested', expect.any(Function));
+    });
+
+    it('calls slackNotify with MR Created when session exits with PR Created status', async () => {
+      const { deps, discovery, locker, sessionExecutor, deferSession } = makeMockDeps();
+      const stage = makeReadyStage();
+      const deferred = deferSession();
+
+      discovery.discover.mockResolvedValueOnce(makeDiscoveryResult([stage]));
+      locker.readStatus
+        .mockResolvedValueOnce('In Build')   // statusBefore
+        .mockResolvedValueOnce('PR Created'); // statusAfter
+
+      // readFrontmatter returns pr_url
+      const readFrontmatter = vi.fn().mockResolvedValue({
+        data: { status: 'PR Created', pr_url: 'https://github.com/org/repo/pull/42' },
+        content: '',
+      });
+
+      const config = makeConfig({ once: true, slackWebhookUrl: 'https://hooks.slack.com/test' });
+      const orchestrator = createOrchestrator(config, { ...deps, readFrontmatter });
+      const startPromise = orchestrator.start();
+
+      await vi.waitFor(() => expect(sessionExecutor.spawn).toHaveBeenCalledTimes(1));
+      deferred.resolve({ exitCode: 0, durationMs: 1000 });
+      await startPromise;
+
+      expect(slackNotify).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'MR Created',
+          stage: stage.id,
+          url: 'https://github.com/org/repo/pull/42',
+        }),
+        'https://hooks.slack.com/test',
+      );
     });
   });
 });


### PR DESCRIPTION
Prerequisite for Issue #10 Slack test plan execution.

Adds orchestrator-level Slack notifications for three events:

1. **User input needed** — fires when Claude pauses for AskUserQuestion or tool approval
2. **MR created** — fires when a stage transitions to PR Created status
3. **MR comments addressed** — fires when new unresolved comments are detected by the MR poller

## Changes
- `types.ts`: `slackWebhookUrl` added to `OrchestratorConfig`
- `config.ts`: `WORKFLOW_SLACK_WEBHOOK` env var wired into config
- `loop.ts`: three notification injection points
- `slack-notify.ts`: local helper (extracted inline — no cross-package dep added)

## Test plan
- [x] `npm run test` passes (555 tests, 4 new)
- [ ] Set `WORKFLOW_SLACK_WEBHOOK` and run orchestrator to verify real notifications