### PR TITLE
feat(ui): WebFetchRenderer and NotebookEditRenderer — replace generic fallback

### DIFF
--- a/tools/web-server/src/client/components/tools/NotebookEditRenderer.tsx
+++ b/tools/web-server/src/client/components/tools/NotebookEditRenderer.tsx
@@ -1,0 +1,75 @@
+import { Notebook } from 'lucide-react';
+import { CodeBlockViewer } from './CodeBlockViewer.js';
+import type { ToolExecution } from '../../types/session.js';
+
+interface Props {
+  execution: ToolExecution;
+}
+
+type EditMode = 'replace' | 'insert' | 'delete';
+type CellType = 'code' | 'markdown';
+
+const editModeBadgeClass: Record<EditMode, string> = {
+  replace: 'bg-blue-100 text-blue-700 border-blue-200',
+  insert: 'bg-green-100 text-green-700 border-green-200',
+  delete: 'bg-red-100 text-red-700 border-red-200',
+};
+
+function getBaseName(filePath: string): string {
+  const parts = filePath.split(/[/\\]/);
+  return parts[parts.length - 1] || filePath;
+}
+
+export function NotebookEditRenderer({ execution }: Props) {
+  const { input } = execution;
+  const notebookPath = (input.notebook_path as string) ?? '';
+  const cellNumber = input.cell_number as number | undefined;
+  const newSource = (input.new_source as string) ?? '';
+  const editMode = (input.edit_mode as EditMode | undefined) ?? 'replace';
+  const cellType = (input.cell_type as CellType | undefined) ?? 'code';
+
+  const fileName = getBaseName(notebookPath);
+  const badgeClass = editModeBadgeClass[editMode] ?? editModeBadgeClass.replace;
+  const language = cellType === 'markdown' ? 'markdown' : 'python';
+
+  return (
+    <div className="space-y-2 text-sm">
+      {/* Header row */}
+      <div className="flex items-center gap-2 flex-wrap">
+        <Notebook className="w-4 h-4 shrink-0 text-slate-400" />
+        <span
+          className="font-mono text-xs text-slate-700 truncate"
+          title={notebookPath}
+        >
+          {fileName}
+        </span>
+        <span
+          className={`shrink-0 rounded px-1.5 py-0.5 text-xs font-medium border ${badgeClass}`}
+        >
+          {editMode}
+        </span>
+        {cellNumber !== undefined && (
+          <span className="text-xs text-slate-500">Cell #{cellNumber}</span>
+        )}
+        {input.cell_type !== undefined && (
+          <span className="shrink-0 rounded px-1.5 py-0.5 text-xs bg-slate-100 text-slate-600 border border-slate-200">
+            {cellType}
+          </span>
+        )}
+      </div>
+
+      {/* Source content */}
+      {newSource && editMode !== 'delete' && (
+        <CodeBlockViewer
+          fileName={`cell.${language === 'markdown' ? 'md' : 'py'}`}
+          content={newSource}
+          language={language}
+        />
+      )}
+
+      {editMode === 'delete' && (
+        <div className="text-xs text-slate-400 italic pl-6">Cell deleted — no source content.</div>
+      )}
+    </div>
+  );
+}

--- a/tools/web-server/src/client/components/tools/WebFetchRenderer.tsx
+++ b/tools/web-server/src/client/components/tools/WebFetchRenderer.tsx
@@ -1,0 +1,76 @@
+import { Globe } from 'lucide-react';
+import { extractResultContent } from '../../utils/session-formatters.js';
+import type { ToolExecution } from '../../types/session.js';
+
+interface Props {
+  execution: ToolExecution;
+}
+
+function truncateUrl(url: string, maxLength = 80): string {
+  if (url.length <= maxLength) return url;
+  return url.slice(0, maxLength) + '\u2026';
+}
+
+function isValidUrl(url: string): boolean {
+  try {
+    new URL(url);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function WebFetchRenderer({ execution }: Props) {
+  const { input, result } = execution;
+  const url = (input.url as string) ?? '';
+  const prompt = (input.prompt as string) ?? '';
+
+  const content = extractResultContent(result);
+  const isError = result?.isError ?? false;
+
+  return (
+    <div className="space-y-2 text-sm">
+      {/* URL header */}
+      <div className="flex items-center gap-2">
+        <Globe className="w-4 h-4 shrink-0 text-slate-400" />
+        {isValidUrl(url) ? (
+          <a
+            href={url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-xs font-mono text-blue-600 hover:text-blue-800 hover:underline truncate"
+            title={url}
+          >
+            {truncateUrl(url)}
+          </a>
+        ) : (
+          <span className="text-xs font-mono text-slate-700 truncate" title={url}>
+            {truncateUrl(url)}
+          </span>
+        )}
+      </div>
+
+      {/* Prompt */}
+      {prompt && (
+        <div className="text-xs text-slate-500 italic pl-6 truncate" title={prompt}>
+          {prompt}
+        </div>
+      )}
+
+      {/* Result content */}
+      {content ? (
+        <pre
+          className={`rounded-lg p-3 text-xs font-mono whitespace-pre-wrap break-words overflow-x-auto max-h-48 overflow-y-auto ${
+            isError
+              ? 'bg-red-50 text-red-800 border border-red-200'
+              : 'bg-slate-50 text-slate-800'
+          }`}
+        >
+          {content}
+        </pre>
+      ) : (
+        <div className="text-xs text-slate-400 italic pl-6">No content returned.</div>
+      )}
+    </div>
+  );
+}

--- a/tools/web-server/src/client/components/tools/index.ts
+++ b/tools/web-server/src/client/components/tools/index.ts
@@ -7,6 +7,8 @@ import { BashRenderer } from './BashRenderer.js';
 import { GlobRenderer } from './GlobRenderer.js';
 import { GrepRenderer } from './GrepRenderer.js';
 import { SkillRenderer } from './SkillRenderer.js';
+import { WebFetchRenderer } from './WebFetchRenderer.js';
+import { NotebookEditRenderer } from './NotebookEditRenderer.js';
 import { DefaultRenderer } from './DefaultRenderer.js';
 
 type ToolRendererComponent = ComponentType<{ execution: ToolExecution }>;
@@ -19,8 +21,8 @@ const rendererMap: Record<string, ToolRendererComponent> = {
   Glob: GlobRenderer,
   Grep: GrepRenderer,
   Skill: SkillRenderer,
-  NotebookEdit: DefaultRenderer,
-  WebFetch: DefaultRenderer,
+  NotebookEdit: NotebookEditRenderer,
+  WebFetch: WebFetchRenderer,
   WebSearch: DefaultRenderer,
 };
 


### PR DESCRIPTION
## Summary

- Implements `WebFetchRenderer`: shows the fetched URL as a clickable link (truncated if long), the extraction prompt in muted italic text, and the result in a scrollable `<pre>` block with error-state styling
- Implements `NotebookEditRenderer`: shows the notebook filename, a coloured edit-mode badge (`replace` / `insert` / `delete`), optional cell number and cell-type badge, and the new source in a syntax-highlighted `CodeBlockViewer`; shows a placeholder for `delete` mode
- Registers both renderers in `tools/index.ts`, replacing the previous `DefaultRenderer` fallback for `WebFetch` and `NotebookEdit`

Part of Issue #31 (tool renderer audit) — QW-2 and QW-3.

## Verification

- 845 tests pass
- Lint and build clean