### PR TITLE
fix(slack): address remaining PR #2 reviewer feedback

### DIFF
--- a/skills/review-cycle/SKILL.md
+++ b/skills/review-cycle/SKILL.md
@@ -265,7 +265,7 @@ glab mr view --output json | jq '.iid'
               "type": "section",
               "text": {
                 "type": "mrkdwn",
-                "text": "*Review Comments Addressed*\n\n*Stage:* STAGE-XXX-YYY-ZZZ — <stage title>\n*Round:* N\n*Comments addressed:* M\n*URL:* <MR/PR URL>\n\nReady for re-review."
+                "text": "*Review Comments Addressed*\n\n*Stage:* STAGE-XXX-YYY-ZZZ\n*Round:* N\n*Comments addressed:* M\n*URL:* <MR/PR URL>\n\nReady for re-review."
               }
             }
           ]

--- a/tools/mcp-server/src/tools/slack.ts
+++ b/tools/mcp-server/src/tools/slack.ts
@@ -79,7 +79,10 @@ export async function handleSlackNotify(
       : `*Epic:* ${args.epic}`;
     lines.push(epicLine);
   }
-  if (args.url) lines.push(`<${args.url}|View MR/PR>`);
+  if (args.url) {
+    const safeUrl = args.url.replace(/[|>]/g, encodeURIComponent);
+    lines.push(`<${safeUrl}|View MR/PR>`);
+  }
 
   const payload = {
     text: args.message, // Top-level fallback for clients that don't render Block Kit


### PR DESCRIPTION
## What

Addresses the two remaining items from PR #2 reviewer feedback that were identified after merge.

## Changes

- **`fix(slack): sanitize mrkdwn link URL`** — Escapes `|` and `>` in URL fields via `encodeURIComponent` to prevent mrkdwn syntax injection in Slack Block Kit links
- **`fix(skills): remove stage title from review-cycle curl fallback`** — Aligns the curl fallback `*Stage:*` line in `review-cycle/SKILL.md` with MCP tool output (no title appendage)

## Verification

- 162 tests passing, 0 failures
- Build: clean
- Lint: clean

Closes out all MUST FIX and SHOULD FIX items from PR #2 review by @jakekausler.