### PR TITLE
feat(deployment): ScopedFileSystemProvider + UserScopedSSE

### DIFF
--- a/tools/web-server/src/server/deployment/hosted/scoped-fs-provider.ts
+++ b/tools/web-server/src/server/deployment/hosted/scoped-fs-provider.ts
@@ -1,0 +1,87 @@
+import * as fs from 'fs';
+import * as fsp from 'fs/promises';
+import type { ReadStream, FSWatcher } from 'fs';
+import type { FileSystemProvider } from '../types.js';
+
+/**
+ * Scoped filesystem provider for hosted (multi-user) deployment.
+ * Restricts all filesystem operations to the user's root directory
+ * with path traversal protection using realpathSync + startsWith checks.
+ */
+export class ScopedFileSystemProvider implements FileSystemProvider {
+  readonly type = 'scoped' as const;
+  private resolvedRoot: string;
+
+  constructor(private rootDir: string) {
+    this.resolvedRoot = fs.realpathSync(rootDir);
+  }
+
+  /**
+   * Validates that the requested path resolves within the scoped root.
+   * - Rejects paths containing '..' segments (defense in depth)
+   * - Resolves symlinks via realpathSync before checking prefix
+   * - Throws on violation and logs the attempt (does not expose paths to client)
+   */
+  private assertWithinScope(requestedPath: string): string {
+    // Defense in depth: reject '..' segments even if they would resolve within scope
+    const segments = requestedPath.split('/');
+    if (segments.includes('..')) {
+      console.error(`[ScopedFS] Path traversal attempt blocked (.. segment): request for path outside scope`);
+      throw new Error('Access denied: path traversal not allowed');
+    }
+
+    let resolved: string;
+    try {
+      resolved = fs.realpathSync(requestedPath);
+    } catch {
+      console.error(`[ScopedFS] Path resolution failed for requested path`);
+      throw new Error('Access denied: path could not be resolved');
+    }
+
+    if (!resolved.startsWith(this.resolvedRoot)) {
+      console.error(`[ScopedFS] Path traversal attempt blocked: resolved path is outside scoped root`);
+      throw new Error('Access denied: path outside allowed scope');
+    }
+
+    return resolved;
+  }
+
+  async readFile(path: string): Promise<Buffer> {
+    const safe = this.assertWithinScope(path);
+    return fsp.readFile(safe);
+  }
+
+  async readdir(path: string): Promise<string[]> {
+    const safe = this.assertWithinScope(path);
+    return fsp.readdir(safe);
+  }
+
+  async stat(path: string): Promise<{ size: number; mtimeMs: number; isDirectory: boolean }> {
+    const safe = this.assertWithinScope(path);
+    const stats = await fsp.stat(safe);
+    return {
+      size: stats.size,
+      mtimeMs: stats.mtimeMs,
+      isDirectory: stats.isDirectory(),
+    };
+  }
+
+  async exists(path: string): Promise<boolean> {
+    try {
+      this.assertWithinScope(path);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  createReadStream(path: string, options?: { start?: number; encoding?: BufferEncoding }): ReadStream {
+    const safe = this.assertWithinScope(path);
+    return fs.createReadStream(safe, options);
+  }
+
+  watch(path: string, options?: { recursive?: boolean }): FSWatcher {
+    const safe = this.assertWithinScope(path);
+    return fs.watch(safe, { recursive: options?.recursive });
+  }
+}

--- a/tools/web-server/src/server/deployment/hosted/user-scoped-sse.ts
+++ b/tools/web-server/src/server/deployment/hosted/user-scoped-sse.ts
@@ -1,0 +1,88 @@
+import type { FastifyReply } from 'fastify';
+import type { EventBroadcaster } from '../types.js';
+
+/**
+ * User-scoped SSE implementation for hosted (multi-user) deployment.
+ * Routes events to per-user connection sets so each user only receives
+ * events for their own sessions. Supports unscoped broadcast for
+ * admin/system-wide events.
+ */
+export class UserScopedSSE implements EventBroadcaster {
+  private userClients = new Map<string, Set<FastifyReply>>();
+
+  get clientCount(): number {
+    let count = 0;
+    for (const clients of this.userClients.values()) {
+      count += clients.size;
+    }
+    return count;
+  }
+
+  addClient(reply: FastifyReply, scope?: { userId: string }): void {
+    if (!scope?.userId) {
+      throw new Error('UserScopedSSE requires a userId scope');
+    }
+
+    let clients = this.userClients.get(scope.userId);
+    if (!clients) {
+      clients = new Set();
+      this.userClients.set(scope.userId, clients);
+    }
+    clients.add(reply);
+
+    // Clean up on connection close or error
+    reply.raw.on('close', () => {
+      this.removeClient(reply);
+    });
+    reply.raw.on('error', () => {
+      this.removeClient(reply);
+    });
+  }
+
+  removeClient(reply: FastifyReply): void {
+    for (const [userId, clients] of this.userClients.entries()) {
+      if (clients.delete(reply)) {
+        if (clients.size === 0) {
+          this.userClients.delete(userId);
+        }
+        break;
+      }
+    }
+  }
+
+  broadcast(event: string, data: unknown, scope?: { userId?: string }): void {
+    if (scope?.userId) {
+      // Send only to this user's connections
+      const clients = this.userClients.get(scope.userId);
+      if (clients) {
+        this.sendToClients(clients, event, data);
+      }
+    } else {
+      // Admin broadcast: send to all connected clients across all users
+      for (const clients of this.userClients.values()) {
+        this.sendToClients(clients, event, data);
+      }
+    }
+  }
+
+  private sendToClients(clients: Set<FastifyReply>, event: string, data: unknown): void {
+    const safeEvent = event.replace(/[\n\r]/g, '');
+    const payload = `event: ${safeEvent}\ndata: ${JSON.stringify(data)}\n\n`;
+    const dead: FastifyReply[] = [];
+
+    for (const client of clients) {
+      try {
+        const ok = client.raw.write(payload);
+        if (!ok) {
+          dead.push(client);
+        }
+      } catch {
+        dead.push(client);
+      }
+    }
+
+    for (const client of dead) {
+      this.removeClient(client);
+    }
+  }
+}

--- a/tools/web-server/src/server/deployment/index.ts
+++ b/tools/web-server/src/server/deployment/index.ts
@@ -6,3 +6,12 @@ export { LocalDeploymentContext } from './local/local-deployment-context.js';
 export { DirectFileSystemProvider } from './local/direct-fs-provider.js';
 export { NoopAuthProvider } from './local/noop-auth-provider.js';
 export { BroadcastAllSSE } from './local/broadcast-all-sse.js';
+
+// Hosted implementations
+export { HostedDeploymentContext } from './hosted/hosted-deployment-context.js';
+export { HostedAuthProvider } from './hosted/hosted-auth-provider.js';
+export { ScopedFileSystemProvider } from './hosted/scoped-fs-provider.js';
+export { UserScopedSSE } from './hosted/user-scoped-sse.js';
+export { createPool, getPool, closePool } from './hosted/db/pg-client.js';
+export type { PgPool, PgPoolClient } from './hosted/db/pg-client.js';
+export { runMigrations } from './hosted/db/migrate.js';


### PR DESCRIPTION
## Summary
- **ScopedFileSystemProvider** (#24): Hosted-mode filesystem provider that restricts all operations to a user's root directory. Uses `realpathSync` + `startsWith` for path traversal protection with defense-in-depth rejection of `..` segments. Implements the full `FileSystemProvider` interface (readFile, readdir, stat, exists, createReadStream, watch).
- **UserScopedSSE** (#25): Per-user SSE event broadcaster using `Map<string, Set<FastifyReply>>`. Routes events to authenticated user's connections only. Supports unscoped admin broadcast. Handles connection lifecycle (close/error cleanup, dead connection pruning).
- Both classes exported from the deployment barrel (`index.ts`).

Closes #24, closes #25.

## Test plan
- [x] `npm run verify` passes (tsc --noEmit + vitest run: 910 tests, 0 failures)
- [x] Follows existing patterns from `DirectFileSystemProvider` and `BroadcastAllSSE`
- [x] Implements all methods of `FileSystemProvider` and `EventBroadcaster` interfaces