### PR TITLE
feat(ui): GitHub/GitLab issue import (#36)

### DIFF
--- a/tools/web-server/src/client/App.tsx
+++ b/tools/web-server/src/client/App.tsx
@@ -11,6 +11,7 @@ import { SessionDetail } from './pages/SessionDetail.js';
 import { DependencyGraph } from './pages/DependencyGraph.js';
 import { Settings } from './pages/Settings.js';
 import { BranchHierarchy } from './pages/BranchHierarchy.js';
+import { ImportIssues } from './pages/ImportIssues.js';
 import { useInteractionSSE } from './api/interaction-hooks.js';
 import { useSessionMap } from './api/use-session-map.js';
 import { InteractionOverlay } from './components/interaction/InteractionOverlay.js';
@@ -46,6 +47,7 @@ function AppContent() {
             <Route path="/graph" element={<DependencyGraph />} />
             <Route path="/branches" element={<BranchHierarchy />} />
             <Route path="/settings" element={<Settings />} />
+            <Route path="/import" element={<ImportIssues />} />
           </Routes>
         </Layout>
       </BrowserRouter>

--- a/tools/web-server/src/client/components/layout/Header.tsx
+++ b/tools/web-server/src/client/components/layout/Header.tsx
@@ -15,6 +15,7 @@ const SEGMENT_LABELS: Record<string, string> = {
   stages: 'Stages',
   sessions: 'Sessions',
   graph: 'Dependency Graph',
+  import: 'Import Issues',
 };
 
 function buildBreadcrumbs(pathname: string): { label: string; to: string }[] {

--- a/tools/web-server/src/client/components/layout/Sidebar.tsx
+++ b/tools/web-server/src/client/components/layout/Sidebar.tsx
@@ -1,5 +1,5 @@
 import { Link, useLocation } from 'react-router-dom';
-import { LayoutDashboard, Layers, GitBranch, GitFork, X, Settings as SettingsIcon } from 'lucide-react';
+import { LayoutDashboard, Layers, GitBranch, GitFork, X, Settings as SettingsIcon, Download } from 'lucide-react';
 import { useSidebarStore } from '../../store/sidebar-store.js';
 
 const navItems = [
@@ -8,6 +8,7 @@ const navItems = [
   { to: '/graph', label: 'Dependency Graph', icon: GitBranch },
   { to: '/branches', label: 'Branch Hierarchy', icon: GitFork },
   { to: '/settings', label: 'Settings', icon: SettingsIcon },
+  { to: '/import', label: 'Import Issues', icon: Download },
 ];
 
 export function Sidebar({ className = '' }: { className?: string }) {

--- a/tools/web-server/src/client/pages/ImportIssues.tsx
+++ b/tools/web-server/src/client/pages/ImportIssues.tsx
@@ -1,0 +1,361 @@
+import { useState } from 'react';
+import { Github, GitMerge, Search, Check, AlertCircle, Loader2, Download } from 'lucide-react';
+import { useQuery } from '@tanstack/react-query';
+import { apiFetch } from '../api/client.js';
+
+const STORAGE_KEY = 'ccw-settings';
+
+interface Settings {
+  github: { personalAccessToken: string; defaultOwner: string; repository: string };
+  gitlab: { instanceUrl: string; accessToken: string; defaultGroup: string };
+}
+
+function loadSettings(): Settings {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw) return JSON.parse(raw) as Settings;
+  } catch { /* ignore */ }
+  return {
+    github: { personalAccessToken: '', defaultOwner: '', repository: '' },
+    gitlab: { instanceUrl: 'gitlab.com', accessToken: '', defaultGroup: '' },
+  };
+}
+
+interface RemoteIssue {
+  id: number;
+  number: number;
+  title: string;
+  body: string | null;
+  state: string;
+  labels: string[];
+  url: string;
+}
+
+interface EpicOption { id: string; title: string }
+
+export function ImportIssues() {
+  const settings = loadSettings();
+
+  const [provider, setProvider] = useState<'github' | 'gitlab'>('github');
+
+  // GitHub fields
+  const [ghOwner, setGhOwner] = useState(settings.github.defaultOwner);
+  const [ghRepo, setGhRepo] = useState(settings.github.repository);
+  const [ghToken, setGhToken] = useState(settings.github.personalAccessToken);
+
+  // GitLab fields
+  const [glProject, setGlProject] = useState('');
+  const [glInstance, setGlInstance] = useState(
+    settings.gitlab.instanceUrl ? `https://${settings.gitlab.instanceUrl}` : 'https://gitlab.com',
+  );
+  const [glToken, setGlToken] = useState(settings.gitlab.accessToken);
+
+  const [fetching, setFetching] = useState(false);
+  const [fetchError, setFetchError] = useState<string | null>(null);
+  const [issues, setIssues] = useState<RemoteIssue[]>([]);
+  const [selected, setSelected] = useState<Set<number>>(new Set());
+  const [epicId, setEpicId] = useState('');
+  const [importing, setImporting] = useState(false);
+  const [importResult, setImportResult] = useState<{ imported: number; skipped: number } | null>(null);
+
+  const epicsQuery = useQuery({
+    queryKey: ['epics-for-import'],
+    queryFn: () => apiFetch<EpicOption[]>('/api/epics'),
+  });
+
+  const epics: EpicOption[] = (epicsQuery.data ?? []).map((e: EpicOption) => ({
+    id: e.id,
+    title: e.title,
+  }));
+
+  const handleFetch = async () => {
+    setFetching(true);
+    setFetchError(null);
+    setIssues([]);
+    setSelected(new Set());
+    setImportResult(null);
+
+    try {
+      let url: string;
+      if (provider === 'github') {
+        const params = new URLSearchParams({ owner: ghOwner, repo: ghRepo });
+        if (ghToken) params.set('token', ghToken);
+        url = `/api/import/github/issues?${params.toString()}`;
+      } else {
+        const params = new URLSearchParams({ projectId: glProject, instanceUrl: glInstance });
+        if (glToken) params.set('token', glToken);
+        url = `/api/import/gitlab/issues?${params.toString()}`;
+      }
+      const res = await fetch(url);
+      const data = await res.json() as { issues?: RemoteIssue[]; error?: string };
+      if (!res.ok || data.error) {
+        setFetchError(data.error ?? `HTTP ${res.status}`);
+        return;
+      }
+      setIssues(data.issues ?? []);
+    } catch (err) {
+      setFetchError(String(err));
+    } finally {
+      setFetching(false);
+    }
+  };
+
+  const toggleAll = () => {
+    if (selected.size === issues.length) {
+      setSelected(new Set());
+    } else {
+      setSelected(new Set(issues.map((i) => i.id)));
+    }
+  };
+
+  const toggleIssue = (id: number) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const handleImport = async () => {
+    const toImport = issues.filter((i) => selected.has(i.id));
+    if (toImport.length === 0) return;
+
+    setImporting(true);
+    setImportResult(null);
+
+    try {
+      const res = await fetch('/api/import/issues', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          provider,
+          issues: toImport,
+          epicId: epicId || undefined,
+        }),
+      });
+      const data = await res.json() as { imported: number; skipped: number };
+      setImportResult(data);
+    } catch (err) {
+      setFetchError(String(err));
+    } finally {
+      setImporting(false);
+    }
+  };
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-slate-900">Import Issues</h1>
+        <p className="mt-1 text-sm text-slate-500">
+          Import GitHub or GitLab issues as tickets. Duplicate issues (same source ID) are skipped.
+        </p>
+      </div>
+
+      {/* Provider selector */}
+      <div className="rounded-lg border border-slate-200 bg-white p-4 space-y-4">
+        <h2 className="text-sm font-semibold text-slate-700">Provider</h2>
+        <div className="flex gap-3">
+          {(['github', 'gitlab'] as const).map((p) => (
+            <button
+              key={p}
+              onClick={() => setProvider(p)}
+              className={`flex items-center gap-2 rounded-lg border px-4 py-3 text-sm font-medium transition-colors ${
+                provider === p
+                  ? 'border-slate-800 bg-slate-800 text-white'
+                  : 'border-slate-200 text-slate-700 hover:border-slate-300 hover:bg-slate-50'
+              }`}
+            >
+              {p === 'github' ? <Github size={16} /> : <GitMerge size={16} />}
+              {p === 'github' ? 'GitHub' : 'GitLab'}
+            </button>
+          ))}
+        </div>
+
+        {/* GitHub fields */}
+        {provider === 'github' && (
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            <div>
+              <label className="block text-xs font-medium text-slate-600 mb-1">Owner</label>
+              <input
+                type="text"
+                value={ghOwner}
+                onChange={(e) => setGhOwner(e.target.value)}
+                placeholder="e.g. octocat"
+                className="w-full rounded-md border border-slate-200 px-3 py-2 text-sm focus:border-slate-400 focus:outline-none"
+              />
+            </div>
+            <div>
+              <label className="block text-xs font-medium text-slate-600 mb-1">Repository</label>
+              <input
+                type="text"
+                value={ghRepo}
+                onChange={(e) => setGhRepo(e.target.value)}
+                placeholder="e.g. my-project"
+                className="w-full rounded-md border border-slate-200 px-3 py-2 text-sm focus:border-slate-400 focus:outline-none"
+              />
+            </div>
+            <div className="sm:col-span-2">
+              <label className="block text-xs font-medium text-slate-600 mb-1">Personal Access Token (optional)</label>
+              <input
+                type="password"
+                value={ghToken}
+                onChange={(e) => setGhToken(e.target.value)}
+                placeholder="ghp_..."
+                className="w-full rounded-md border border-slate-200 px-3 py-2 text-sm focus:border-slate-400 focus:outline-none"
+              />
+            </div>
+          </div>
+        )}
+
+        {/* GitLab fields */}
+        {provider === 'gitlab' && (
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            <div>
+              <label className="block text-xs font-medium text-slate-600 mb-1">Project ID or path</label>
+              <input
+                type="text"
+                value={glProject}
+                onChange={(e) => setGlProject(e.target.value)}
+                placeholder="e.g. 12345 or group/project"
+                className="w-full rounded-md border border-slate-200 px-3 py-2 text-sm focus:border-slate-400 focus:outline-none"
+              />
+            </div>
+            <div>
+              <label className="block text-xs font-medium text-slate-600 mb-1">Instance URL</label>
+              <input
+                type="text"
+                value={glInstance}
+                onChange={(e) => setGlInstance(e.target.value)}
+                placeholder="https://gitlab.com"
+                className="w-full rounded-md border border-slate-200 px-3 py-2 text-sm focus:border-slate-400 focus:outline-none"
+              />
+            </div>
+            <div className="sm:col-span-2">
+              <label className="block text-xs font-medium text-slate-600 mb-1">Access Token (optional)</label>
+              <input
+                type="password"
+                value={glToken}
+                onChange={(e) => setGlToken(e.target.value)}
+                placeholder="glpat-..."
+                className="w-full rounded-md border border-slate-200 px-3 py-2 text-sm focus:border-slate-400 focus:outline-none"
+              />
+            </div>
+          </div>
+        )}
+
+        <button
+          onClick={handleFetch}
+          disabled={fetching}
+          className="flex items-center gap-2 rounded-lg bg-slate-800 px-4 py-2 text-sm font-medium text-white hover:bg-slate-700 disabled:opacity-50"
+        >
+          {fetching ? <Loader2 size={16} className="animate-spin" /> : <Search size={16} />}
+          Fetch Issues
+        </button>
+
+        {fetchError && (
+          <div className="flex items-center gap-2 text-sm text-red-600 bg-red-50 rounded-lg px-3 py-2">
+            <AlertCircle size={16} />
+            {fetchError}
+          </div>
+        )}
+      </div>
+
+      {/* Issue list */}
+      {issues.length > 0 && (
+        <div className="rounded-lg border border-slate-200 bg-white overflow-hidden">
+          <div className="flex items-center justify-between px-4 py-3 border-b border-slate-200 bg-slate-50">
+            <div className="flex items-center gap-3">
+              <input
+                type="checkbox"
+                checked={selected.size === issues.length}
+                onChange={toggleAll}
+                className="rounded"
+              />
+              <span className="text-sm font-medium text-slate-700">
+                {issues.length} issue{issues.length !== 1 ? 's' : ''} found
+              </span>
+            </div>
+            <span className="text-xs text-slate-500">{selected.size} selected</span>
+          </div>
+
+          <div className="divide-y divide-slate-100 max-h-72 overflow-y-auto">
+            {issues.map((issue) => (
+              <label key={issue.id} className="flex items-start gap-3 px-4 py-3 hover:bg-slate-50 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={selected.has(issue.id)}
+                  onChange={() => toggleIssue(issue.id)}
+                  className="mt-0.5 rounded"
+                />
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm font-medium text-slate-800 truncate">{issue.title}</span>
+                    <span className="text-xs text-slate-400 flex-shrink-0">#{issue.number}</span>
+                  </div>
+                  {issue.labels.length > 0 && (
+                    <div className="flex flex-wrap gap-1 mt-1">
+                      {issue.labels.map((l) => (
+                        <span key={l} className="rounded-full bg-slate-100 px-2 py-0.5 text-xs text-slate-600">{l}</span>
+                      ))}
+                    </div>
+                  )}
+                </div>
+                <span className={`text-xs flex-shrink-0 rounded-full px-2 py-0.5 ${
+                  issue.state === 'open' || issue.state === 'opened'
+                    ? 'bg-green-100 text-green-700'
+                    : 'bg-slate-100 text-slate-600'
+                }`}>
+                  {issue.state}
+                </span>
+              </label>
+            ))}
+          </div>
+
+          {/* Epic association */}
+          <div className="px-4 py-3 border-t border-slate-200 bg-slate-50 space-y-3">
+            <div>
+              <label className="block text-xs font-medium text-slate-600 mb-1">Associate with Epic (optional)</label>
+              <select
+                value={epicId}
+                onChange={(e) => setEpicId(e.target.value)}
+                className="w-full rounded-md border border-slate-200 px-3 py-2 text-sm bg-white focus:border-slate-400 focus:outline-none"
+              >
+                <option value="">No epic</option>
+                {epics.map((e) => (
+                  <option key={e.id} value={e.id}>{e.title} ({e.id})</option>
+                ))}
+              </select>
+            </div>
+
+            <button
+              onClick={handleImport}
+              disabled={importing || selected.size === 0}
+              className="flex items-center gap-2 rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-700 disabled:opacity-50"
+            >
+              {importing ? <Loader2 size={16} className="animate-spin" /> : <Download size={16} />}
+              Import {selected.size > 0 ? `${selected.size} issue${selected.size !== 1 ? 's' : ''}` : 'selected issues'}
+            </button>
+
+            {importResult && (
+              <div className="flex items-center gap-2 text-sm text-emerald-700 bg-emerald-50 rounded-lg px-3 py-2">
+                <Check size={16} />
+                Imported {importResult.imported} issue{importResult.imported !== 1 ? 's' : ''}.
+                {importResult.skipped > 0 && ` ${importResult.skipped} skipped (already imported).`}
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Periodic sync stub */}
+      <div className="rounded-lg border border-dashed border-slate-300 bg-slate-50 p-4">
+        <h2 className="text-sm font-semibold text-slate-600">Periodic Sync</h2>
+        <p className="mt-1 text-xs text-slate-500">
+          Automatic periodic sync configuration will be available in a future release.
+          Configure sync criteria (labels, milestones, assignees) and sync interval in Settings.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/tools/web-server/src/server/app.ts
+++ b/tools/web-server/src/server/app.ts
@@ -22,6 +22,7 @@ import { eventRoutes, broadcastEvent, setBroadcaster } from './routes/events.js'
 import { interactionRoutes } from './routes/interaction.js';
 import { orchestratorRoutes, computeWaitingType } from './routes/orchestrator.js';
 import { searchRoutes } from './routes/search.js';
+import { importRoutes } from './routes/import.js';
 
 interface SessionStatusSSE {
   stageId: string;
@@ -270,6 +271,7 @@ export async function createServer(
   await app.register(sessionRoutes);
   await app.register(repoRoutes);
   await app.register(eventRoutes);
+  await app.register(importRoutes);
 
   // Orchestrator routes — session status endpoint
   await app.register(orchestratorRoutes);

--- a/tools/web-server/src/server/routes/import.ts
+++ b/tools/web-server/src/server/routes/import.ts
@@ -1,0 +1,227 @@
+import type { FastifyPluginCallback } from 'fastify';
+import fp from 'fastify-plugin';
+import { z } from 'zod';
+import { existsSync, readdirSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
+import { join, dirname } from 'path';
+import matter from 'gray-matter';
+
+const githubQuerySchema = z.object({
+  owner: z.string().min(1),
+  repo: z.string().min(1),
+  state: z.enum(['open', 'closed', 'all']).optional().default('open'),
+  token: z.string().optional(),
+});
+
+const gitlabQuerySchema = z.object({
+  projectId: z.string().min(1),
+  state: z.enum(['opened', 'closed', 'all']).optional().default('opened'),
+  instanceUrl: z.string().optional().default('https://gitlab.com'),
+  token: z.string().optional(),
+});
+
+const importBodySchema = z.object({
+  provider: z.enum(['github', 'gitlab']),
+  issues: z.array(z.object({
+    id: z.number(),
+    number: z.number(),
+    title: z.string(),
+    body: z.string().nullable(),
+    state: z.string(),
+    labels: z.array(z.string()),
+    url: z.string(),
+  })),
+  epicId: z.string().optional(),
+});
+
+export interface RemoteIssue {
+  id: number;
+  number: number;
+  title: string;
+  body: string | null;
+  state: string;
+  labels: string[];
+  url: string;
+}
+
+function findExistingSourceIds(ticketsDir: string, provider: string): Set<string> {
+  const sourceIds = new Set<string>();
+  if (!existsSync(ticketsDir)) return sourceIds;
+
+  try {
+    const files = readdirSync(ticketsDir, { recursive: true }) as string[];
+    for (const f of files) {
+      if (!f.endsWith('.md')) continue;
+      const filePath = join(ticketsDir, f);
+      try {
+        const content = readFileSync(filePath, 'utf-8');
+        const { data } = matter(content);
+        if (data.source === provider && data.source_id) {
+          sourceIds.add(String(data.source_id));
+        }
+      } catch {
+        // skip unreadable files
+      }
+    }
+  } catch {
+    // directory not readable
+  }
+  return sourceIds;
+}
+
+const importPlugin: FastifyPluginCallback = (app, _opts, done) => {
+  // GET /api/import/github/issues
+  app.get('/api/import/github/issues', async (request, reply) => {
+    const parseResult = githubQuerySchema.safeParse(request.query);
+    if (!parseResult.success) {
+      return reply.status(400).send({ error: 'Invalid parameters', details: parseResult.error.issues });
+    }
+    const { owner, repo, state, token } = parseResult.data;
+
+    const headers: Record<string, string> = {
+      'Accept': 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+    };
+    if (token) headers['Authorization'] = `Bearer ${token}`;
+
+    try {
+      const url = `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/issues?state=${state}&per_page=50`;
+      const res = await fetch(url, { headers });
+      if (!res.ok) {
+        const msg = await res.text();
+        return reply.status(res.status).send({ error: `GitHub API error: ${msg}` });
+      }
+      const raw = await res.json() as Array<Record<string, unknown>>;
+      const issues: RemoteIssue[] = raw
+        .filter((i) => !i['pull_request'])
+        .map((i) => ({
+          id: i['id'] as number,
+          number: i['number'] as number,
+          title: i['title'] as string,
+          body: (i['body'] as string | null) ?? null,
+          state: i['state'] as string,
+          labels: ((i['labels'] as Array<{ name: string }>) ?? []).map((l) => l.name),
+          url: i['html_url'] as string,
+        }));
+
+      return reply.send({ issues });
+    } catch (err) {
+      return reply.status(500).send({ error: String(err) });
+    }
+  });
+
+  // GET /api/import/gitlab/issues
+  app.get('/api/import/gitlab/issues', async (request, reply) => {
+    const parseResult = gitlabQuerySchema.safeParse(request.query);
+    if (!parseResult.success) {
+      return reply.status(400).send({ error: 'Invalid parameters', details: parseResult.error.issues });
+    }
+    const { projectId, state, instanceUrl, token } = parseResult.data;
+
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+    };
+    if (token) headers['PRIVATE-TOKEN'] = token;
+
+    try {
+      const base = instanceUrl.replace(/\/$/, '');
+      const url = `${base}/api/v4/projects/${encodeURIComponent(projectId)}/issues?state=${state}&per_page=50`;
+      const res = await fetch(url, { headers });
+      if (!res.ok) {
+        const msg = await res.text();
+        return reply.status(res.status).send({ error: `GitLab API error: ${msg}` });
+      }
+      const raw = await res.json() as Array<Record<string, unknown>>;
+      const issues: RemoteIssue[] = raw.map((i) => ({
+        id: i['id'] as number,
+        number: i['iid'] as number,
+        title: i['title'] as string,
+        body: (i['description'] as string | null) ?? null,
+        state: i['state'] as string,
+        labels: ((i['labels'] as string[]) ?? []),
+        url: i['web_url'] as string,
+      }));
+
+      return reply.send({ issues });
+    } catch (err) {
+      return reply.status(500).send({ error: String(err) });
+    }
+  });
+
+  // POST /api/import/issues — create ticket files
+  app.post('/api/import/issues', async (request, reply) => {
+    const parseResult = importBodySchema.safeParse(request.body);
+    if (!parseResult.success) {
+      return reply.status(400).send({ error: 'Invalid parameters', details: parseResult.error.issues });
+    }
+
+    if (!app.dataService) {
+      return reply.status(503).send({ error: 'Database not initialized' });
+    }
+
+    const { provider, issues, epicId } = parseResult.data;
+
+    // Determine tickets directory from the repo data
+    let ticketsDir: string;
+    const repos = app.dataService.repos.findAll();
+    if (repos.length > 0) {
+      const repo = repos[0];
+      if (repo.path) {
+        ticketsDir = join(repo.path, 'tickets');
+      } else {
+        // Fall back to first ticket's file_path
+        const tickets = app.dataService.tickets.listByRepo(repo.id);
+        if (tickets.length > 0 && tickets[0].file_path) {
+          ticketsDir = dirname(tickets[0].file_path);
+        } else {
+          ticketsDir = join(process.cwd(), 'tickets');
+        }
+      }
+    } else {
+      ticketsDir = join(process.cwd(), 'tickets');
+    }
+
+    // Check for duplicates
+    const existingIds = findExistingSourceIds(ticketsDir, provider);
+    const toImport = issues.filter((i) => !existingIds.has(String(i.number)));
+
+    if (toImport.length === 0) {
+      return reply.send({ imported: 0, skipped: issues.length, files: [] });
+    }
+
+    if (!existsSync(ticketsDir)) {
+      mkdirSync(ticketsDir, { recursive: true });
+    }
+
+    const files: string[] = [];
+    let imported = 0;
+
+    for (const issue of toImport) {
+      const existing = existsSync(ticketsDir) ? readdirSync(ticketsDir).filter((f) => f.endsWith('.md')) : [];
+      const nextNum = (existing.length + 1).toString().padStart(3, '0');
+      const slug = issue.title.toLowerCase().replace(/[^a-z0-9]+/g, '-').slice(0, 40).replace(/-$/, '');
+      const fileName = `TICKET-001-${nextNum}-${slug}.md`;
+      const filePath = join(ticketsDir, fileName);
+
+      const frontmatter: Record<string, unknown> = {
+        title: issue.title,
+        status: 'to_convert',
+        source: provider,
+        source_id: issue.number,
+        source_url: issue.url,
+        labels: issue.labels,
+      };
+      if (epicId) frontmatter['epic_id'] = epicId;
+
+      const body = matter.stringify(issue.body ?? '', frontmatter);
+      writeFileSync(filePath, body, 'utf-8');
+      files.push(filePath);
+      imported++;
+    }
+
+    return reply.send({ imported, skipped: issues.length - imported, files });
+  });
+
+  done();
+};
+
+export const importRoutes = fp(importPlugin, { name: 'import-routes' });


### PR DESCRIPTION
## Summary
- `GET /api/import/github/issues?owner=&repo=&token=` — lists open GitHub issues via GitHub REST API (native fetch, no octokit)
- `GET /api/import/gitlab/issues?projectId=&instanceUrl=&token=` — lists open GitLab issues via GitLab REST API
- `POST /api/import/issues` — imports selected issues as ticket `.md` files with frontmatter (`source`, `source_id`, `source_url`, `labels`); skips already-imported issues; derives tickets directory from first repo's `path` in the database
- New `ImportIssues` page with multi-step UI: provider selector → fetch issues → checkbox selection → epic association → confirm import
- Duplicate detection: checks `source_id` in existing ticket frontmatter before writing
- Periodic sync UI stub in the import page (scheduler deferred to Phase 15)
- Sidebar nav item: "Import Issues"
- Header breadcrumb label: "Import Issues"

Closes #36

## Test plan
- [ ] Select GitHub provider, enter a public repo (no token), click Fetch Issues → issues appear
- [ ] Select issues, click Import → ticket files created in tickets dir
- [ ] Re-import same issues → skipped count shown
- [ ] Associate with an epic → epic_id in ticket frontmatter
- [ ] GitLab flow works with a valid project ID and token