### PR TITLE
feat(ui): global search with Cmd+K shortcut (#35)

### DIFF
--- a/tools/web-server/src/client/App.tsx
+++ b/tools/web-server/src/client/App.tsx
@@ -14,6 +14,7 @@ import { BranchHierarchy } from './pages/BranchHierarchy.js';
 import { useInteractionSSE } from './api/interaction-hooks.js';
 import { useSessionMap } from './api/use-session-map.js';
 import { InteractionOverlay } from './components/interaction/InteractionOverlay.js';
+import { GlobalSearch } from './components/search/GlobalSearch.js';
 
 function AppContent() {
   // Hooks that require QueryClientProvider context must live here, not in App()
@@ -23,6 +24,7 @@ function AppContent() {
   return (
     <>
       <InteractionOverlay />
+      <GlobalSearch />
       <BrowserRouter>
         <Layout>
           <Routes>

--- a/tools/web-server/src/client/components/layout/Header.tsx
+++ b/tools/web-server/src/client/components/layout/Header.tsx
@@ -1,6 +1,7 @@
 import { useLocation, Link } from 'react-router-dom';
-import { ChevronRight, Menu } from 'lucide-react';
+import { ChevronRight, Menu, Search } from 'lucide-react';
 import { useSidebarStore } from '../../store/sidebar-store.js';
+import { useSearchStore } from '../../store/search-store.js';
 
 /**
  * Known route segment labels. Dynamic segments (IDs) are left as-is since
@@ -37,6 +38,7 @@ export function Header() {
   const location = useLocation();
   const crumbs = buildBreadcrumbs(location.pathname);
   const toggleSidebar = useSidebarStore((s) => s.toggle);
+  const { open: openSearch } = useSearchStore();
 
   return (
     <header className="flex items-center gap-3 border-b border-slate-200 bg-white px-4 py-3 md:px-6">
@@ -61,6 +63,17 @@ export function Header() {
           </span>
         ))}
       </nav>
+      <div className="ml-auto flex items-center gap-2">
+        <button
+          onClick={openSearch}
+          className="flex items-center gap-2 rounded-md border border-slate-200 bg-slate-50 px-3 py-1.5 text-sm text-slate-500 hover:bg-slate-100 hover:text-slate-700 transition-colors"
+          aria-label="Open search (⌘K)"
+        >
+          <Search size={14} />
+          <span className="hidden sm:inline">Search</span>
+          <kbd className="hidden sm:inline-flex items-center rounded border border-slate-200 bg-white px-1 py-0.5 text-xs text-slate-400">⌘K</kbd>
+        </button>
+      </div>
     </header>
   );
 }

--- a/tools/web-server/src/client/components/search/GlobalSearch.tsx
+++ b/tools/web-server/src/client/components/search/GlobalSearch.tsx
@@ -1,0 +1,257 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Search, X, Layers, FileText, GitBranch, Clock, ChevronRight } from 'lucide-react';
+import { useSearchStore } from '../../store/search-store.js';
+import { useDrawerStore } from '../../store/drawer-store.js';
+
+interface SearchResult {
+  type: 'epic' | 'ticket' | 'stage';
+  id: string;
+  title: string;
+  status: string;
+  parentContext: string;
+}
+
+const RECENT_KEY = 'ccw-recent-searches';
+const MAX_RECENT = 5;
+
+function loadRecent(): string[] {
+  try {
+    return JSON.parse(localStorage.getItem(RECENT_KEY) ?? '[]');
+  } catch {
+    return [];
+  }
+}
+
+function saveRecent(searches: string[]) {
+  localStorage.setItem(RECENT_KEY, JSON.stringify(searches.slice(0, MAX_RECENT)));
+}
+
+const TYPE_ICONS = {
+  epic: Layers,
+  ticket: FileText,
+  stage: GitBranch,
+} as const;
+
+const TYPE_LABELS = {
+  epic: 'Epic',
+  ticket: 'Ticket',
+  stage: 'Stage',
+} as const;
+
+export function GlobalSearch() {
+  const { isOpen, close } = useSearchStore();
+  const navigate = useNavigate();
+  const openDrawer = useDrawerStore((s) => s.open);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const [query, setQuery] = useState('');
+  const [typeFilter, setTypeFilter] = useState<'epic' | 'ticket' | 'stage' | ''>('');
+  const [results, setResults] = useState<SearchResult[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [recent, setRecent] = useState<string[]>(loadRecent);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Focus input when opened
+  useEffect(() => {
+    if (isOpen) {
+      setTimeout(() => inputRef.current?.focus(), 50);
+      setQuery('');
+      setResults([]);
+    }
+  }, [isOpen]);
+
+  // Keyboard shortcut
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+        e.preventDefault();
+        if (isOpen) close();
+        else useSearchStore.getState().open();
+      }
+      if (e.key === 'Escape' && isOpen) close();
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [isOpen, close]);
+
+  const doSearch = useCallback(async (q: string, type: string) => {
+    if (!q.trim()) {
+      setResults([]);
+      return;
+    }
+    setLoading(true);
+    try {
+      const params = new URLSearchParams({ q });
+      if (type) params.set('type', type);
+      const res = await fetch(`/api/search?${params}`);
+      if (res.ok) {
+        const data = await res.json() as { results: SearchResult[] };
+        setResults(data.results);
+      }
+    } catch {
+      // ignore
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const handleQueryChange = (val: string) => {
+    setQuery(val);
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => doSearch(val, typeFilter), 300);
+  };
+
+  const handleTypeFilter = (t: 'epic' | 'ticket' | 'stage' | '') => {
+    setTypeFilter(t);
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => doSearch(query, t), 0);
+  };
+
+  const handleSelect = (result: SearchResult) => {
+    // Save to recent
+    const updated = [result.title, ...recent.filter((r) => r !== result.title)].slice(0, MAX_RECENT);
+    setRecent(updated);
+    saveRecent(updated);
+    close();
+
+    // Navigate or open drawer based on type
+    if (result.type === 'epic') {
+      navigate(`/epics/${result.id}`);
+    } else if (result.type === 'ticket') {
+      openDrawer({ type: 'ticket', id: result.id });
+    } else if (result.type === 'stage') {
+      openDrawer({ type: 'stage', id: result.id });
+    }
+  };
+
+  const handleRecentClick = (term: string) => {
+    setQuery(term);
+    doSearch(term, typeFilter);
+  };
+
+  if (!isOpen) return null;
+
+  // Group results by type
+  const grouped: Record<string, SearchResult[]> = {};
+  for (const r of results) {
+    (grouped[r.type] ??= []).push(r);
+  }
+
+  return (
+    <div className="fixed inset-0 z-[100] flex items-start justify-center pt-[15vh] px-4">
+      {/* Backdrop */}
+      <div
+        className="absolute inset-0 bg-black/40"
+        onClick={close}
+        aria-hidden="true"
+      />
+
+      {/* Modal */}
+      <div className="relative w-full max-w-xl bg-white rounded-xl shadow-2xl ring-1 ring-slate-200 overflow-hidden">
+        {/* Search input */}
+        <div className="flex items-center gap-3 px-4 py-3 border-b border-slate-200">
+          <Search size={18} className="text-slate-400 flex-shrink-0" />
+          <input
+            ref={inputRef}
+            type="text"
+            placeholder="Search epics, tickets, stages…"
+            value={query}
+            onChange={(e) => handleQueryChange(e.target.value)}
+            className="flex-1 text-sm text-slate-900 placeholder:text-slate-400 outline-none bg-transparent"
+          />
+          {loading && (
+            <span className="text-xs text-slate-400 animate-pulse">Searching…</span>
+          )}
+          <button
+            onClick={close}
+            className="rounded p-1 text-slate-400 hover:text-slate-600"
+            aria-label="Close search"
+          >
+            <X size={16} />
+          </button>
+        </div>
+
+        {/* Filter chips */}
+        <div className="flex items-center gap-2 px-4 py-2 border-b border-slate-100">
+          {(['', 'epic', 'ticket', 'stage'] as const).map((t) => (
+            <button
+              key={t}
+              onClick={() => handleTypeFilter(t)}
+              className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
+                typeFilter === t
+                  ? 'bg-slate-800 text-white'
+                  : 'bg-slate-100 text-slate-600 hover:bg-slate-200'
+              }`}
+            >
+              {t === '' ? 'All' : TYPE_LABELS[t]}
+            </button>
+          ))}
+        </div>
+
+        {/* Results */}
+        <div className="max-h-80 overflow-y-auto">
+          {!query && recent.length > 0 && (
+            <div className="px-4 py-2">
+              <p className="text-xs font-medium text-slate-400 uppercase tracking-wide mb-2">Recent</p>
+              {recent.map((r) => (
+                <button
+                  key={r}
+                  onClick={() => handleRecentClick(r)}
+                  className="w-full flex items-center gap-3 px-2 py-2 rounded-lg hover:bg-slate-50 text-left"
+                >
+                  <Clock size={14} className="text-slate-400 flex-shrink-0" />
+                  <span className="text-sm text-slate-700 truncate">{r}</span>
+                </button>
+              ))}
+            </div>
+          )}
+
+          {query && results.length === 0 && !loading && (
+            <div className="px-4 py-8 text-center text-sm text-slate-400">
+              No results for &quot;{query}&quot;
+            </div>
+          )}
+
+          {Object.entries(grouped).map(([type, items]) => (
+            <div key={type} className="px-4 py-2">
+              <p className="text-xs font-medium text-slate-400 uppercase tracking-wide mb-1">
+                {TYPE_LABELS[type as keyof typeof TYPE_LABELS]}s
+              </p>
+              {items.map((result) => {
+                const Icon = TYPE_ICONS[result.type];
+                return (
+                  <button
+                    key={result.id}
+                    onClick={() => handleSelect(result)}
+                    className="w-full flex items-center gap-3 px-2 py-2 rounded-lg hover:bg-slate-50 text-left"
+                  >
+                    <Icon size={14} className="text-slate-500 flex-shrink-0" />
+                    <div className="flex-1 min-w-0">
+                      <span className="text-sm text-slate-800 truncate block">{result.title}</span>
+                      {result.parentContext && (
+                        <span className="text-xs text-slate-400 truncate block">{result.parentContext}</span>
+                      )}
+                    </div>
+                    <span className="text-xs text-slate-400 flex-shrink-0">{result.status}</span>
+                    <ChevronRight size={14} className="text-slate-300 flex-shrink-0" />
+                  </button>
+                );
+              })}
+            </div>
+          ))}
+        </div>
+
+        {/* Footer hint */}
+        <div className="px-4 py-2 border-t border-slate-100 flex items-center justify-between">
+          <span className="text-xs text-slate-400">
+            <kbd className="bg-slate-100 rounded px-1 py-0.5">⌘K</kbd> to toggle
+          </span>
+          <span className="text-xs text-slate-400">
+            <kbd className="bg-slate-100 rounded px-1 py-0.5">Esc</kbd> to close
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/tools/web-server/src/client/store/search-store.ts
+++ b/tools/web-server/src/client/store/search-store.ts
@@ -1,0 +1,15 @@
+import { create } from 'zustand';
+
+interface SearchState {
+  isOpen: boolean;
+  open: () => void;
+  close: () => void;
+  toggle: () => void;
+}
+
+export const useSearchStore = create<SearchState>((set) => ({
+  isOpen: false,
+  open: () => set({ isOpen: true }),
+  close: () => set({ isOpen: false }),
+  toggle: () => set((s) => ({ isOpen: !s.isOpen })),
+}));

--- a/tools/web-server/src/server/app.ts
+++ b/tools/web-server/src/server/app.ts
@@ -21,6 +21,7 @@ import { repoRoutes } from './routes/repos.js';
 import { eventRoutes, broadcastEvent, setBroadcaster } from './routes/events.js';
 import { interactionRoutes } from './routes/interaction.js';
 import { orchestratorRoutes, computeWaitingType } from './routes/orchestrator.js';
+import { searchRoutes } from './routes/search.js';
 
 interface SessionStatusSSE {
   stageId: string;
@@ -277,6 +278,8 @@ export async function createServer(
   if (orchestratorClient) {
     await app.register(interactionRoutes, { orchestratorClient });
   }
+
+  await app.register(searchRoutes);
 
   // --- Static serving / dev proxy ---
   if (!isDev) {

--- a/tools/web-server/src/server/routes/search.ts
+++ b/tools/web-server/src/server/routes/search.ts
@@ -1,0 +1,102 @@
+import type { FastifyPluginCallback } from 'fastify';
+import fp from 'fastify-plugin';
+import { z } from 'zod';
+
+const searchQuerySchema = z.object({
+  q: z.string().min(1),
+  type: z.enum(['epic', 'ticket', 'stage']).optional(),
+  status: z.string().optional(),
+});
+
+export interface SearchResult {
+  type: 'epic' | 'ticket' | 'stage';
+  id: string;
+  title: string;
+  status: string;
+  parentContext: string;
+}
+
+const searchPlugin: FastifyPluginCallback = (app, _opts, done) => {
+  app.get('/api/search', async (request, reply) => {
+    if (!app.dataService) {
+      return reply.status(503).send({ error: 'Database not initialized' });
+    }
+
+    const parseResult = searchQuerySchema.safeParse(request.query);
+    if (!parseResult.success) {
+      return reply.status(400).send({ error: 'Invalid parameters', details: parseResult.error.issues });
+    }
+
+    const { q, type, status } = parseResult.data;
+    const term = q.toLowerCase();
+    const results: SearchResult[] = [];
+
+    const repos = app.dataService.repos.findAll();
+    if (repos.length === 0) return reply.send({ results: [] });
+    const repo = repos[0];
+
+    // Search epics
+    if (!type || type === 'epic') {
+      const epics = app.dataService.epics.listByRepo(repo.id);
+      for (const epic of epics) {
+        if (!epic.title?.toLowerCase().includes(term)) continue;
+        if (status && epic.status !== status) continue;
+        results.push({
+          type: 'epic',
+          id: epic.id,
+          title: epic.title ?? '',
+          status: epic.status ?? '',
+          parentContext: '',
+        });
+      }
+    }
+
+    // Search tickets
+    if (!type || type === 'ticket') {
+      const tickets = app.dataService.tickets.listByRepo(repo.id);
+      const epicMap = new Map<string, string>();
+      for (const e of app.dataService.epics.listByRepo(repo.id)) {
+        epicMap.set(e.id, e.title ?? e.id);
+      }
+      for (const ticket of tickets) {
+        if (!ticket.title?.toLowerCase().includes(term)) continue;
+        if (status && ticket.status !== status) continue;
+        const epicTitle = ticket.epic_id ? (epicMap.get(ticket.epic_id) ?? ticket.epic_id) : '';
+        results.push({
+          type: 'ticket',
+          id: ticket.id,
+          title: ticket.title ?? '',
+          status: ticket.status ?? '',
+          parentContext: epicTitle ? `in ${epicTitle}` : '',
+        });
+      }
+    }
+
+    // Search stages
+    if (!type || type === 'stage') {
+      const stages = app.dataService.stages.listByRepo(repo.id);
+      const ticketMap = new Map<string, string>();
+      for (const t of app.dataService.tickets.listByRepo(repo.id)) {
+        ticketMap.set(t.id, t.title ?? t.id);
+      }
+      for (const stage of stages) {
+        if (!stage.title?.toLowerCase().includes(term)) continue;
+        if (status && stage.status !== status) continue;
+        const ticketTitle = stage.ticket_id ? (ticketMap.get(stage.ticket_id) ?? stage.ticket_id) : '';
+        results.push({
+          type: 'stage',
+          id: stage.id,
+          title: stage.title ?? '',
+          status: stage.status ?? '',
+          parentContext: ticketTitle ? `in ${ticketTitle}` : '',
+        });
+      }
+    }
+
+    return reply.send({ results: results.slice(0, 50) });
+  });
+
+  done();
+};
+
+export const searchRoutes = fp(searchPlugin, { name: 'search-routes' });


### PR DESCRIPTION
## Summary
- New `GET /api/search?q=&type=&status=` endpoint — searches epics, tickets, stages by title using in-memory data cache (results capped at 50)
- `GlobalSearch` modal opens with Cmd+K / Ctrl+K or the search button in the header
- Debounced 300ms input, filter chips for entity type, recent searches in localStorage
- Click result: epics navigate to detail page; tickets/stages open the detail drawer

Closes #35

## Test plan
- [ ] Press Cmd+K — search modal opens
- [ ] Type in search box — results appear after 300ms debounce
- [ ] Click type filter chip — filters results
- [ ] Click a result — navigates to epic page or opens drawer
- [ ] Recent searches appear when query is empty
- [ ] Press Esc — modal closes

🤖 Generated with [Claude Code](https://claude.com/claude-code)