### PR TITLE
feat(ui): TaskUpdate renderer status transition display

### DIFF
--- a/tools/web-server/src/client/components/tools/TaskRenderers.tsx
+++ b/tools/web-server/src/client/components/tools/TaskRenderers.tsx
@@ -43,6 +43,26 @@ function tryParseJson(content: string): unknown {
   }
 }
 
+/**
+ * Extract the previous task status from a TaskUpdate result content string.
+ *
+ * When the TaskUpdate tool returns the prior task state as JSON (e.g.
+ * `{"id":"42","status":"pending",...}`), this function pulls out the
+ * `status` field so the renderer can display a transition arrow.
+ *
+ * Returns `null` if the content is absent, unparseable, or has no `status`.
+ */
+export function extractPreviousStatus(content: string | null | undefined): string | null {
+  if (!content) return null;
+  const parsed = tryParseJson(content);
+  if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+    const obj = parsed as Record<string, unknown>;
+    const status = obj.status;
+    if (typeof status === 'string' && status.length > 0) return status;
+  }
+  return null;
+}
+
 // ---------------------------------------------------------------------------
 // TaskCreate
 // ---------------------------------------------------------------------------
@@ -83,6 +103,16 @@ export function TaskUpdateRenderer({ execution }: Props) {
   const newStatus = input.status as string | undefined;
   const newSubject = input.subject as string | undefined;
 
+  // Attempt to read the previous status from the result content.
+  const resultContent = extractResultContent(execution.result);
+  const previousStatus = extractPreviousStatus(resultContent);
+
+  // Show a transition when: both old and new status are known and they differ.
+  const showTransition =
+    newStatus != null &&
+    previousStatus != null &&
+    previousStatus.toLowerCase() !== newStatus.toLowerCase();
+
   const fields: UpdateField[] = [];
   if (newSubject) fields.push({ label: 'subject', value: newSubject });
 
@@ -102,7 +132,15 @@ export function TaskUpdateRenderer({ execution }: Props) {
         <span className="text-xs font-medium text-slate-700">
           Task {taskId ? `#${taskId}` : ''}
         </span>
-        {newStatus && <StatusBadge status={newStatus} />}
+        {showTransition ? (
+          <>
+            <StatusBadge status={previousStatus!} />
+            <span className="text-slate-400 text-xs">&rarr;</span>
+            <StatusBadge status={newStatus!} />
+          </>
+        ) : (
+          newStatus && <StatusBadge status={newStatus} />
+        )}
       </div>
       {fields.length > 0 && (
         <div className="pl-6 space-y-1">

--- a/tools/web-server/tests/client/components/tools/TaskRenderers.test.ts
+++ b/tools/web-server/tests/client/components/tools/TaskRenderers.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { extractPreviousStatus } from '../../../../src/client/components/tools/TaskRenderers.js';
+
+describe('extractPreviousStatus', () => {
+  it('returns the status from a JSON object string', () => {
+    const content = JSON.stringify({ id: '42', status: 'pending', subject: 'Fix bug' });
+    expect(extractPreviousStatus(content)).toBe('pending');
+  });
+
+  it('returns null for null input', () => {
+    expect(extractPreviousStatus(null)).toBeNull();
+  });
+
+  it('returns null for undefined input', () => {
+    expect(extractPreviousStatus(undefined)).toBeNull();
+  });
+
+  it('returns null for empty string', () => {
+    expect(extractPreviousStatus('')).toBeNull();
+  });
+
+  it('returns null for non-JSON string', () => {
+    expect(extractPreviousStatus('Task updated successfully')).toBeNull();
+  });
+
+  it('returns null when parsed JSON has no status field', () => {
+    const content = JSON.stringify({ id: '42', subject: 'No status here' });
+    expect(extractPreviousStatus(content)).toBeNull();
+  });
+
+  it('returns null when status field is not a string', () => {
+    const content = JSON.stringify({ id: '42', status: 3 });
+    expect(extractPreviousStatus(content)).toBeNull();
+  });
+
+  it('returns null when status is an empty string', () => {
+    const content = JSON.stringify({ id: '42', status: '' });
+    expect(extractPreviousStatus(content)).toBeNull();
+  });
+
+  it('returns null for a JSON array', () => {
+    const content = JSON.stringify([{ status: 'pending' }]);
+    expect(extractPreviousStatus(content)).toBeNull();
+  });
+
+  it('handles in_progress status', () => {
+    const content = JSON.stringify({ id: '7', status: 'in_progress' });
+    expect(extractPreviousStatus(content)).toBe('in_progress');
+  });
+
+  it('handles completed status', () => {
+    const content = JSON.stringify({ id: '1', status: 'completed', subject: 'Done' });
+    expect(extractPreviousStatus(content)).toBe('completed');
+  });
+
+  it('handles blocked status', () => {
+    const content = JSON.stringify({ status: 'blocked' });
+    expect(extractPreviousStatus(content)).toBe('blocked');
+  });
+
+  it('handles failed status', () => {
+    const content = JSON.stringify({ status: 'failed' });
+    expect(extractPreviousStatus(content)).toBe('failed');
+  });
+});


### PR DESCRIPTION
## Summary

- Exports `extractPreviousStatus()` pure function from `TaskRenderers.tsx` — parses the prior task state from a `TaskUpdate` result content JSON string
- `TaskUpdateRenderer` now shows coloured `StatusBadge → StatusBadge` when old and new statuses differ (e.g. `pending → in_progress`)
- Falls back gracefully to showing only the new status badge when no previous status is available
- Self-contained — reads only from the single `ToolExecution` object

## Verification

- 13 new unit tests covering all status values and edge cases
- 906 tests total pass
- Lint clean

Part of Issue #31 (LW-2).