### PR TITLE
feat(ui): GlobRenderer tree, GrepRenderer grouped, WebSearchRenderer, Task tool renderers

### DIFF
--- a/tools/web-server/src/client/components/tools/GlobRenderer.tsx
+++ b/tools/web-server/src/client/components/tools/GlobRenderer.tsx
@@ -1,4 +1,5 @@
-import { FolderSearch } from 'lucide-react';
+import { useState } from 'react';
+import { FolderSearch, Folder, FolderOpen, File } from 'lucide-react';
 import { extractResultContent } from '../../utils/session-formatters.js';
 import type { ToolExecution } from '../../types/session.js';
 
@@ -6,27 +7,107 @@ interface Props {
   execution: ToolExecution;
 }
 
+export interface TreeNode {
+  name: string;
+  path: string;
+  isFile: boolean;
+  children: TreeNode[];
+}
+
+/**
+ * Parse a flat list of file paths into a nested tree structure.
+ */
+export function buildFileTree(files: string[]): TreeNode[] {
+  const root: TreeNode = { name: '', path: '', isFile: false, children: [] };
+
+  for (const filePath of files) {
+    const parts = filePath.replace(/^\//, '').split('/');
+    let current = root;
+
+    for (let i = 0; i < parts.length; i++) {
+      const part = parts[i];
+      const isFile = i === parts.length - 1;
+      const path = parts.slice(0, i + 1).join('/');
+
+      let existing = current.children.find((c) => c.name === part);
+      if (!existing) {
+        existing = { name: part, path, isFile, children: [] };
+        current.children.push(existing);
+      }
+      current = existing;
+    }
+  }
+
+  return root.children;
+}
+
+interface TreeNodeViewProps {
+  node: TreeNode;
+  depth: number;
+}
+
+function TreeNodeView({ node, depth }: TreeNodeViewProps) {
+  const [open, setOpen] = useState(true);
+
+  if (node.isFile) {
+    return (
+      <div
+        className="flex items-center gap-1 py-0.5 text-xs font-mono text-slate-700"
+        style={{ paddingLeft: `${depth * 12}px` }}
+      >
+        <File className="w-3 h-3 shrink-0 text-slate-400" />
+        <span>{node.name}</span>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <button
+        className="flex items-center gap-1 py-0.5 text-xs font-mono text-slate-600 hover:text-slate-900 w-full text-left"
+        style={{ paddingLeft: `${depth * 12}px` }}
+        onClick={() => setOpen((o) => !o)}
+      >
+        {open ? (
+          <FolderOpen className="w-3 h-3 shrink-0 text-amber-500" />
+        ) : (
+          <Folder className="w-3 h-3 shrink-0 text-amber-500" />
+        )}
+        <span>{node.name}/</span>
+      </button>
+      {open &&
+        node.children.map((child) => (
+          <TreeNodeView key={child.path} node={child} depth={depth + 1} />
+        ))}
+    </div>
+  );
+}
+
 export function GlobRenderer({ execution }: Props) {
   const { input } = execution;
   const pattern = input.pattern as string | undefined;
 
   const output = extractResultContent(execution.result);
-
   const files = output ? output.split('\n').filter(Boolean) : [];
+  const tree = buildFileTree(files);
 
   return (
     <div className="space-y-2 text-sm">
-      {pattern && (
-        <div className="flex items-center gap-2 text-slate-600">
-          <FolderSearch className="w-4 h-4" />
+      <div className="flex items-center gap-2 text-slate-600">
+        <FolderSearch className="w-4 h-4" />
+        {pattern && (
           <code className="text-xs font-mono bg-slate-100 px-2 py-0.5 rounded">{pattern}</code>
-          <span className="text-xs text-slate-400">{files.length} files</span>
-        </div>
-      )}
+        )}
+        <span className="text-xs text-slate-400">
+          {files.length === 0
+            ? 'No files matched'
+            : `${files.length} file${files.length === 1 ? '' : 's'} matched`}
+        </span>
+      </div>
       {files.length > 0 && (
-        <div className="bg-slate-50 rounded-lg p-3 max-h-48 overflow-y-auto">
-          {files.map((file, i) => (
-            <div key={i} className="text-xs font-mono text-slate-700 py-0.5">{file}</div>
+        <div className="bg-slate-50 rounded-lg p-3 max-h-64 overflow-y-auto">
+          {tree.map((node) => (
+            <TreeNodeView key={node.path} node={node} depth={0} />
           ))}
         </div>
       )}

--- a/tools/web-server/src/client/components/tools/GrepRenderer.tsx
+++ b/tools/web-server/src/client/components/tools/GrepRenderer.tsx
@@ -1,9 +1,162 @@
-import { Search } from 'lucide-react';
+import { useState } from 'react';
+import { ChevronDown, ChevronRight, Search } from 'lucide-react';
 import { extractResultContent } from '../../utils/session-formatters.js';
 import type { ToolExecution } from '../../types/session.js';
 
 interface Props {
   execution: ToolExecution;
+}
+
+export interface GrepMatch {
+  lineNumber: number | null;
+  text: string;
+}
+
+export interface GrepFileGroup {
+  filePath: string;
+  matches: GrepMatch[];
+}
+
+/**
+ * Parse a single grep output line in `file:line:content` or `file:content` format.
+ * Lines that don't contain a colon are treated as plain text (no file grouping).
+ * Returns null for lines that cannot be parsed into a file group.
+ */
+export function parseGrepLine(line: string): { filePath: string; lineNumber: number | null; text: string } | null {
+  if (!line) return null;
+
+  // Try file:linenum:content format (ripgrep default with -n)
+  const withLineNum = line.match(/^([^:]+):(\d+):(.*)$/);
+  if (withLineNum) {
+    return {
+      filePath: withLineNum[1],
+      lineNumber: parseInt(withLineNum[2], 10),
+      text: withLineNum[3],
+    };
+  }
+
+  // Try file:content format (no line numbers)
+  const withoutLineNum = line.match(/^([^:]+):(.+)$/);
+  if (withoutLineNum) {
+    return {
+      filePath: withoutLineNum[1],
+      lineNumber: null,
+      text: withoutLineNum[2],
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Group grep output lines into per-file match groups.
+ * Lines that can't be attributed to a file are collected under an empty-string key.
+ */
+export function groupGrepMatches(lines: string[]): GrepFileGroup[] {
+  const map = new Map<string, GrepMatch[]>();
+  const order: string[] = [];
+
+  for (const line of lines) {
+    const parsed = parseGrepLine(line);
+    if (parsed) {
+      if (!map.has(parsed.filePath)) {
+        map.set(parsed.filePath, []);
+        order.push(parsed.filePath);
+      }
+      map.get(parsed.filePath)!.push({ lineNumber: parsed.lineNumber, text: parsed.text });
+    } else {
+      // Unattributed line — group under empty string
+      if (!map.has('')) {
+        map.set('', []);
+        order.push('');
+      }
+      map.get('')!.push({ lineNumber: null, text: line });
+    }
+  }
+
+  return order.map((filePath) => ({ filePath, matches: map.get(filePath)! }));
+}
+
+/**
+ * Split text around occurrences of `term` (case-insensitive) for highlighting.
+ * Returns an array of { text, highlight } segments.
+ */
+export function splitForHighlight(text: string, term: string): Array<{ text: string; highlight: boolean }> {
+  if (!term) return [{ text, highlight: false }];
+
+  const escaped = term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const regex = new RegExp(`(${escaped})`, 'gi');
+  const parts = text.split(regex);
+
+  return parts.map((part) => ({
+    text: part,
+    highlight: regex.test(part),
+  }));
+}
+
+function HighlightedText({ text, term }: { text: string; term: string }) {
+  const parts = splitForHighlight(text, term);
+  return (
+    <>
+      {parts.map((part, i) =>
+        part.highlight ? (
+          <mark key={i} className="bg-yellow-200 text-yellow-900 rounded px-0.5 font-semibold">
+            {part.text}
+          </mark>
+        ) : (
+          <span key={i}>{part.text}</span>
+        ),
+      )}
+    </>
+  );
+}
+
+function FileGroup({ group, pattern }: { group: GrepFileGroup; pattern: string }) {
+  const [open, setOpen] = useState(true);
+  const fileName = group.filePath
+    ? group.filePath.split('/').pop() || group.filePath
+    : '(unattributed)';
+  const dirPath = group.filePath.includes('/')
+    ? group.filePath.slice(0, group.filePath.lastIndexOf('/') + 1)
+    : '';
+
+  return (
+    <div className="border border-slate-200 rounded-lg overflow-hidden">
+      <button
+        onClick={() => setOpen((v) => !v)}
+        className="w-full flex items-center gap-2 px-3 py-2 bg-slate-100 hover:bg-slate-200 text-left transition-colors"
+      >
+        {open ? (
+          <ChevronDown className="w-3.5 h-3.5 text-slate-500 flex-shrink-0" />
+        ) : (
+          <ChevronRight className="w-3.5 h-3.5 text-slate-500 flex-shrink-0" />
+        )}
+        <span className="text-xs font-mono">
+          {dirPath && <span className="text-slate-400">{dirPath}</span>}
+          <span className="text-slate-700 font-semibold">{fileName}</span>
+        </span>
+        <span className="ml-auto text-xs text-slate-400 flex-shrink-0">
+          {group.matches.length} {group.matches.length === 1 ? 'match' : 'matches'}
+        </span>
+      </button>
+      {open && (
+        <div className="divide-y divide-slate-100">
+          {group.matches.map((match, i) => (
+            <div key={i} className="flex items-start gap-0 text-xs font-mono px-0">
+              {match.lineNumber !== null && (
+                <span className="w-10 flex-shrink-0 text-right text-slate-400 select-none px-2 py-1 bg-slate-50 border-r border-slate-200">
+                  {match.lineNumber}
+                </span>
+              )}
+              <span className="px-3 py-1 text-slate-700 break-all">
+                <HighlightedText text={match.text} term={pattern} />
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
 }
 
 export function GrepRenderer({ execution }: Props) {
@@ -12,25 +165,34 @@ export function GrepRenderer({ execution }: Props) {
   const glob = input.glob as string | undefined;
 
   const output = extractResultContent(execution.result);
-
   const lines = output ? output.split('\n').filter(Boolean) : [];
+  const groups = groupGrepMatches(lines);
+  const totalMatches = groups.reduce((sum, g) => sum + g.matches.length, 0);
+  const fileCount = groups.filter((g) => g.filePath !== '').length;
 
   return (
     <div className="space-y-2 text-sm">
       <div className="flex items-center gap-2 text-slate-600">
-        <Search className="w-4 h-4" />
+        <Search className="w-4 h-4 flex-shrink-0" />
         {pattern && (
           <code className="text-xs font-mono bg-slate-100 px-2 py-0.5 rounded">"{pattern}"</code>
         )}
         {glob && <span className="text-xs text-slate-400">in {glob}</span>}
-        <span className="text-xs text-slate-400">{lines.length} matches</span>
+        {lines.length === 0 ? (
+          <span className="text-xs text-slate-400">No matches found</span>
+        ) : (
+          <span className="text-xs text-slate-400">
+            {totalMatches} {totalMatches === 1 ? 'match' : 'matches'}
+            {fileCount > 0 && ` in ${fileCount} ${fileCount === 1 ? 'file' : 'files'}`}
+          </span>
+        )}
       </div>
-      {lines.length > 0 && (
-        <pre className="bg-slate-50 rounded-lg p-3 text-xs font-mono overflow-x-auto max-h-48 overflow-y-auto">
-          {lines.map((line, i) => (
-            <div key={i} className="text-slate-700 py-0.5">{line}</div>
+      {groups.length > 0 && (
+        <div className="space-y-1 max-h-96 overflow-y-auto">
+          {groups.map((group, i) => (
+            <FileGroup key={i} group={group} pattern={pattern ?? ''} />
           ))}
-        </pre>
+        </div>
       )}
     </div>
   );

--- a/tools/web-server/src/client/components/tools/TaskRenderers.tsx
+++ b/tools/web-server/src/client/components/tools/TaskRenderers.tsx
@@ -1,0 +1,276 @@
+import { CheckSquare, RefreshCw, List, Eye } from 'lucide-react';
+import { extractResultContent } from '../../utils/session-formatters.js';
+import type { ToolExecution } from '../../types/session.js';
+
+interface Props {
+  execution: ToolExecution;
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+type TaskStatus = string;
+
+const STATUS_STYLES: Record<string, string> = {
+  pending: 'bg-slate-100 text-slate-600',
+  in_progress: 'bg-blue-100 text-blue-700',
+  completed: 'bg-green-100 text-green-700',
+  done: 'bg-green-100 text-green-700',
+  failed: 'bg-red-100 text-red-700',
+  cancelled: 'bg-slate-100 text-slate-500',
+  blocked: 'bg-amber-100 text-amber-700',
+};
+
+function StatusBadge({ status }: { status: TaskStatus }) {
+  const cls = STATUS_STYLES[status?.toLowerCase()] ?? 'bg-slate-100 text-slate-600';
+  return (
+    <span className={`inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium ${cls}`}>
+      {status}
+    </span>
+  );
+}
+
+function truncate(s: string, max: number): string {
+  return s.length <= max ? s : s.slice(0, max - 1) + '\u2026';
+}
+
+function tryParseJson(content: string): unknown {
+  try {
+    return JSON.parse(content);
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// TaskCreate
+// ---------------------------------------------------------------------------
+
+export function TaskCreateRenderer({ execution }: Props) {
+  const { input } = execution;
+  const subject = (input.subject as string) ?? '';
+  const description = (input.description as string) ?? '';
+
+  return (
+    <div className="space-y-2 text-sm">
+      <div className="flex items-center gap-2 text-slate-600">
+        <CheckSquare className="w-4 h-4 shrink-0 text-blue-500" />
+        <span className="text-xs font-medium text-slate-800">{subject || 'New task'}</span>
+        <StatusBadge status="pending" />
+      </div>
+      {description && (
+        <div className="text-xs text-slate-500 pl-6 italic">
+          {truncate(description, 200)}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// TaskUpdate
+// ---------------------------------------------------------------------------
+
+interface UpdateField {
+  label: string;
+  value: string;
+}
+
+export function TaskUpdateRenderer({ execution }: Props) {
+  const { input } = execution;
+  const taskId = (input.taskId as string) ?? (input.task_id as string) ?? '';
+  const newStatus = input.status as string | undefined;
+  const newSubject = input.subject as string | undefined;
+
+  const fields: UpdateField[] = [];
+  if (newSubject) fields.push({ label: 'subject', value: newSubject });
+
+  // Collect any other scalar updates besides taskId / status / subject
+  const SKIP = new Set(['taskId', 'task_id', 'status', 'subject']);
+  for (const [k, v] of Object.entries(input)) {
+    if (SKIP.has(k)) continue;
+    if (typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean') {
+      fields.push({ label: k, value: String(v) });
+    }
+  }
+
+  return (
+    <div className="space-y-2 text-sm">
+      <div className="flex items-center gap-2 text-slate-600">
+        <RefreshCw className="w-4 h-4 shrink-0 text-amber-500" />
+        <span className="text-xs font-medium text-slate-700">
+          Task {taskId ? `#${taskId}` : ''}
+        </span>
+        {newStatus && <StatusBadge status={newStatus} />}
+      </div>
+      {fields.length > 0 && (
+        <div className="pl-6 space-y-1">
+          {fields.map((f) => (
+            <div key={f.label} className="flex gap-1 text-xs">
+              <span className="text-slate-400 font-mono">{f.label}:</span>
+              <span className="text-slate-700">{truncate(f.value, 100)}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// TaskList
+// ---------------------------------------------------------------------------
+
+interface TaskItem {
+  id?: string | number;
+  subject?: string;
+  title?: string;
+  status?: string;
+}
+
+function parseTaskList(content: string): TaskItem[] | null {
+  const parsed = tryParseJson(content);
+  if (Array.isArray(parsed)) {
+    return parsed as TaskItem[];
+  }
+  if (parsed && typeof parsed === 'object') {
+    const obj = parsed as Record<string, unknown>;
+    // Common wrapper shapes: { tasks: [...] } or { items: [...] }
+    const arr = obj.tasks ?? obj.items ?? obj.data;
+    if (Array.isArray(arr)) return arr as TaskItem[];
+  }
+  return null;
+}
+
+export function TaskListRenderer({ execution }: Props) {
+  const content = extractResultContent(execution.result);
+  const isError = execution.result?.isError ?? false;
+
+  const tasks = content ? parseTaskList(content) : null;
+
+  return (
+    <div className="space-y-2 text-sm">
+      <div className="flex items-center gap-2 text-slate-600">
+        <List className="w-4 h-4 shrink-0 text-slate-500" />
+        <span className="text-xs font-medium text-slate-700">
+          {tasks ? `${tasks.length} task${tasks.length !== 1 ? 's' : ''}` : 'Task list'}
+        </span>
+      </div>
+
+      {tasks ? (
+        <div className="pl-6 space-y-1">
+          {tasks.map((t, i) => {
+            const id = t.id != null ? String(t.id) : null;
+            const label = t.subject ?? t.title ?? `Task ${i + 1}`;
+            return (
+              <div key={i} className="flex items-center gap-2 text-xs">
+                {id && <span className="text-slate-400 font-mono">#{id}</span>}
+                <span className="text-slate-700 flex-1">{truncate(label, 80)}</span>
+                {t.status && <StatusBadge status={t.status} />}
+              </div>
+            );
+          })}
+        </div>
+      ) : content ? (
+        <pre
+          className={`rounded-lg p-3 text-xs font-mono whitespace-pre-wrap overflow-x-auto max-h-48 overflow-y-auto ${
+            isError
+              ? 'bg-red-50 text-red-800 border border-red-200'
+              : 'bg-slate-50 text-slate-800'
+          }`}
+        >
+          {content}
+        </pre>
+      ) : (
+        <div className="text-xs text-slate-400 italic pl-6">No tasks found.</div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// TaskGet
+// ---------------------------------------------------------------------------
+
+interface TaskDetail {
+  id?: string | number;
+  subject?: string;
+  title?: string;
+  description?: string;
+  status?: string;
+  blockedBy?: unknown[];
+  blocks?: unknown[];
+}
+
+function parseTaskDetail(content: string): TaskDetail | null {
+  const parsed = tryParseJson(content);
+  if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+    return parsed as TaskDetail;
+  }
+  return null;
+}
+
+export function TaskGetRenderer({ execution }: Props) {
+  const { input } = execution;
+  const taskIdInput = (input.taskId as string) ?? (input.task_id as string) ?? '';
+  const content = extractResultContent(execution.result);
+  const isError = execution.result?.isError ?? false;
+
+  const detail = content ? parseTaskDetail(content) : null;
+
+  const subject = detail?.subject ?? detail?.title ?? '';
+  const description = detail?.description ?? '';
+  const status = detail?.status ?? '';
+  const blockedBy = Array.isArray(detail?.blockedBy) ? detail!.blockedBy : [];
+  const blocks = Array.isArray(detail?.blocks) ? detail!.blocks : [];
+
+  const displayId = detail?.id != null ? String(detail.id) : taskIdInput;
+
+  return (
+    <div className="space-y-2 text-sm">
+      <div className="flex items-center gap-2 text-slate-600">
+        <Eye className="w-4 h-4 shrink-0 text-slate-500" />
+        <span className="text-xs font-medium text-slate-800">
+          {displayId ? `Task #${displayId}` : 'Task details'}
+        </span>
+        {status && <StatusBadge status={status} />}
+      </div>
+
+      {detail ? (
+        <div className="pl-6 space-y-1.5">
+          {subject && (
+            <div className="text-xs font-semibold text-slate-800">{subject}</div>
+          )}
+          {description && (
+            <div className="text-xs text-slate-500 italic">{truncate(description, 300)}</div>
+          )}
+          {blockedBy.length > 0 && (
+            <div className="text-xs text-slate-500">
+              <span className="text-slate-400">blocked by:</span>{' '}
+              {blockedBy.map((b) => (typeof b === 'object' ? JSON.stringify(b) : String(b))).join(', ')}
+            </div>
+          )}
+          {blocks.length > 0 && (
+            <div className="text-xs text-slate-500">
+              <span className="text-slate-400">blocks:</span>{' '}
+              {blocks.map((b) => (typeof b === 'object' ? JSON.stringify(b) : String(b))).join(', ')}
+            </div>
+          )}
+        </div>
+      ) : content ? (
+        <pre
+          className={`rounded-lg p-3 text-xs font-mono whitespace-pre-wrap overflow-x-auto max-h-48 overflow-y-auto ${
+            isError
+              ? 'bg-red-50 text-red-800 border border-red-200'
+              : 'bg-slate-50 text-slate-800'
+          }`}
+        >
+          {content}
+        </pre>
+      ) : (
+        <div className="text-xs text-slate-400 italic pl-6">No task data returned.</div>
+      )}
+    </div>
+  );
+}

--- a/tools/web-server/src/client/components/tools/WebSearchRenderer.tsx
+++ b/tools/web-server/src/client/components/tools/WebSearchRenderer.tsx
@@ -1,0 +1,100 @@
+import { Search } from 'lucide-react';
+import { extractResultContent } from '../../utils/session-formatters.js';
+import type { ToolExecution } from '../../types/session.js';
+
+interface Props {
+  execution: ToolExecution;
+}
+
+interface SearchResult {
+  title?: string;
+  url?: string;
+  snippet?: string;
+}
+
+function parseResults(content: string): SearchResult[] | null {
+  try {
+    const parsed = JSON.parse(content);
+    if (Array.isArray(parsed)) {
+      const results = parsed as unknown[];
+      const typed = results.filter(
+        (r): r is SearchResult =>
+          typeof r === 'object' &&
+          r !== null &&
+          ('title' in r || 'url' in r || 'snippet' in r),
+      );
+      if (typed.length > 0) return typed;
+    }
+  } catch {
+    // Not JSON — fall through
+  }
+  return null;
+}
+
+export function WebSearchRenderer({ execution }: Props) {
+  const { input, result } = execution;
+  const query = (input.query as string) ?? '';
+  const isError = result?.isError ?? false;
+
+  const content = extractResultContent(result);
+  const structuredResults = content ? parseResults(content) : null;
+
+  return (
+    <div className="space-y-2 text-sm">
+      {/* Header: icon + query */}
+      <div className="flex items-center gap-2 text-slate-600">
+        <Search className="w-4 h-4 shrink-0" />
+        {query && (
+          <span className="text-xs font-medium">
+            &ldquo;{query}&rdquo;
+          </span>
+        )}
+        {structuredResults && (
+          <span className="text-xs text-slate-400">
+            {structuredResults.length} result{structuredResults.length !== 1 ? 's' : ''}
+          </span>
+        )}
+      </div>
+
+      {/* Structured results */}
+      {structuredResults ? (
+        <div className="space-y-2 pl-6">
+          {structuredResults.map((r, i) => (
+            <div key={i} className="border-l-2 border-slate-200 pl-3 space-y-0.5">
+              {r.title && (
+                <div className="text-xs font-semibold text-slate-800">{r.title}</div>
+              )}
+              {r.url && (
+                <a
+                  href={r.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-xs text-blue-600 hover:underline truncate block"
+                  title={r.url}
+                >
+                  {r.url}
+                </a>
+              )}
+              {r.snippet && (
+                <div className="text-xs text-slate-600">{r.snippet}</div>
+              )}
+            </div>
+          ))}
+        </div>
+      ) : content ? (
+        /* Plain text fallback */
+        <pre
+          className={`rounded-lg p-3 text-xs font-mono whitespace-pre-wrap break-words overflow-x-auto max-h-48 overflow-y-auto ${
+            isError
+              ? 'bg-red-50 text-red-800 border border-red-200'
+              : 'bg-slate-50 text-slate-800'
+          }`}
+        >
+          {content}
+        </pre>
+      ) : (
+        <div className="text-xs text-slate-400 italic pl-6">No results returned.</div>
+      )}
+    </div>
+  );
+}

--- a/tools/web-server/src/client/components/tools/index.ts
+++ b/tools/web-server/src/client/components/tools/index.ts
@@ -9,6 +9,13 @@ import { GrepRenderer } from './GrepRenderer.js';
 import { SkillRenderer } from './SkillRenderer.js';
 import { WebFetchRenderer } from './WebFetchRenderer.js';
 import { NotebookEditRenderer } from './NotebookEditRenderer.js';
+import { WebSearchRenderer } from './WebSearchRenderer.js';
+import {
+  TaskCreateRenderer,
+  TaskUpdateRenderer,
+  TaskListRenderer,
+  TaskGetRenderer,
+} from './TaskRenderers.js';
 import { DefaultRenderer } from './DefaultRenderer.js';
 
 type ToolRendererComponent = ComponentType<{ execution: ToolExecution }>;
@@ -23,7 +30,11 @@ const rendererMap: Record<string, ToolRendererComponent> = {
   Skill: SkillRenderer,
   NotebookEdit: NotebookEditRenderer,
   WebFetch: WebFetchRenderer,
-  WebSearch: DefaultRenderer,
+  WebSearch: WebSearchRenderer,
+  TaskCreate: TaskCreateRenderer,
+  TaskUpdate: TaskUpdateRenderer,
+  TaskList: TaskListRenderer,
+  TaskGet: TaskGetRenderer,
 };
 
 export function getToolRenderer(toolName: string): ToolRendererComponent {

--- a/tools/web-server/tests/client/components/tools/GlobRenderer.test.ts
+++ b/tools/web-server/tests/client/components/tools/GlobRenderer.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { buildFileTree } from '../../../../src/client/components/tools/GlobRenderer.js';
+
+describe('buildFileTree', () => {
+  it('returns empty array for empty input', () => {
+    expect(buildFileTree([])).toEqual([]);
+  });
+
+  it('returns a single file at root level', () => {
+    const tree = buildFileTree(['file.ts']);
+    expect(tree).toHaveLength(1);
+    expect(tree[0]).toMatchObject({ name: 'file.ts', isFile: true, children: [] });
+  });
+
+  it('groups files under a shared directory', () => {
+    const tree = buildFileTree(['src/a.ts', 'src/b.ts']);
+    expect(tree).toHaveLength(1);
+    const src = tree[0];
+    expect(src.name).toBe('src');
+    expect(src.isFile).toBe(false);
+    expect(src.children).toHaveLength(2);
+    expect(src.children.map((c) => c.name)).toEqual(['a.ts', 'b.ts']);
+  });
+
+  it('handles deeply nested paths', () => {
+    const tree = buildFileTree(['a/b/c/deep.ts']);
+    expect(tree[0].name).toBe('a');
+    expect(tree[0].children[0].name).toBe('b');
+    expect(tree[0].children[0].children[0].name).toBe('c');
+    expect(tree[0].children[0].children[0].children[0]).toMatchObject({
+      name: 'deep.ts',
+      isFile: true,
+    });
+  });
+
+  it('merges common directory prefixes', () => {
+    const tree = buildFileTree(['src/utils/foo.ts', 'src/utils/bar.ts', 'src/index.ts']);
+    expect(tree).toHaveLength(1);
+    const src = tree[0];
+    expect(src.name).toBe('src');
+    // Should have utils/ dir and index.ts
+    const names = src.children.map((c) => c.name).sort();
+    expect(names).toEqual(['index.ts', 'utils']);
+    const utils = src.children.find((c) => c.name === 'utils')!;
+    expect(utils.isFile).toBe(false);
+    expect(utils.children).toHaveLength(2);
+  });
+
+  it('handles files with leading slash', () => {
+    const tree = buildFileTree(['/src/main.ts']);
+    expect(tree[0].name).toBe('src');
+    expect(tree[0].children[0].name).toBe('main.ts');
+  });
+
+  it('handles multiple top-level directories', () => {
+    const tree = buildFileTree(['src/a.ts', 'tests/b.test.ts']);
+    const names = tree.map((n) => n.name).sort();
+    expect(names).toEqual(['src', 'tests']);
+  });
+
+  it('does not duplicate nodes for repeated paths', () => {
+    const tree = buildFileTree(['src/a.ts', 'src/b.ts', 'src/c.ts']);
+    expect(tree).toHaveLength(1);
+    expect(tree[0].children).toHaveLength(3);
+  });
+
+  it('marks directories as non-file nodes', () => {
+    const tree = buildFileTree(['dir/file.ts']);
+    expect(tree[0].isFile).toBe(false);
+    expect(tree[0].children[0].isFile).toBe(true);
+  });
+
+  it('sets correct path on each node', () => {
+    const tree = buildFileTree(['a/b/c.ts']);
+    expect(tree[0].path).toBe('a');
+    expect(tree[0].children[0].path).toBe('a/b');
+    expect(tree[0].children[0].children[0].path).toBe('a/b/c.ts');
+  });
+});

--- a/tools/web-server/tests/client/components/tools/GrepRenderer.test.ts
+++ b/tools/web-server/tests/client/components/tools/GrepRenderer.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseGrepLine,
+  groupGrepMatches,
+  splitForHighlight,
+} from '../../../../src/client/components/tools/GrepRenderer.js';
+
+describe('parseGrepLine', () => {
+  it('parses file:linenum:content format', () => {
+    const result = parseGrepLine('src/foo.ts:42:  const x = 1;');
+    expect(result).toEqual({ filePath: 'src/foo.ts', lineNumber: 42, text: '  const x = 1;' });
+  });
+
+  it('parses file:content format (no line number)', () => {
+    const result = parseGrepLine('src/foo.ts:some match text');
+    expect(result).toEqual({ filePath: 'src/foo.ts', lineNumber: null, text: 'some match text' });
+  });
+
+  it('returns null for empty string', () => {
+    expect(parseGrepLine('')).toBeNull();
+  });
+
+  it('handles content with colons after the line number', () => {
+    const result = parseGrepLine('path/to/file.ts:10:http://example.com');
+    expect(result).toEqual({
+      filePath: 'path/to/file.ts',
+      lineNumber: 10,
+      text: 'http://example.com',
+    });
+  });
+
+  it('parses nested path with line number', () => {
+    const result = parseGrepLine('a/b/c/d.js:1:export default {}');
+    expect(result).toEqual({ filePath: 'a/b/c/d.js', lineNumber: 1, text: 'export default {}' });
+  });
+});
+
+describe('groupGrepMatches', () => {
+  it('returns empty array for empty input', () => {
+    expect(groupGrepMatches([])).toEqual([]);
+  });
+
+  it('groups matches by file path', () => {
+    const lines = [
+      'src/a.ts:1:match one',
+      'src/b.ts:5:match two',
+      'src/a.ts:10:match three',
+    ];
+    const groups = groupGrepMatches(lines);
+    expect(groups).toHaveLength(2);
+    expect(groups[0].filePath).toBe('src/a.ts');
+    expect(groups[0].matches).toHaveLength(2);
+    expect(groups[1].filePath).toBe('src/b.ts');
+    expect(groups[1].matches).toHaveLength(1);
+  });
+
+  it('preserves insertion order for file groups', () => {
+    const lines = [
+      'z.ts:1:first',
+      'a.ts:2:second',
+      'z.ts:3:third',
+    ];
+    const groups = groupGrepMatches(lines);
+    expect(groups[0].filePath).toBe('z.ts');
+    expect(groups[1].filePath).toBe('a.ts');
+  });
+
+  it('collects unparseable lines under empty-string key', () => {
+    const lines = ['plaintext line with no colon'];
+    const groups = groupGrepMatches(lines);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].filePath).toBe('');
+    expect(groups[0].matches[0].text).toBe('plaintext line with no colon');
+  });
+
+  it('includes correct line numbers in matches', () => {
+    const lines = ['src/foo.ts:7:  return value;'];
+    const groups = groupGrepMatches(lines);
+    expect(groups[0].matches[0].lineNumber).toBe(7);
+    expect(groups[0].matches[0].text).toBe('  return value;');
+  });
+
+  it('handles multiple files with multiple matches each', () => {
+    const lines = [
+      'x.ts:1:alpha',
+      'x.ts:2:beta',
+      'y.ts:3:gamma',
+      'y.ts:4:delta',
+      'y.ts:5:epsilon',
+    ];
+    const groups = groupGrepMatches(lines);
+    expect(groups).toHaveLength(2);
+    expect(groups[0].matches).toHaveLength(2);
+    expect(groups[1].matches).toHaveLength(3);
+  });
+});
+
+describe('splitForHighlight', () => {
+  it('returns single non-highlighted segment when term is empty', () => {
+    const parts = splitForHighlight('hello world', '');
+    expect(parts).toEqual([{ text: 'hello world', highlight: false }]);
+  });
+
+  it('highlights a single occurrence', () => {
+    const parts = splitForHighlight('foo bar baz', 'bar');
+    const highlighted = parts.filter((p) => p.highlight);
+    expect(highlighted).toHaveLength(1);
+    expect(highlighted[0].text).toBe('bar');
+  });
+
+  it('highlights multiple occurrences', () => {
+    const parts = splitForHighlight('foo foo foo', 'foo');
+    const highlighted = parts.filter((p) => p.highlight);
+    expect(highlighted).toHaveLength(3);
+  });
+
+  it('is case-insensitive', () => {
+    const parts = splitForHighlight('Hello HELLO hello', 'hello');
+    const highlighted = parts.filter((p) => p.highlight);
+    expect(highlighted).toHaveLength(3);
+  });
+
+  it('returns non-highlighted segment when term not found', () => {
+    const parts = splitForHighlight('hello world', 'xyz');
+    expect(parts).toEqual([{ text: 'hello world', highlight: false }]);
+  });
+
+  it('handles regex special characters in term', () => {
+    const parts = splitForHighlight('price is $5.00', '$5.00');
+    const highlighted = parts.filter((p) => p.highlight);
+    expect(highlighted).toHaveLength(1);
+    expect(highlighted[0].text).toBe('$5.00');
+  });
+
+  it('returns empty segments correctly for match at start', () => {
+    const parts = splitForHighlight('foobar', 'foo');
+    // split with capture group produces ['', 'foo', 'bar'] — first highlighted segment is at index 1
+    const highlighted = parts.filter((p) => p.highlight);
+    expect(highlighted[0]).toMatchObject({ highlight: true, text: 'foo' });
+  });
+
+  it('returns empty segments correctly for match at end', () => {
+    const parts = splitForHighlight('foobar', 'bar');
+    const highlighted = parts.filter((p) => p.highlight);
+    expect(highlighted[0]).toMatchObject({ text: 'bar' });
+  });
+});


### PR DESCRIPTION
## Summary

All four parallel renderer improvements landed on this branch (MW-1, MW-2, MW-4, LW-1 from Issue #31):

**GlobRenderer — directory tree view (MW-2)**
- Replaces flat file list with indented collapsible directory tree
- Exports `buildFileTree` utility; shows folder/file icons with Lucide
- File count header and empty state

**GrepRenderer — grouped-by-file with match highlighting (MW-1)**
- Replaces flat match list with file-grouped sections
- Line numbers and highlighted match text per file
- Match count + file count header

**WebSearchRenderer (MW-4)**
- Purpose-built renderer for WebSearch tool calls
- Shows query and structured result list (title, URL, snippet)

**Task tool renderers — TaskCreate, TaskUpdate, TaskList, TaskGet (LW-1)**
- Self-contained renderers for all four Task tools
- Show task subject, status badges, description, status transitions
- Replace DefaultRenderer generic fallback

## Verification

- Tests pass (10 new GlobRenderer unit tests included)
- Lint clean

Part of Issue #31 (tool renderer audit).