### PR TITLE
feat: add GitHub and GitLab integration test seed scripts (Issue #7)

### DIFF
--- a/scripts/test-setup/README.md
+++ b/scripts/test-setup/README.md
@@ -46,3 +46,52 @@ The state file (`.jira-seed-state.json`) is deleted after a successful teardown.
 - Both scripts use Basic Auth (`JIRA_EMAIL:JIRA_TOKEN` base64-encoded) against the Jira REST API v3.
 - Deleting issues requires the "Delete Issues" project permission in Jira. If you see HTTP 403 errors during teardown, check your API token's permissions.
 - Status transitions depend on your project's workflow. If a target status is unavailable, a warning is logged and the script continues.
+
+## Git Integration Test Setup
+
+Scripts for seeding and tearing down GitHub and GitLab test data used in integration tests.
+
+### Required Environment Variables
+
+#### GitHub
+
+| Variable | Description | Example |
+|---|---|---|
+| `GH_TOKEN` | GitHub personal access token with `repo` scope | `ghp_xxx...` |
+| `GH_TEST_REPO` | Target repository in `owner/repo` format | `myorg/myrepo` |
+
+#### GitLab
+
+| Variable | Description | Example |
+|---|---|---|
+| `GITLAB_TOKEN` | GitLab personal access token with `api` scope | `glpat-xxx...` |
+| `GITLAB_TEST_REPO` | Target project in `namespace/project` format | `mygroup/myrepo` |
+| `GITLAB_HOST` | GitLab hostname (optional, default: `gitlab.com`) | `gitlab.example.com` |
+
+### Seed
+
+Creates a test branch with a placeholder commit, opens a PR/MR, and adds a review comment.
+
+```bash
+# GitHub
+GH_TOKEN=... GH_TEST_REPO=owner/repo bash scripts/test-setup/github-seed.sh
+
+# GitLab
+GITLAB_TOKEN=... GITLAB_TEST_REPO=group/project bash scripts/test-setup/gitlab-seed.sh
+```
+
+PR/MR number and branch name are printed to stdout and written to `.github-seed-state.json` / `.gitlab-seed-state.json` in the current directory.
+
+### Teardown
+
+Closes the PR/MR, deletes the test branch, and removes the state files.
+
+```bash
+GH_TOKEN=... GITLAB_TOKEN=... bash scripts/test-setup/git-teardown.sh
+```
+
+### Notes
+
+- Scripts use the `gh` CLI (GitHub) and `glab` CLI (GitLab). Both must be installed and accessible in `PATH`.
+- State files (`.github-seed-state.json`, `.gitlab-seed-state.json`) are written to the current working directory and deleted after a successful teardown.
+- Scripts do not need to run against real repositories to be merged — they are validated with `bash -n` for syntax correctness.

--- a/scripts/test-setup/git-teardown.sh
+++ b/scripts/test-setup/git-teardown.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# git-teardown.sh — Clean up GitHub PR/branch and GitLab MR/branch created by seed scripts.
+#
+# Reads state from:
+#   .github-seed-state.json  (written by github-seed.sh)
+#   .gitlab-seed-state.json  (written by gitlab-seed.sh)
+#
+# Required env vars (same as seed scripts):
+#   GH_TOKEN      — GitHub personal access token (required if GitHub state file exists)
+#   GITLAB_TOKEN  — GitLab personal access token (required if GitLab state file exists)
+#
+# Usage:
+#   GH_TOKEN=... GITLAB_TOKEN=... bash scripts/test-setup/git-teardown.sh
+
+GITHUB_STATE="$(pwd)/.github-seed-state.json"
+GITLAB_STATE="$(pwd)/.gitlab-seed-state.json"
+ERRORS=0
+
+echo "==> Starting git integration test teardown..."
+
+# ── GitHub teardown ───────────────────────────────────────────────────────────
+
+if [[ -f "$GITHUB_STATE" ]]; then
+  echo "==> Reading GitHub state from $GITHUB_STATE"
+
+  if [[ -z "${GH_TOKEN:-}" ]]; then
+    echo "WARN: GH_TOKEN not set — skipping GitHub teardown" >&2
+    ERRORS=$((ERRORS + 1))
+  else
+    export GITHUB_TOKEN="$GH_TOKEN"
+
+    GH_REPO="$(python3 -c "import json,sys; print(json.load(open('$GITHUB_STATE'))['repo'])")"
+    GH_BRANCH="$(python3 -c "import json,sys; print(json.load(open('$GITHUB_STATE'))['branch'])")"
+    GH_PR="$(python3 -c "import json,sys; print(json.load(open('$GITHUB_STATE'))['prNumber'])")"
+
+    echo "    Repo:   $GH_REPO"
+    echo "    PR:     #$GH_PR"
+    echo "    Branch: $GH_BRANCH"
+
+    echo "==> Closing GitHub PR #$GH_PR..."
+    if gh pr close "$GH_PR" --repo "$GH_REPO" 2>/dev/null; then
+      echo "    PR closed"
+    else
+      echo "    WARN: PR may already be closed or not found" >&2
+    fi
+
+    echo "==> Deleting GitHub branch $GH_BRANCH..."
+    if gh api "repos/$GH_REPO/git/refs/heads/$GH_BRANCH" -X DELETE --silent 2>/dev/null; then
+      echo "    Branch deleted"
+    else
+      echo "    WARN: Branch may already be deleted or not found" >&2
+    fi
+
+    rm -f "$GITHUB_STATE"
+    echo "==> GitHub teardown complete"
+  fi
+else
+  echo "INFO: No GitHub state file found at $GITHUB_STATE — skipping"
+fi
+
+# ── GitLab teardown ───────────────────────────────────────────────────────────
+
+if [[ -f "$GITLAB_STATE" ]]; then
+  echo "==> Reading GitLab state from $GITLAB_STATE"
+
+  if [[ -z "${GITLAB_TOKEN:-}" ]]; then
+    echo "WARN: GITLAB_TOKEN not set — skipping GitLab teardown" >&2
+    ERRORS=$((ERRORS + 1))
+  else
+    export GITLAB_TOKEN="$GITLAB_TOKEN"
+
+    GL_HOST="$(python3 -c "import json,sys; print(json.load(open('$GITLAB_STATE'))['host'])")"
+    GL_ENCODED_REPO="$(python3 -c "import json,sys; print(json.load(open('$GITLAB_STATE'))['encodedRepo'])")"
+    GL_BRANCH="$(python3 -c "import json,sys; print(json.load(open('$GITLAB_STATE'))['branch'])")"
+    GL_MR_IID="$(python3 -c "import json,sys; print(json.load(open('$GITLAB_STATE'))['mrIid'])")"
+
+    echo "    Host:   $GL_HOST"
+    echo "    MR:     !$GL_MR_IID"
+    echo "    Branch: $GL_BRANCH"
+
+    echo "==> Closing GitLab MR !$GL_MR_IID..."
+    if GITLAB_HOST="$GL_HOST" glab api "projects/$GL_ENCODED_REPO/merge_requests/$GL_MR_IID" \
+      -X PUT -f "state_event=close" 2>/dev/null; then
+      echo "    MR closed"
+    else
+      echo "    WARN: MR may already be closed or not found" >&2
+    fi
+
+    echo "==> Deleting GitLab branch $GL_BRANCH..."
+    ENCODED_BRANCH="${GL_BRANCH//\//%2F}"
+    if GITLAB_HOST="$GL_HOST" glab api "projects/$GL_ENCODED_REPO/repository/branches/$ENCODED_BRANCH" \
+      -X DELETE 2>/dev/null; then
+      echo "    Branch deleted"
+    else
+      echo "    WARN: Branch may already be deleted or not found" >&2
+    fi
+
+    rm -f "$GITLAB_STATE"
+    echo "==> GitLab teardown complete"
+  fi
+else
+  echo "INFO: No GitLab state file found at $GITLAB_STATE — skipping"
+fi
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+
+echo ""
+if [[ $ERRORS -gt 0 ]]; then
+  echo "Teardown completed with $ERRORS warning(s). Check output above for details." >&2
+  exit 1
+fi
+
+echo "Teardown complete."

--- a/scripts/test-setup/github-seed.sh
+++ b/scripts/test-setup/github-seed.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# github-seed.sh — Create test GitHub branch, PR, and review comment for integration testing.
+#
+# Creates:
+#   - 1 test branch with a committed placeholder file
+#   - 1 pull request targeting the default branch
+#   - 1 inline review comment on the PR
+#
+# Outputs PR number and branch name to stdout and writes them to
+# .github-seed-state.json in the current working directory for use
+# by git-teardown.sh.
+#
+# Required env vars:
+#   GH_TOKEN      — GitHub personal access token with repo scope
+#   GH_TEST_REPO  — Target repository in owner/repo format (e.g. myorg/myrepo)
+#
+# Usage:
+#   GH_TOKEN=... GH_TEST_REPO=owner/repo bash scripts/test-setup/github-seed.sh
+
+# ── Validate env vars ─────────────────────────────────────────────────────────
+
+REQUIRED_VARS=(GH_TOKEN GH_TEST_REPO)
+for var in "${REQUIRED_VARS[@]}"; do
+  if [[ -z "${!var:-}" ]]; then
+    echo "ERROR: Required environment variable $var is not set" >&2
+    exit 1
+  fi
+done
+
+# ── Configuration ─────────────────────────────────────────────────────────────
+
+export GITHUB_TOKEN="$GH_TOKEN"
+REPO="$GH_TEST_REPO"
+TIMESTAMP="$(date +%Y%m%d%H%M%S)"
+BRANCH_NAME="test/claude-code-workflow-integration-${TIMESTAMP}"
+STATE_FILE="$(pwd)/.github-seed-state.json"
+
+echo "==> Starting GitHub seed for repo: $REPO"
+
+# ── Resolve default branch ────────────────────────────────────────────────────
+
+echo "==> Resolving default branch..."
+DEFAULT_BRANCH="$(gh api "repos/$REPO" --jq '.default_branch')"
+echo "    Default branch: $DEFAULT_BRANCH"
+
+# ── Get base SHA ──────────────────────────────────────────────────────────────
+
+BASE_SHA="$(gh api "repos/$REPO/git/ref/heads/$DEFAULT_BRANCH" --jq '.object.sha')"
+echo "    Base SHA: $BASE_SHA"
+
+# ── Create test branch ────────────────────────────────────────────────────────
+
+echo "==> Creating test branch: $BRANCH_NAME"
+gh api "repos/$REPO/git/refs" \
+  -X POST \
+  -f "ref=refs/heads/$BRANCH_NAME" \
+  -f "sha=$BASE_SHA" \
+  --silent
+echo "    Branch created"
+
+# ── Create a file blob ───────────────────────────────────────────────────────
+
+echo "==> Creating test commit on $BRANCH_NAME..."
+BLOB_SHA="$(gh api "repos/$REPO/git/blobs" \
+  -X POST \
+  -f "content=Integration test file created by claude-code-workflow github-seed.sh at $TIMESTAMP" \
+  -f "encoding=utf-8" \
+  --jq '.sha')"
+
+TREE_SHA="$(gh api "repos/$REPO/git/trees" \
+  -X POST \
+  --raw-field "tree=[{\"path\":\"test-integration-$TIMESTAMP.txt\",\"mode\":\"100644\",\"type\":\"blob\",\"sha\":\"$BLOB_SHA\"}]" \
+  -f "base_tree=$BASE_SHA" \
+  --jq '.sha')"
+
+COMMIT_SHA="$(gh api "repos/$REPO/git/commits" \
+  -X POST \
+  -f "message=test: add integration test file ($TIMESTAMP)" \
+  -f "tree=$TREE_SHA" \
+  --raw-field "parents=[\"$BASE_SHA\"]" \
+  --jq '.sha')"
+
+gh api "repos/$REPO/git/refs/heads/$BRANCH_NAME" \
+  -X PATCH \
+  -f "sha=$COMMIT_SHA" \
+  --silent
+echo "    Committed: $COMMIT_SHA"
+
+# ── Open PR ───────────────────────────────────────────────────────────────────
+
+echo "==> Opening pull request..."
+PR_NUMBER="$(gh api "repos/$REPO/pulls" \
+  -X POST \
+  -f "title=test: claude-code-workflow integration test PR ($TIMESTAMP)" \
+  -f "body=This PR was created automatically by the claude-code-workflow integration test suite (github-seed.sh). It can be safely closed." \
+  -f "head=$BRANCH_NAME" \
+  -f "base=$DEFAULT_BRANCH" \
+  --jq '.number')"
+echo "    PR #$PR_NUMBER created"
+
+# ── Add inline review comment ─────────────────────────────────────────────────
+
+echo "==> Adding review comment to PR #$PR_NUMBER..."
+gh api "repos/$REPO/pulls/$PR_NUMBER/comments" \
+  -X POST \
+  -f "body=Integration test review comment from claude-code-workflow github-seed.sh" \
+  -f "commit_id=$COMMIT_SHA" \
+  -f "path=test-integration-$TIMESTAMP.txt" \
+  -F "line=1" \
+  --silent
+echo "    Review comment added"
+
+# ── Write state file ──────────────────────────────────────────────────────────
+
+echo "==> Writing state file to $STATE_FILE..."
+cat > "$STATE_FILE" <<EOF
+{
+  "createdAt": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "repo": "$REPO",
+  "defaultBranch": "$DEFAULT_BRANCH",
+  "branch": "$BRANCH_NAME",
+  "commitSha": "$COMMIT_SHA",
+  "prNumber": $PR_NUMBER
+}
+EOF
+
+echo ""
+echo "Seed complete."
+echo "Repo:   $REPO"
+echo "Branch: $BRANCH_NAME"
+echo "PR:     #$PR_NUMBER"
+echo "State written to: $STATE_FILE"

--- a/scripts/test-setup/gitlab-seed.sh
+++ b/scripts/test-setup/gitlab-seed.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# gitlab-seed.sh — Create test GitLab branch, MR, and review comment for integration testing.
+#
+# Creates:
+#   - 1 test branch with a committed placeholder file
+#   - 1 merge request targeting the default branch
+#   - 1 discussion comment on the MR
+#
+# Outputs MR IID and branch name to stdout and writes them to
+# .gitlab-seed-state.json in the current working directory for use
+# by git-teardown.sh.
+#
+# Required env vars:
+#   GITLAB_TOKEN     — GitLab personal access token with api scope
+#   GITLAB_TEST_REPO — Target project in namespace/project format (e.g. mygroup/myrepo)
+#
+# Optional env vars:
+#   GITLAB_HOST      — GitLab hostname (default: gitlab.com)
+#
+# Usage:
+#   GITLAB_TOKEN=... GITLAB_TEST_REPO=group/project bash scripts/test-setup/gitlab-seed.sh
+
+# ── Validate env vars ─────────────────────────────────────────────────────────
+
+REQUIRED_VARS=(GITLAB_TOKEN GITLAB_TEST_REPO)
+for var in "${REQUIRED_VARS[@]}"; do
+  if [[ -z "${!var:-}" ]]; then
+    echo "ERROR: Required environment variable $var is not set" >&2
+    exit 1
+  fi
+done
+
+# ── Configuration ─────────────────────────────────────────────────────────────
+
+export GITLAB_TOKEN="$GITLAB_TOKEN"
+GITLAB_HOST="${GITLAB_HOST:-gitlab.com}"
+REPO="$GITLAB_TEST_REPO"
+TIMESTAMP="$(date +%Y%m%d%H%M%S)"
+BRANCH_NAME="test/claude-code-workflow-integration-${TIMESTAMP}"
+STATE_FILE="$(pwd)/.gitlab-seed-state.json"
+
+# URL-encode the project path (replace / with %2F)
+ENCODED_REPO="${REPO//\//%2F}"
+
+echo "==> Starting GitLab seed for project: $REPO on $GITLAB_HOST"
+
+# ── Resolve default branch ────────────────────────────────────────────────────
+
+echo "==> Resolving default branch..."
+DEFAULT_BRANCH="$(GITLAB_HOST="$GITLAB_HOST" glab api "projects/$ENCODED_REPO" --field . | python3 -c "import json,sys; print(json.load(sys.stdin)['default_branch'])")"
+echo "    Default branch: $DEFAULT_BRANCH"
+
+# ── Create test branch ────────────────────────────────────────────────────────
+
+echo "==> Creating test branch: $BRANCH_NAME"
+GITLAB_HOST="$GITLAB_HOST" glab api "projects/$ENCODED_REPO/repository/branches" \
+  -X POST \
+  -f "branch=$BRANCH_NAME" \
+  -f "ref=$DEFAULT_BRANCH"
+echo "    Branch created"
+
+# ── Create a test commit ──────────────────────────────────────────────────────
+
+echo "==> Creating test commit on $BRANCH_NAME..."
+FILE_PATH="test-integration-${TIMESTAMP}.txt"
+GITLAB_HOST="$GITLAB_HOST" glab api "projects/$ENCODED_REPO/repository/files/$FILE_PATH" \
+  -X POST \
+  -f "branch=$BRANCH_NAME" \
+  -f "content=Integration test file created by claude-code-workflow gitlab-seed.sh at $TIMESTAMP" \
+  -f "commit_message=test: add integration test file ($TIMESTAMP)" \
+  -f "encoding=text"
+echo "    File committed: $FILE_PATH"
+
+# ── Open MR ───────────────────────────────────────────────────────────────────
+
+echo "==> Opening merge request..."
+MR_IID="$(GITLAB_HOST="$GITLAB_HOST" glab api "projects/$ENCODED_REPO/merge_requests" \
+  -X POST \
+  -f "source_branch=$BRANCH_NAME" \
+  -f "target_branch=$DEFAULT_BRANCH" \
+  -f "title=test: claude-code-workflow integration test MR ($TIMESTAMP)" \
+  -f "description=This MR was created automatically by the claude-code-workflow integration test suite (gitlab-seed.sh). It can be safely closed." | python3 -c "import json,sys; print(json.load(sys.stdin)['iid'])")"
+echo "    MR !$MR_IID created"
+
+# ── Add review comment (discussion) ──────────────────────────────────────────
+
+echo "==> Adding review comment to MR !$MR_IID..."
+GITLAB_HOST="$GITLAB_HOST" glab api "projects/$ENCODED_REPO/merge_requests/$MR_IID/notes" \
+  -X POST \
+  -f "body=Integration test review comment from claude-code-workflow gitlab-seed.sh"
+echo "    Review comment added"
+
+# ── Write state file ──────────────────────────────────────────────────────────
+
+echo "==> Writing state file to $STATE_FILE..."
+cat > "$STATE_FILE" <<EOF
+{
+  "createdAt": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "host": "$GITLAB_HOST",
+  "repo": "$REPO",
+  "encodedRepo": "$ENCODED_REPO",
+  "defaultBranch": "$DEFAULT_BRANCH",
+  "branch": "$BRANCH_NAME",
+  "mrIid": $MR_IID
+}
+EOF
+
+echo ""
+echo "Seed complete."
+echo "Host:   $GITLAB_HOST"
+echo "Repo:   $REPO"
+echo "Branch: $BRANCH_NAME"
+echo "MR:     !$MR_IID"
+echo "State written to: $STATE_FILE"


### PR DESCRIPTION
## Summary
- Add `scripts/test-setup/github-seed.sh` — creates test branch, PR, and inline review comment via `gh` CLI
- Add `scripts/test-setup/gitlab-seed.sh` — creates test branch, MR, and discussion comment via `glab` CLI
- Add `scripts/test-setup/git-teardown.sh` — closes PR/MR, deletes branches, removes state files
- Update `scripts/test-setup/README.md` with required env vars (GH_TOKEN, GH_TEST_REPO, GITLAB_TOKEN, GITLAB_TEST_REPO, GITLAB_HOST) and usage instructions

Follows the same pattern as `jira-seed.ts`: env var validation, progress logging, state file for teardown.

Closes #7

## Test plan
- [x] All three scripts pass `bash -n` syntax check
- [x] `set -euo pipefail` at top of each script
- [x] Required env var validation with descriptive error messages
- [x] State files written for teardown coordination
- [x] README documents all required env vars and usage