### PR TITLE
fix(ui): mobile responsiveness improvements (#33)

### DIFF
--- a/tools/web-server/src/client/components/board/BoardColumn.tsx
+++ b/tools/web-server/src/client/components/board/BoardColumn.tsx
@@ -9,7 +9,7 @@ interface BoardColumnProps {
 
 export function BoardColumn({ title, color, count, children }: BoardColumnProps) {
   return (
-    <div className="flex flex-col rounded-lg bg-slate-100 min-h-0">
+    <div className="flex flex-col rounded-lg bg-slate-100 min-h-[200px] sm:min-h-0">
       <div className="sticky top-0 z-10 rounded-t-lg bg-slate-100 px-3 py-2">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">

--- a/tools/web-server/src/client/components/board/BoardLayout.tsx
+++ b/tools/web-server/src/client/components/board/BoardLayout.tsx
@@ -62,7 +62,7 @@ export function BoardLayout({ children, isLoading, error, emptyMessage, isEmpty,
   }
 
   return (
-    <div ref={gridRef} className="grid auto-cols-[280px] grid-flow-col gap-4 overflow-x-auto pb-4">
+    <div ref={gridRef} className="grid auto-cols-[280px] grid-flow-col gap-4 overflow-x-auto pb-4 select-none" style={{ WebkitOverflowScrolling: 'touch' }}>
       {children}
     </div>
   );

--- a/tools/web-server/src/client/components/board/FilterBar.tsx
+++ b/tools/web-server/src/client/components/board/FilterBar.tsx
@@ -21,7 +21,7 @@ export function FilterBar() {
   );
 
   return (
-    <div className="mb-4 flex items-center gap-3">
+    <div className="mb-4 flex flex-wrap items-center gap-3">
       {/* Repo Filter — always shown */}
       <select
         value={selectedRepo ?? ''}

--- a/tools/web-server/src/client/components/layout/Layout.tsx
+++ b/tools/web-server/src/client/components/layout/Layout.tsx
@@ -30,7 +30,7 @@ export function Layout({ children }: LayoutProps) {
 
       <div className="flex flex-1 flex-col overflow-hidden">
         <Header />
-        <main className="flex-1 overflow-auto p-6">{children}</main>
+        <main className="flex-1 overflow-auto p-3 sm:p-4 md:p-6">{children}</main>
       </div>
       <DrawerHost />
     </div>

--- a/tools/web-server/src/client/components/tools/CodeBlockViewer.tsx
+++ b/tools/web-server/src/client/components/tools/CodeBlockViewer.tsx
@@ -61,7 +61,7 @@ export function CodeBlockViewer({
   const displayFileName = getBaseName(fileName);
 
   return (
-    <div className="overflow-hidden rounded-lg border border-slate-700 shadow-sm">
+    <div className="overflow-hidden rounded-lg border border-slate-700 shadow-sm max-w-full">
       {/* Header */}
       <div className="flex items-center justify-between px-3 py-2 bg-slate-800 border-b border-slate-700">
         <div className="flex min-w-0 items-center gap-2">

--- a/tools/web-server/src/client/pages/SessionDetail.tsx
+++ b/tools/web-server/src/client/pages/SessionDetail.tsx
@@ -115,7 +115,7 @@ export function SessionDetail() {
   const { metrics } = session;
 
   return (
-    <div className="flex flex-col h-full">
+    <div className="flex flex-col h-full overflow-x-hidden">
       {/* Top bar: session metadata */}
       <div className="flex items-center gap-4 px-4 py-3 border-b border-slate-200 bg-white">
         <button onClick={() => navigate(-1)} className="text-slate-400 hover:text-slate-600 transition-colors">


### PR DESCRIPTION
## Summary
- Add WebKit touch-momentum scrolling to kanban board horizontal scroll
- Add min-height to board columns on mobile so they're visible without content
- Fix code block horizontal overflow in session viewer (max-w-full on container)
- Reduce main layout padding on small screens: `p-3 sm:p-4 md:p-6`
- Add `flex-wrap` to filter bar so selects wrap on narrow screens
- Add `overflow-x-hidden` to SessionDetail root container

Closes #33

## Test plan
- [ ] Kanban board scrolls horizontally on mobile with momentum
- [ ] Board columns show minimum height on mobile even when empty
- [ ] Session viewer code blocks scroll horizontally instead of overflowing
- [ ] Filter bar selects wrap on screens narrower than 640px
- [ ] Main content padding is reduced on mobile
- [ ] Drawer is full-screen on mobile (no change needed — already correct)