### PR TITLE
perf(ui): optimize session viewer rendering for long sessions (#32)

### DIFF
--- a/tools/web-server/src/client/components/chat/AIChunk.tsx
+++ b/tools/web-server/src/client/components/chat/AIChunk.tsx
@@ -1,3 +1,4 @@
+import { memo, useCallback } from 'react';
 import { Bot, ChevronRight } from 'lucide-react';
 import { formatTimestamp, formatTokenCount, formatDuration } from '../../utils/session-formatters.js';
 import { findLastOutput } from '../../utils/last-output-detector.js';
@@ -51,11 +52,12 @@ function buildStepSummary(steps: SemanticStep[]): string {
   return parts.join(', ');
 }
 
-export function AIChunk({ chunk, chunkIndex }: Props) {
+export const AIChunk = memo(function AIChunk({ chunk, chunkIndex }: Props) {
   const { messages, timestamp } = chunk;
   const enhanced = isEnhanced(chunk);
   const { expandedGroups, toggleGroup } = useSessionViewStore();
   const isExpanded = expandedGroups.has(String(chunkIndex));
+  const handleToggle = useCallback(() => toggleGroup(String(chunkIndex)), [toggleGroup, chunkIndex]);
 
   // Build tool execution lookup from chunk messages
   const toolExecutions = new Map<string, ToolExecution>();
@@ -140,7 +142,7 @@ export function AIChunk({ chunk, chunkIndex }: Props) {
       {/* Clickable header bar */}
       <button
         type="button"
-        onClick={() => toggleGroup(String(chunkIndex))}
+        onClick={handleToggle}
         className="w-full flex items-center gap-2 px-2 py-1.5 rounded-lg cursor-pointer select-none hover:bg-slate-50 dark:hover:bg-slate-800/50 transition-colors"
       >
         {/* Left side: bot icon, model badge, step summary */}
@@ -187,7 +189,7 @@ export function AIChunk({ chunk, chunkIndex }: Props) {
       </div>
     </div>
   );
-}
+});
 
 function AIStepRenderer({
   step,

--- a/tools/web-server/src/client/components/chat/ChatHistory.tsx
+++ b/tools/web-server/src/client/components/chat/ChatHistory.tsx
@@ -14,7 +14,7 @@ interface Props {
   totalPhases?: number;
 }
 
-const VIRTUALIZATION_THRESHOLD = 120;
+const VIRTUALIZATION_THRESHOLD = 50;
 const ESTIMATE_SIZE = 260;
 const OVERSCAN = 8;
 const NEAR_BOTTOM_PX = 100;

--- a/tools/web-server/src/client/components/chat/items/LinkedToolItem.tsx
+++ b/tools/web-server/src/client/components/chat/items/LinkedToolItem.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import {
   ChevronRight,
   CheckCircle2,
@@ -31,7 +32,7 @@ const toolIcons: Record<string, typeof FileText> = {
   Skill: Zap,
 };
 
-export function LinkedToolItem({ execution }: Props) {
+export const LinkedToolItem = memo(function LinkedToolItem({ execution }: Props) {
   const expanded = useSessionViewStore((s) => s.expandedTools.has(execution.toolCallId));
   const toggleTool = useSessionViewStore((s) => s.toggleTool);
   const { toolName, input, result, durationMs, isOrphaned } = execution;
@@ -84,4 +85,4 @@ export function LinkedToolItem({ execution }: Props) {
       )}
     </div>
   );
-}
+});


### PR DESCRIPTION
## Summary
- Wrap `LinkedToolItem` and `AIChunk` in `React.memo` to eliminate redundant re-renders during SSE streaming updates
- Stabilize `AIChunk` toggle callback with `useCallback`
- Lower virtualization threshold from 120 → 50 items so longer sessions virtualize sooner

Closes #32

## Test plan
- [ ] Open a session with 50+ chunks — confirm scrolling stays smooth
- [ ] Verify collapsed tool calls don't re-render on new SSE events