### PR TITLE
docs: add CREDITS.md and Acknowledgments section (Issue #13)

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -1,0 +1,21 @@
+# Credits
+
+This project builds heavily on the work of others. We are grateful to the following projects.
+
+## claude-devtools
+
+The session viewer and analysis capabilities in this project are derived from or heavily inspired by [claude-devtools](https://github.com/anthropics/claude-devtools). The following core subsystems originate from that work:
+
+- **Session JSONL parsing** — Reading and interpreting Claude Code session files in JSONL format, including handling of message types, roles, and metadata
+- **Chunk building** — Assembling raw session events into structured conversation chunks with proper turn boundaries
+- **Tool rendering** — Displaying tool use invocations and tool result blocks in the session viewer UI
+- **Subagent tree resolution** — Walking the hierarchy of agent invocations to reconstruct the full execution tree from a session
+- **Context tracking** — Measuring and surfacing context window usage across the lifetime of a session
+- **Cost calculation** — Computing per-turn and per-session token costs using model-specific pricing
+
+## vibe-kanban
+
+The kanban board design and deployment approach were inspired by [vibe-kanban](https://github.com/mckaywrigley/vibe-kanban):
+
+- **Kanban board design** — Column-based stage visualization, card layout patterns, and drag-and-drop interaction model
+- **Hosted deployment architecture** — The approach to packaging and deploying the web server for shared team access

--- a/README.md
+++ b/README.md
@@ -939,7 +939,9 @@ MIT License - see LICENSE file for details.
 
 ## Acknowledgments
 
-Built on patterns from:
+This project builds on the work of others. See [CREDITS.md](./CREDITS.md) for full attribution, including heavy credit to [claude-devtools](https://github.com/anthropics/claude-devtools) for session JSONL parsing, chunk building, tool rendering, subagent tree resolution, context tracking, and cost calculation — and inspiration from [vibe-kanban](https://github.com/mckaywrigley/vibe-kanban) for the kanban board design and hosted deployment architecture.
+
+Also built on patterns from:
 
 - The Superpowers plugin by obra
 - The Claude Code community


### PR DESCRIPTION
## Summary
- Add \`CREDITS.md\` at repo root with attribution to claude-devtools (session JSONL parsing, chunk building, tool rendering, subagent tree resolution, context tracking, cost calculation) and inspiration credit to vibe-kanban (kanban board design, hosted deployment architecture)
- Update \`README.md\` Acknowledgments section to link to CREDITS.md with specific project credits

Closes #13

## Test plan
- [x] CREDITS.md created with full attribution to both projects
- [x] README.md Acknowledgments section updated with links to CREDITS.md, claude-devtools, and vibe-kanban