### PR TITLE
perf(ui): optimize session viewer rendering for long sessions (#32)

### DIFF
--- a/tools/web-server/src/client/components/chat/AIChatGroup.tsx
+++ b/tools/web-server/src/client/components/chat/AIChatGroup.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, memo } from 'react';
 import { Bot, ChevronRight, Clock } from 'lucide-react';
 import { enhanceAIGroup } from '../../utils/ai-group-enhancer.js';
 import { DisplayItemList } from './DisplayItemList.js';
@@ -27,7 +27,7 @@ const MODEL_COLORS: Record<string, string> = {
   haiku: 'text-emerald-700 bg-emerald-100',
 };
 
-export function AIChatGroup({ aiGroup, contextStats, totalPhases, precedingSlash, claudeMdStats }: Props) {
+export const AIChatGroup = memo(function AIChatGroup({ aiGroup, contextStats, totalPhases, precedingSlash, claudeMdStats }: Props) {
   const expanded = useSessionViewStore((s) => s.expandedGroups.has(aiGroup.id));
   const toggleGroup = useSessionViewStore((s) => s.toggleGroup);
 
@@ -101,7 +101,7 @@ export function AIChatGroup({ aiGroup, contextStats, totalPhases, precedingSlash
       </div>
     </div>
   );
-}
+});
 
 function categoryBreakdown(stats: ContextStats) {
   const cats = stats.turnTokens;

--- a/tools/web-server/src/client/components/chat/ChatHistory.tsx
+++ b/tools/web-server/src/client/components/chat/ChatHistory.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect, useCallback } from 'react';
+import { useRef, useEffect, useCallback, memo } from 'react';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { AIChatGroup } from './AIChatGroup.js';
 import { UserChatGroup } from './UserChatGroup.js';
@@ -79,7 +79,7 @@ function itemKey(item: ChatItem, index: number): string {
   return `${item.type}-${item.group.id}-${index}`;
 }
 
-function ItemRenderer({ item, contextStats, totalPhases }: {
+const ItemRenderer = memo(function ItemRenderer({ item, contextStats, totalPhases }: {
   item: ChatItem;
   contextStats?: Map<string, ContextStats>;
   totalPhases?: number;
@@ -102,7 +102,7 @@ function ItemRenderer({ item, contextStats, totalPhases }: {
     default:
       return null;
   }
-}
+});
 
 function VirtualizedItemList({
   parentRef,

--- a/tools/web-server/src/client/components/chat/CompactBoundary.tsx
+++ b/tools/web-server/src/client/components/chat/CompactBoundary.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, memo } from 'react';
 import { Layers, ChevronRight } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -30,7 +30,7 @@ interface Props {
   compactGroup: CompactGroup;
 }
 
-export function CompactBoundary({ compactGroup }: Props) {
+export const CompactBoundary = memo(function CompactBoundary({ compactGroup }: Props) {
   const [expanded, setExpanded] = useState(false);
   const { summary, tokenDelta, startingPhaseNumber, timestamp } = compactGroup;
   const hasSummary = !!summary;
@@ -86,4 +86,4 @@ export function CompactBoundary({ compactGroup }: Props) {
       )}
     </div>
   );
-}
+});

--- a/tools/web-server/src/client/components/chat/DisplayItemList.tsx
+++ b/tools/web-server/src/client/components/chat/DisplayItemList.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import { ThinkingItem } from './items/ThinkingItem.js';
 import { TextItem } from './items/TextItem.js';
 import { LinkedToolItemDisplay } from './items/LinkedToolItemDisplay.js';
@@ -16,7 +17,7 @@ function displayItemKey(item: AIGroupDisplayItem, index: number): string {
   }
 }
 
-export function DisplayItemList({ items }: Props) {
+export const DisplayItemList = memo(function DisplayItemList({ items }: Props) {
   return (
     <div className="space-y-1">
       {items.map((item, i) => (
@@ -24,9 +25,9 @@ export function DisplayItemList({ items }: Props) {
       ))}
     </div>
   );
-}
+});
 
-function DisplayItemRenderer({ item }: { item: AIGroupDisplayItem }) {
+const DisplayItemRenderer = memo(function DisplayItemRenderer({ item }: { item: AIGroupDisplayItem }) {
   switch (item.type) {
     case 'thinking':
       return <ThinkingItem content={item.content} tokenCount={item.tokenCount} />;
@@ -68,4 +69,4 @@ function DisplayItemRenderer({ item }: { item: AIGroupDisplayItem }) {
     default:
       return null;
   }
-}
+});

--- a/tools/web-server/src/client/components/chat/LastOutputDisplay.tsx
+++ b/tools/web-server/src/client/components/chat/LastOutputDisplay.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import { CheckCircle2, FileCheck, XCircle } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -48,7 +49,7 @@ interface Props {
   lastOutput: AIGroupLastOutput | null;
 }
 
-export function LastOutputDisplay({ lastOutput }: Props) {
+export const LastOutputDisplay = memo(function LastOutputDisplay({ lastOutput }: Props) {
   if (!lastOutput) return null;
 
   switch (lastOutput.type) {
@@ -132,4 +133,4 @@ export function LastOutputDisplay({ lastOutput }: Props) {
     default:
       return null;
   }
-}
+});

--- a/tools/web-server/src/client/components/chat/SystemChatGroup.tsx
+++ b/tools/web-server/src/client/components/chat/SystemChatGroup.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import { Terminal } from 'lucide-react';
 import { formatTimestampLong } from '../../utils/session-formatters.js';
 import type { SystemGroup } from '../../types/groups.js';
@@ -6,7 +7,7 @@ interface Props {
   systemGroup: SystemGroup;
 }
 
-export function SystemChatGroup({ systemGroup }: Props) {
+export const SystemChatGroup = memo(function SystemChatGroup({ systemGroup }: Props) {
   const { commandOutput, timestamp } = systemGroup;
   const cleaned = commandOutput.replace(/\x1B\[[0-9;]*m/g, '');
   if (!cleaned.trim()) return null;
@@ -22,4 +23,4 @@ export function SystemChatGroup({ systemGroup }: Props) {
       </div>
     </div>
   );
-}
+});

--- a/tools/web-server/src/client/components/chat/UserChatGroup.tsx
+++ b/tools/web-server/src/client/components/chat/UserChatGroup.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, memo } from 'react';
 import { User } from 'lucide-react';
 import ReactMarkdown, { type Components } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -119,7 +119,7 @@ function createMarkdownComponents(knownPaths: Set<string>): Components {
   };
 }
 
-export function UserChatGroup({ userGroup }: Props) {
+export const UserChatGroup = memo(function UserChatGroup({ userGroup }: Props) {
   const [expanded, setExpanded] = useState(false);
   const { content, timestamp } = userGroup;
   const text = content.rawText ?? content.text ?? '';
@@ -179,4 +179,4 @@ export function UserChatGroup({ userGroup }: Props) {
       </div>
     </div>
   );
-}
+});

--- a/tools/web-server/src/client/components/chat/items/LinkedToolItemDisplay.tsx
+++ b/tools/web-server/src/client/components/chat/items/LinkedToolItemDisplay.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import {
   ChevronRight,
   CheckCircle2,
@@ -67,7 +68,7 @@ function toToolExecution(tool: LinkedToolItemData): ToolExecution {
  * - teammate_spawned renders as a small badge instead of full card.
  * - SendMessage with shutdown intent renders as an inline indicator.
  */
-export function LinkedToolItemDisplay({ tool }: Props) {
+export const LinkedToolItemDisplay = memo(function LinkedToolItemDisplay({ tool }: Props) {
   const expanded = useSessionViewStore((s) => s.expandedTools.has(tool.id));
   const toggleTool = useSessionViewStore((s) => s.toggleTool);
 
@@ -185,4 +186,4 @@ export function LinkedToolItemDisplay({ tool }: Props) {
       )}
     </div>
   );
-}
+});

--- a/tools/web-server/src/client/components/chat/items/SubagentItem.tsx
+++ b/tools/web-server/src/client/components/chat/items/SubagentItem.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useMemo, useState, memo } from 'react';
 import {
   ChevronRight,
   CheckCircle2,
@@ -94,7 +94,7 @@ function extractLastUsage(messages: ParsedMessage[]): UsageMetadata | null {
   return null;
 }
 
-export function SubagentItem({ process, depth = 0 }: Props) {
+export const SubagentItem = memo(function SubagentItem({ process, depth = 0 }: Props) {
   const expanded = useSessionViewStore((s) => s.expandedSubagents.has(process.id));
   const toggleSubagent = useSessionViewStore((s) => s.toggleSubagent);
   const showTrace = useSessionViewStore((s) => s.expandedSubagentTraces.has(process.id));
@@ -323,7 +323,7 @@ export function SubagentItem({ process, depth = 0 }: Props) {
       )}
     </div>
   );
-}
+});
 
 // ─── Execution Trace Item Renderer ───────────────────────────────────────────
 

--- a/tools/web-server/src/client/components/chat/items/TextItem.tsx
+++ b/tools/web-server/src/client/components/chat/items/TextItem.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import type { Components } from 'react-markdown';
@@ -65,7 +66,7 @@ interface Props {
   content: string;
 }
 
-export function TextItem({ content }: Props) {
+export const TextItem = memo(function TextItem({ content }: Props) {
   return (
     <div className="prose prose-sm prose-slate max-w-none">
       <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
@@ -73,4 +74,4 @@ export function TextItem({ content }: Props) {
       </ReactMarkdown>
     </div>
   );
-}
+});

--- a/tools/web-server/src/client/components/chat/items/ThinkingItem.tsx
+++ b/tools/web-server/src/client/components/chat/items/ThinkingItem.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, memo } from 'react';
 import { Brain, ChevronRight } from 'lucide-react';
 import { formatTokenCount } from '../../../utils/session-formatters.js';
 
@@ -7,7 +7,7 @@ interface Props {
   tokenCount?: number;
 }
 
-export function ThinkingItem({ content, tokenCount }: Props) {
+export const ThinkingItem = memo(function ThinkingItem({ content, tokenCount }: Props) {
   const [expanded, setExpanded] = useState(false);
 
   return (
@@ -36,4 +36,4 @@ export function ThinkingItem({ content, tokenCount }: Props) {
       )}
     </div>
   );
-}
+});


### PR DESCRIPTION
## Summary

- Add `React.memo` to all 11 session viewer components to prevent unnecessary re-renders during SSE updates and expand/collapse interactions
- Components already use zustand selectors for expand state, so memo correctly short-circuits when only sibling state changes (e.g., expanding one tool no longer re-renders all other tool cards)
- Virtualization via `@tanstack/react-virtual` was already in place for sessions >120 items; this PR complements it by reducing per-item render cost

### Memoized components
| Layer | Components |
|-------|-----------|
| Chat groups | `AIChatGroup`, `UserChatGroup`, `SystemChatGroup`, `CompactBoundary` |
| Item dispatch | `ItemRenderer` (ChatHistory), `DisplayItemList`, `DisplayItemRenderer` |
| Tool/subagent | `LinkedToolItemDisplay`, `SubagentItem` |
| Leaf items | `ThinkingItem`, `TextItem`, `LastOutputDisplay` |

### What this does NOT include (next steps)
- **Progressive/batched rendering** for initial load of very large sessions
- **Lowering the virtualization threshold** (currently 120) -- could be tuned lower
- Tool call details are already lazy-rendered (only when expanded), so no change needed there

## Test plan
- [x] `npm run verify` passes (lint + 910 tests)
- [x] No changes to component APIs or behavior -- memo is transparent
- [ ] Manual: open a long session (500+ chunks), verify smooth scrolling and responsive expand/collapse

🤖 Generated with [Claude Code](https://claude.com/claude-code)