### PR TITLE
feat: move checklist templates to YAML frontmatter (Issue #20)

### DIFF
--- a/tools/kanban-cli/scripts/migrate-checklists.ts
+++ b/tools/kanban-cli/scripts/migrate-checklists.ts
@@ -1,0 +1,186 @@
+#!/usr/bin/env npx tsx
+/**
+ * Migration script: moves markdown checkbox lists from stage file bodies to YAML frontmatter.
+ *
+ * Usage:
+ *   npx tsx scripts/migrate-checklists.ts <repo-path> [--dry-run]
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import matter from 'gray-matter';
+
+interface ChecklistItem {
+  text: string;
+  checked: boolean;
+}
+
+interface Checklist {
+  title: string;
+  items: ChecklistItem[];
+}
+
+/**
+ * Parse a line as a markdown checkbox item.
+ * Returns null if the line is not a checkbox.
+ */
+function parseCheckboxLine(line: string): ChecklistItem | null {
+  const match = line.match(/^\s*-\s+\[([ xX])\]\s+(.+)$/);
+  if (!match) return null;
+  return {
+    text: match[2].trim(),
+    checked: match[1] !== ' ',
+  };
+}
+
+/**
+ * Extract checklists from the markdown body.
+ * A checklist is a heading (##, ###, etc.) followed by one or more checkbox lines.
+ * Standalone checkbox groups (without a heading) use "Checklist" as the default title.
+ *
+ * Returns the extracted checklists and the cleaned body with checklist content removed.
+ */
+function extractChecklists(body: string): { checklists: Checklist[]; cleanedBody: string } {
+  const lines = body.split('\n');
+  const checklists: Checklist[] = [];
+  const cleanedLines: string[] = [];
+
+  let currentTitle: string | null = null;
+  let currentItems: ChecklistItem[] = [];
+  let headingLineIndex = -1;
+
+  function flushChecklist() {
+    if (currentItems.length > 0) {
+      checklists.push({
+        title: currentTitle ?? 'Checklist',
+        items: [...currentItems],
+      });
+      // Remove the heading line if we captured one
+      if (headingLineIndex >= 0 && cleanedLines.length > headingLineIndex) {
+        cleanedLines.splice(headingLineIndex, cleanedLines.length - headingLineIndex);
+      }
+    } else if (headingLineIndex >= 0) {
+      // Heading had no checklist items — keep it
+    }
+    currentTitle = null;
+    currentItems = [];
+    headingLineIndex = -1;
+  }
+
+  for (const line of lines) {
+    const headingMatch = line.match(/^(#{2,6})\s+(.+)$/);
+    const checkboxItem = parseCheckboxLine(line);
+
+    if (headingMatch) {
+      flushChecklist();
+      currentTitle = headingMatch[2].trim();
+      cleanedLines.push(line);
+      headingLineIndex = cleanedLines.length - 1;
+    } else if (checkboxItem) {
+      currentItems.push(checkboxItem);
+      // Don't add checkbox lines to cleanedLines — they'll go into frontmatter
+    } else {
+      // Non-checkbox, non-heading line — flush any pending checklist
+      if (currentItems.length > 0) {
+        flushChecklist();
+      } else {
+        // Reset heading tracking if the line after a heading isn't a checkbox
+        if (headingLineIndex >= 0) {
+          headingLineIndex = -1;
+          currentTitle = null;
+        }
+      }
+      cleanedLines.push(line);
+    }
+  }
+
+  // Flush any remaining checklist
+  flushChecklist();
+
+  // Clean up trailing blank lines from removed sections
+  let cleaned = cleanedLines.join('\n');
+  cleaned = cleaned.replace(/\n{3,}/g, '\n\n').trimEnd() + '\n';
+
+  return { checklists, cleanedBody: cleaned };
+}
+
+function discoverStageFiles(repoPath: string): string[] {
+  const epicsDir = path.join(repoPath, 'epics');
+  if (!fs.existsSync(epicsDir)) return [];
+
+  const files: string[] = [];
+  function walk(dir: string) {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(full);
+      } else if (entry.isFile() && entry.name.startsWith('STAGE-') && entry.name.endsWith('.md')) {
+        files.push(full);
+      }
+    }
+  }
+  walk(epicsDir);
+  return files;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const dryRun = args.includes('--dry-run');
+  const repoPath = args.find((a) => !a.startsWith('--'));
+
+  if (!repoPath) {
+    console.error('Usage: npx tsx scripts/migrate-checklists.ts <repo-path> [--dry-run]');
+    process.exit(1);
+  }
+
+  const resolvedPath = path.resolve(repoPath);
+  if (!fs.existsSync(resolvedPath)) {
+    console.error(`Repository path not found: ${resolvedPath}`);
+    process.exit(1);
+  }
+
+  const stageFiles = discoverStageFiles(resolvedPath);
+  console.log(`Found ${stageFiles.length} stage files in ${resolvedPath}`);
+
+  let migratedCount = 0;
+
+  for (const filePath of stageFiles) {
+    const raw = fs.readFileSync(filePath, 'utf-8');
+    const { data, content } = matter(raw);
+
+    // Skip files that already have checklists in frontmatter
+    if (Array.isArray(data.checklists) && data.checklists.length > 0) {
+      console.log(`  SKIP (already has frontmatter checklists): ${path.relative(resolvedPath, filePath)}`);
+      continue;
+    }
+
+    const { checklists, cleanedBody } = extractChecklists(content);
+
+    if (checklists.length === 0) {
+      continue;
+    }
+
+    data.checklists = checklists;
+
+    const output = matter.stringify(cleanedBody, data);
+
+    if (dryRun) {
+      console.log(`  DRY-RUN: ${path.relative(resolvedPath, filePath)} — ${checklists.length} checklist(s) found`);
+      for (const cl of checklists) {
+        console.log(`    "${cl.title}" (${cl.items.length} items)`);
+      }
+    } else {
+      fs.writeFileSync(filePath, output, 'utf-8');
+      console.log(`  MIGRATED: ${path.relative(resolvedPath, filePath)} — ${checklists.length} checklist(s)`);
+    }
+
+    migratedCount++;
+  }
+
+  console.log(`\nDone. ${migratedCount} file(s) ${dryRun ? 'would be ' : ''}migrated.`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/tools/kanban-cli/scripts/seed-test-repo.sh
+++ b/tools/kanban-cli/scripts/seed-test-repo.sh
@@ -143,6 +143,21 @@ refinement_type:
 depends_on:
   - STAGE-001-001-002
 priority: 0
+checklists:
+  - title: "Pre-flight checks"
+    items:
+      - text: "Review PR"
+        checked: false
+      - text: "Run tests"
+        checked: true
+  - title: "Deployment steps"
+    items:
+      - text: "Update environment variables"
+        checked: false
+      - text: "Run database migration"
+        checked: false
+      - text: "Verify health endpoint"
+        checked: false
 ---
 
 ## Overview

--- a/tools/kanban-cli/src/parser/frontmatter-schemas.ts
+++ b/tools/kanban-cli/src/parser/frontmatter-schemas.ts
@@ -19,9 +19,19 @@ export const jiraLinkSchema = z.object({
   mime_type: z.string().optional(),
 });
 
+export const checklistItemSchema = z.object({
+  text: z.string(),
+  checked: z.boolean(),
+});
+
+export const checklistSchema = z.object({
+  title: z.string(),
+  items: z.array(checklistItemSchema),
+});
+
 // ─── Full-document schemas ──────────────────────────────────────────────────
 // Available for standalone validation and future use.
-// Sub-schemas (pendingMergeParentSchema, jiraLinkSchema) are used directly by the parser.
+// Sub-schemas (pendingMergeParentSchema, jiraLinkSchema, checklistSchema) are used directly by the parser.
 
 // ─── Stage frontmatter schema ───────────────────────────────────────────────
 
@@ -42,6 +52,7 @@ export const stageFrontmatterSchema = z.object({
   pending_merge_parents: z.array(pendingMergeParentSchema).default([]),
   is_draft: z.boolean().default(false),
   mr_target_branch: z.string().nullable().default(null),
+  checklists: z.array(checklistSchema).default([]),
 });
 
 // ─── Ticket frontmatter schema ──────────────────────────────────────────────

--- a/tools/kanban-cli/src/parser/frontmatter.ts
+++ b/tools/kanban-cli/src/parser/frontmatter.ts
@@ -1,8 +1,9 @@
 import matter from 'gray-matter';
-import type { Epic, Ticket, Stage, WorkItemType, PendingMergeParent, JiraLink } from '../types/work-items.js';
+import type { Epic, Ticket, Stage, WorkItemType, PendingMergeParent, JiraLink, Checklist } from '../types/work-items.js';
 import {
   pendingMergeParentSchema,
   jiraLinkSchema,
+  checklistSchema,
 } from './frontmatter-schemas.js';
 
 /**
@@ -112,6 +113,16 @@ export function parseStageFrontmatter(content: string, filePath: string): Stage 
     }
   });
 
+  // Parse checklists with Zod validation, defaulting to []
+  const rawChecklists = Array.isArray(data.checklists) ? data.checklists : [];
+  const checklists: Checklist[] = rawChecklists.map((item: unknown) => {
+    try {
+      return checklistSchema.parse(item);
+    } catch (e) {
+      throw new Error(`Invalid checklists entry in ${filePath}: ${e instanceof Error ? e.message : e}`);
+    }
+  });
+
   return {
     id: requireField<string>(data, 'id', filePath),
     ticket: requireField<string>(data, 'ticket', filePath),
@@ -129,6 +140,7 @@ export function parseStageFrontmatter(content: string, filePath: string): Stage 
     pending_merge_parents: pendingMergeParents,
     is_draft: data.is_draft === true ? true : false,
     mr_target_branch: (data.mr_target_branch as string) ?? null,
+    checklists,
     file_path: filePath,
   };
 }

--- a/tools/kanban-cli/src/types/work-items.ts
+++ b/tools/kanban-cli/src/types/work-items.ts
@@ -64,6 +64,22 @@ export interface Ticket {
 }
 
 /**
+ * A single item in a checklist.
+ */
+export interface ChecklistItem {
+  text: string;
+  checked: boolean;
+}
+
+/**
+ * A named checklist containing ordered items.
+ */
+export interface Checklist {
+  title: string;
+  items: ChecklistItem[];
+}
+
+/**
  * A parent stage whose MR must merge before this stage's MR can proceed.
  */
 export interface PendingMergeParent {
@@ -106,6 +122,7 @@ export interface Stage {
   pending_merge_parents: PendingMergeParent[];
   is_draft: boolean;
   mr_target_branch: string | null;
+  checklists: Checklist[];
   file_path: string;
 }
 

--- a/tools/web-server/package-lock.json
+++ b/tools/web-server/package-lock.json
@@ -13,6 +13,7 @@
         "@tanstack/react-query": "^5.0.0",
         "@tanstack/react-virtual": "^3.10.0",
         "fastify": "^5.0.0",
+        "gray-matter": "^4.0.3",
         "lucide-react": "^0.460.0",
         "mermaid": "^11.12.3",
         "react": "^19.0.0",
@@ -2360,6 +2361,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -3620,6 +3630,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/estree-util-is-identifier-name": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
@@ -3655,6 +3678,18 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
+    },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/fast-decode-uri-component": {
       "version": "1.0.1",
@@ -3969,6 +4004,21 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/gray-matter": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^3.13.1",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
     "node_modules/hachure-fill": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/hachure-fill/-/hachure-fill-0.5.2.tgz",
@@ -4206,6 +4256,15 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -4309,6 +4368,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/js-yaml": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -4389,6 +4461,15 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/khroma/-/khroma-2.1.0.tgz",
       "integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/langium": {
       "version": "4.2.1",
@@ -6447,6 +6528,19 @@
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
     },
+    "node_modules/section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/secure-json-parse": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-4.1.0.tgz",
@@ -6592,6 +6686,12 @@
         "node": ">= 10.x"
       }
     },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -6655,6 +6755,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/strip-literal": {

--- a/tools/web-server/package.json
+++ b/tools/web-server/package.json
@@ -17,6 +17,7 @@
     "@tanstack/react-query": "^5.0.0",
     "@tanstack/react-virtual": "^3.10.0",
     "fastify": "^5.0.0",
+    "gray-matter": "^4.0.3",
     "lucide-react": "^0.460.0",
     "mermaid": "^11.12.3",
     "react": "^19.0.0",

--- a/tools/web-server/src/client/api/hooks.ts
+++ b/tools/web-server/src/client/api/hooks.ts
@@ -155,6 +155,16 @@ export interface DependencyItem {
   resolved: boolean;
 }
 
+export interface ChecklistItem {
+  text: string;
+  checked: boolean;
+}
+
+export interface ChecklistData {
+  title: string;
+  items: ChecklistItem[];
+}
+
 export interface StageDetail extends StageListItem {
   pr_number: number | null;
   is_draft: boolean;
@@ -162,6 +172,7 @@ export interface StageDetail extends StageListItem {
   mr_target_branch: string | null;
   depends_on: DependencyItem[];
   depended_on_by: DependencyItem[];
+  checklists: ChecklistData[];
 }
 
 // Graph

--- a/tools/web-server/src/client/components/detail/StageDetailContent.tsx
+++ b/tools/web-server/src/client/components/detail/StageDetailContent.tsx
@@ -19,6 +19,8 @@ import {
   Loader2,
   AlertCircle,
   FileCode,
+  CheckSquare,
+  Square,
 } from 'lucide-react';
 
 interface StageDetailContentProps {
@@ -168,6 +170,32 @@ export function StageDetailContent({ stageId }: StageDetailContentProps) {
                   isComplete={phase.isComplete}
                   defaultExpanded={!phase.isComplete}
                 />
+              ))}
+            </div>
+          )}
+
+          {/* Checklists — read-only display of frontmatter checklists */}
+          {stage.checklists && stage.checklists.length > 0 && (
+            <div className="space-y-3">
+              <h3 className="text-sm font-semibold text-slate-700">Checklists</h3>
+              {stage.checklists.map((checklist) => (
+                <div key={checklist.title} className="rounded-lg border border-slate-200 bg-slate-50 p-3">
+                  <h4 className="mb-2 text-xs font-medium text-slate-600">{checklist.title}</h4>
+                  <ul className="space-y-1">
+                    {checklist.items.map((item) => (
+                      <li key={item.text} className="flex items-center gap-2 text-sm text-slate-700">
+                        {item.checked ? (
+                          <CheckSquare size={14} className="shrink-0 text-green-600" />
+                        ) : (
+                          <Square size={14} className="shrink-0 text-slate-400" />
+                        )}
+                        <span className={item.checked ? 'line-through text-slate-400' : ''}>
+                          {item.text}
+                        </span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
               ))}
             </div>
           )}

--- a/tools/web-server/src/server/routes/stages.ts
+++ b/tools/web-server/src/server/routes/stages.ts
@@ -1,6 +1,8 @@
 import type { FastifyPluginCallback } from 'fastify';
 import fp from 'fastify-plugin';
 import { z } from 'zod';
+import { existsSync, readFileSync } from 'node:fs';
+import matter from 'gray-matter';
 import { parseRefinementType } from './utils.js';
 
 /** Zod schema for the :id route parameter. */
@@ -89,6 +91,20 @@ const stagePlugin: FastifyPluginCallback = (app, _opts, done) => {
       resolved: d.resolved !== 0,
     });
 
+    // Read checklists from the stage file's frontmatter
+    let checklists: Array<{ title: string; items: Array<{ text: string; checked: boolean }> }> = [];
+    if (stage.file_path && existsSync(stage.file_path)) {
+      try {
+        const raw = readFileSync(stage.file_path, 'utf-8');
+        const { data } = matter(raw);
+        if (Array.isArray(data.checklists)) {
+          checklists = data.checklists;
+        }
+      } catch {
+        // If file read or parse fails, return empty checklists
+      }
+    }
+
     return reply.send({
       id: stage.id,
       title: stage.title ?? '',
@@ -110,6 +126,7 @@ const stagePlugin: FastifyPluginCallback = (app, _opts, done) => {
       file_path: stage.file_path,
       depends_on: depsFrom.map(mapDep),
       depended_on_by: depsTo.map(mapDep),
+      checklists,
     });
   });
 


### PR DESCRIPTION
## Summary
- Add `checklistItemSchema` and `checklistSchema` to `frontmatter-schemas.ts` with Zod validation
- Add `Checklist`/`ChecklistItem` interfaces to `work-items.ts` and extend the `Stage` type
- Update `parseStageFrontmatter` to parse checklists from frontmatter with Zod validation
- Create `scripts/migrate-checklists.ts` migration script (parses markdown checkboxes from body, moves to frontmatter)
- Update `seed-test-repo.sh` with sample frontmatter checklists on STAGE-001-001-003
- Add `gray-matter` to web-server, extend stage detail API to read and return checklists from file frontmatter
- Add read-only checklist rendering in `StageDetailContent.tsx` with checked/unchecked icons

Closes #20

## Test plan
- [x] npm run test passes in tools/kanban-cli (all parser/schema tests pass)
- [x] npm run lint passes in tools/kanban-cli
- [x] npm run test passes in tools/web-server (all stages tests pass)
- [x] npm run lint passes in tools/web-server