### PR TITLE
feat(deployment): Team Management (#28)

### DIFF
--- a/tools/web-server/src/client/App.tsx
+++ b/tools/web-server/src/client/App.tsx
@@ -12,6 +12,8 @@ import { DependencyGraph } from './pages/DependencyGraph.js';
 import { Settings } from './pages/Settings.js';
 import { BranchHierarchy } from './pages/BranchHierarchy.js';
 import { ImportIssues } from './pages/ImportIssues.js';
+import { TeamManagement } from './pages/TeamManagement.js';
+import { TeamDetail } from './pages/TeamDetail.js';
 import { useInteractionSSE } from './api/interaction-hooks.js';
 import { useSessionMap } from './api/use-session-map.js';
 import { InteractionOverlay } from './components/interaction/InteractionOverlay.js';
@@ -47,6 +49,8 @@ function AppContent() {
             <Route path="/graph" element={<DependencyGraph />} />
             <Route path="/branches" element={<BranchHierarchy />} />
             <Route path="/settings" element={<Settings />} />
+            <Route path="/teams" element={<TeamManagement />} />
+            <Route path="/teams/:teamId" element={<TeamDetail />} />
             <Route path="/import" element={<ImportIssues />} />
           </Routes>
         </Layout>

--- a/tools/web-server/src/client/components/layout/Sidebar.tsx
+++ b/tools/web-server/src/client/components/layout/Sidebar.tsx
@@ -1,5 +1,5 @@
 import { Link, useLocation } from 'react-router-dom';
-import { LayoutDashboard, Layers, GitBranch, GitFork, X, Settings as SettingsIcon, Download } from 'lucide-react';
+import { LayoutDashboard, Layers, GitBranch, GitFork, X, Settings as SettingsIcon, Download, Users } from 'lucide-react';
 import { useSidebarStore } from '../../store/sidebar-store.js';
 
 const navItems = [
@@ -7,6 +7,7 @@ const navItems = [
   { to: '/board', label: 'Board', icon: Layers },
   { to: '/graph', label: 'Dependency Graph', icon: GitBranch },
   { to: '/branches', label: 'Branch Hierarchy', icon: GitFork },
+  { to: '/teams', label: 'Teams', icon: Users },
   { to: '/settings', label: 'Settings', icon: SettingsIcon },
   { to: '/import', label: 'Import Issues', icon: Download },
 ];

--- a/tools/web-server/src/client/pages/TeamDetail.tsx
+++ b/tools/web-server/src/client/pages/TeamDetail.tsx
@@ -1,0 +1,303 @@
+import { useState } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { apiFetch } from '../api/client.js';
+
+interface Team {
+  id: string;
+  name: string;
+  description: string | null;
+  created_by: string;
+  created_at: string;
+  updated_at: string;
+}
+
+interface TeamMember {
+  id: string;
+  team_id: string;
+  user_id: string;
+  added_at: string;
+  username?: string;
+}
+
+interface TeamRepoAccess {
+  id: string;
+  team_id: string;
+  repo_id: number;
+  role_name: string;
+  created_at: string;
+  repo_name?: string;
+}
+
+interface TeamDetailResponse {
+  team: Team;
+  members: TeamMember[];
+  repoAccess: TeamRepoAccess[];
+}
+
+interface RepoItem {
+  id: number;
+  name: string;
+  path: string;
+}
+
+function useTeamDetail(teamId: string) {
+  return useQuery({
+    queryKey: ['teams', teamId],
+    queryFn: () => apiFetch<TeamDetailResponse>(`/teams/${teamId}`),
+    enabled: !!teamId,
+  });
+}
+
+function useRepos() {
+  return useQuery({
+    queryKey: ['repos'],
+    queryFn: () => apiFetch<RepoItem[]>('/repos'),
+  });
+}
+
+function MembersSection({
+  teamId,
+  members,
+}: {
+  teamId: string;
+  members: TeamMember[];
+}) {
+  const queryClient = useQueryClient();
+  const [userId, setUserId] = useState('');
+
+  const addMutation = useMutation({
+    mutationFn: (addUserId: string) =>
+      apiFetch(`/teams/${teamId}/members`, {
+        method: 'POST',
+        body: JSON.stringify({ userId: addUserId }),
+      }),
+    onSuccess: () => {
+      setUserId('');
+      queryClient.invalidateQueries({ queryKey: ['teams', teamId] });
+    },
+  });
+
+  const removeMutation = useMutation({
+    mutationFn: (removeUserId: string) =>
+      apiFetch(`/teams/${teamId}/members/${removeUserId}`, {
+        method: 'DELETE',
+      }),
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: ['teams', teamId] }),
+  });
+
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white p-6">
+      <h2 className="mb-4 text-base font-semibold text-slate-800">Members</h2>
+
+      {/* Add member */}
+      <div className="flex gap-2 mb-4">
+        <input
+          type="text"
+          value={userId}
+          onChange={(e) => setUserId(e.target.value)}
+          placeholder="User ID"
+          className="flex-1 rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-900 placeholder-slate-400 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+        />
+        <button
+          onClick={() => userId.trim() && addMutation.mutate(userId.trim())}
+          disabled={!userId.trim() || addMutation.isPending}
+          className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+        >
+          Add
+        </button>
+      </div>
+
+      {/* Members list */}
+      {members.length === 0 ? (
+        <p className="text-sm text-slate-500">No members yet.</p>
+      ) : (
+        <div className="divide-y divide-slate-100">
+          {members.map((m) => (
+            <div
+              key={m.id}
+              className="flex items-center justify-between py-2"
+            >
+              <span className="text-sm text-slate-700">
+                {m.username || m.user_id}
+              </span>
+              <button
+                onClick={() => removeMutation.mutate(m.user_id)}
+                className="text-xs text-red-500 hover:text-red-700"
+              >
+                Remove
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function RepoAccessSection({
+  teamId,
+  repoAccess,
+}: {
+  teamId: string;
+  repoAccess: TeamRepoAccess[];
+}) {
+  const queryClient = useQueryClient();
+  const { data: repos } = useRepos();
+  const [selectedRepoId, setSelectedRepoId] = useState('');
+  const [selectedRole, setSelectedRole] = useState<
+    'admin' | 'developer' | 'viewer'
+  >('developer');
+
+  const setAccessMutation = useMutation({
+    mutationFn: ({
+      repoId,
+      roleName,
+    }: {
+      repoId: number;
+      roleName: string;
+    }) =>
+      apiFetch(`/teams/${teamId}/repos`, {
+        method: 'POST',
+        body: JSON.stringify({ repoId, roleName }),
+      }),
+    onSuccess: () => {
+      setSelectedRepoId('');
+      queryClient.invalidateQueries({ queryKey: ['teams', teamId] });
+    },
+  });
+
+  const removeAccessMutation = useMutation({
+    mutationFn: (repoId: number) =>
+      apiFetch(`/teams/${teamId}/repos/${repoId}`, {
+        method: 'DELETE',
+      }),
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: ['teams', teamId] }),
+  });
+
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white p-6">
+      <h2 className="mb-4 text-base font-semibold text-slate-800">
+        Repo Access
+      </h2>
+
+      {/* Add repo access */}
+      <div className="flex gap-2 mb-4">
+        <select
+          value={selectedRepoId}
+          onChange={(e) => setSelectedRepoId(e.target.value)}
+          className="flex-1 rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-900 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+        >
+          <option value="">Select a repo...</option>
+          {repos?.map((r) => (
+            <option key={r.id} value={r.id}>
+              {r.name}
+            </option>
+          ))}
+        </select>
+        <select
+          value={selectedRole}
+          onChange={(e) =>
+            setSelectedRole(
+              e.target.value as 'admin' | 'developer' | 'viewer',
+            )
+          }
+          className="rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-900 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+        >
+          <option value="admin">Admin</option>
+          <option value="developer">Developer</option>
+          <option value="viewer">Viewer</option>
+        </select>
+        <button
+          onClick={() =>
+            selectedRepoId &&
+            setAccessMutation.mutate({
+              repoId: parseInt(selectedRepoId, 10),
+              roleName: selectedRole,
+            })
+          }
+          disabled={!selectedRepoId || setAccessMutation.isPending}
+          className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+        >
+          Assign
+        </button>
+      </div>
+
+      {/* Repo access list */}
+      {repoAccess.length === 0 ? (
+        <p className="text-sm text-slate-500">No repo access configured.</p>
+      ) : (
+        <div className="divide-y divide-slate-100">
+          {repoAccess.map((ra) => (
+            <div
+              key={ra.id}
+              className="flex items-center justify-between py-2"
+            >
+              <div>
+                <span className="text-sm font-medium text-slate-700">
+                  {ra.repo_name || `Repo #${ra.repo_id}`}
+                </span>
+                <span className="ml-2 inline-flex items-center rounded-full bg-slate-100 px-2 py-0.5 text-xs font-medium text-slate-600">
+                  {ra.role_name}
+                </span>
+              </div>
+              <button
+                onClick={() => removeAccessMutation.mutate(ra.repo_id)}
+                className="text-xs text-red-500 hover:text-red-700"
+              >
+                Revoke
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function TeamDetail() {
+  const { teamId } = useParams<{ teamId: string }>();
+  const { data, isLoading, error } = useTeamDetail(teamId ?? '');
+
+  if (isLoading) {
+    return <p className="text-sm text-slate-500">Loading team...</p>;
+  }
+
+  if (error) {
+    return (
+      <p className="text-sm text-red-600">
+        Failed to load team: {(error as Error).message}
+      </p>
+    );
+  }
+
+  if (!data) {
+    return <p className="text-sm text-slate-500">Team not found.</p>;
+  }
+
+  const { team, members, repoAccess } = data;
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-3">
+        <Link
+          to="/teams"
+          className="text-sm text-blue-600 hover:text-blue-800"
+        >
+          Teams
+        </Link>
+        <span className="text-sm text-slate-400">/</span>
+        <h1 className="text-2xl font-bold text-slate-900">{team.name}</h1>
+      </div>
+
+      {team.description && (
+        <p className="text-sm text-slate-600">{team.description}</p>
+      )}
+
+      <MembersSection teamId={team.id} members={members} />
+      <RepoAccessSection teamId={team.id} repoAccess={repoAccess} />
+    </div>
+  );
+}

--- a/tools/web-server/src/client/pages/TeamManagement.tsx
+++ b/tools/web-server/src/client/pages/TeamManagement.tsx
@@ -1,0 +1,158 @@
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { Link } from 'react-router-dom';
+import { apiFetch } from '../api/client.js';
+
+interface Team {
+  id: string;
+  name: string;
+  description: string | null;
+  created_by: string;
+  created_at: string;
+  updated_at: string;
+  member_count: number;
+}
+
+function useTeams() {
+  return useQuery({
+    queryKey: ['teams'],
+    queryFn: () => apiFetch<Team[]>('/teams'),
+  });
+}
+
+function CreateTeamForm({ onCreated }: { onCreated: () => void }) {
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const mutation = useMutation({
+    mutationFn: () =>
+      apiFetch<Team>('/teams', {
+        method: 'POST',
+        body: JSON.stringify({ name, description }),
+      }),
+    onSuccess: () => {
+      setName('');
+      setDescription('');
+      setError(null);
+      onCreated();
+    },
+    onError: (err: Error) => setError(err.message),
+  });
+
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white p-6">
+      <h2 className="mb-4 text-base font-semibold text-slate-800">Create Team</h2>
+      <div className="space-y-4">
+        <div>
+          <label className="block text-sm font-medium text-slate-600 mb-1">
+            Team Name
+          </label>
+          <input
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="Engineering"
+            className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-900 placeholder-slate-400 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-slate-600 mb-1">
+            Description
+          </label>
+          <input
+            type="text"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="Core engineering team"
+            className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-900 placeholder-slate-400 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+          />
+        </div>
+        {error && <p className="text-sm text-red-600">{error}</p>}
+        <button
+          onClick={() => mutation.mutate()}
+          disabled={!name.trim() || mutation.isPending}
+          className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:opacity-50"
+        >
+          {mutation.isPending ? 'Creating...' : 'Create Team'}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function TeamList({ teams }: { teams: Team[] }) {
+  const queryClient = useQueryClient();
+
+  const deleteMutation = useMutation({
+    mutationFn: (teamId: string) =>
+      apiFetch(`/teams/${teamId}`, { method: 'DELETE' }),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['teams'] }),
+  });
+
+  if (teams.length === 0) {
+    return (
+      <div className="rounded-lg border border-slate-200 bg-white p-6 text-center text-sm text-slate-500">
+        No teams yet. Create one above.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {teams.map((team) => (
+        <div
+          key={team.id}
+          className="rounded-lg border border-slate-200 bg-white p-4 flex items-center justify-between"
+        >
+          <div className="flex-1">
+            <Link
+              to={`/teams/${team.id}`}
+              className="text-sm font-semibold text-blue-600 hover:text-blue-800"
+            >
+              {team.name}
+            </Link>
+            {team.description && (
+              <p className="text-xs text-slate-500 mt-1">{team.description}</p>
+            )}
+            <p className="text-xs text-slate-400 mt-1">
+              {team.member_count} member{team.member_count !== 1 ? 's' : ''}
+            </p>
+          </div>
+          <button
+            onClick={() => {
+              if (confirm(`Delete team "${team.name}"?`)) {
+                deleteMutation.mutate(team.id);
+              }
+            }}
+            className="rounded-md border border-red-200 bg-white px-3 py-1 text-xs font-medium text-red-600 hover:bg-red-50"
+          >
+            Delete
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function TeamManagement() {
+  const { data: teams, isLoading, error, refetch } = useTeams();
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold text-slate-900">Team Management</h1>
+
+      <CreateTeamForm onCreated={() => refetch()} />
+
+      {isLoading && (
+        <p className="text-sm text-slate-500">Loading teams...</p>
+      )}
+      {error && (
+        <p className="text-sm text-red-600">
+          Failed to load teams: {(error as Error).message}
+        </p>
+      )}
+      {teams && <TeamList teams={teams} />}
+    </div>
+  );
+}

--- a/tools/web-server/src/server/app.ts
+++ b/tools/web-server/src/server/app.ts
@@ -13,6 +13,7 @@ import type { DeploymentContext } from './deployment/index.js';
 import { LocalDeploymentContext } from './deployment/index.js';
 import { HostedDeploymentContext } from './deployment/index.js';
 import { RoleService, registerRbacRoutes } from './deployment/index.js';
+import { TeamService, registerTeamRoutes } from './deployment/index.js';
 import { boardRoutes } from './routes/board.js';
 import { epicRoutes } from './routes/epics.js';
 import { ticketRoutes } from './routes/tickets.js';
@@ -285,11 +286,14 @@ export async function createServer(
 
   await app.register(searchRoutes);
 
-  // RBAC routes — only in hosted mode (requires PostgreSQL pool)
+  // RBAC and Team routes — only in hosted mode (requires PostgreSQL pool)
   if (deploymentContext.mode === 'hosted') {
     const hostedCtx = deploymentContext as HostedDeploymentContext;
     const roleService = new RoleService(hostedCtx.getPool());
     registerRbacRoutes(app, roleService);
+
+    const teamService = new TeamService(hostedCtx.getPool());
+    registerTeamRoutes(app, teamService);
   }
 
   // --- Static serving / dev proxy ---

--- a/tools/web-server/src/server/deployment/hosted/db/migrations/003_teams.sql
+++ b/tools/web-server/src/server/deployment/hosted/db/migrations/003_teams.sql
@@ -1,0 +1,35 @@
+-- Team management tables: teams, team_members, team_repo_access.
+
+-- Teams
+CREATE TABLE IF NOT EXISTS teams (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name VARCHAR(255) NOT NULL,
+  description TEXT,
+  created_by UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Team members
+CREATE TABLE IF NOT EXISTS team_members (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  team_id UUID NOT NULL REFERENCES teams(id) ON DELETE CASCADE,
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  added_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (team_id, user_id)
+);
+
+-- Team repo access
+CREATE TABLE IF NOT EXISTS team_repo_access (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  team_id UUID NOT NULL REFERENCES teams(id) ON DELETE CASCADE,
+  repo_id INTEGER NOT NULL REFERENCES repos(id) ON DELETE CASCADE,
+  role_name VARCHAR(50) NOT NULL CHECK (role_name IN ('admin', 'developer', 'viewer')),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (team_id, repo_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_team_members_user_id ON team_members(user_id);
+CREATE INDEX IF NOT EXISTS idx_team_members_team_id ON team_members(team_id);
+CREATE INDEX IF NOT EXISTS idx_team_repo_access_team_id ON team_repo_access(team_id);
+CREATE INDEX IF NOT EXISTS idx_team_repo_access_repo_id ON team_repo_access(repo_id);

--- a/tools/web-server/src/server/deployment/hosted/teams/index.ts
+++ b/tools/web-server/src/server/deployment/hosted/teams/index.ts
@@ -1,0 +1,2 @@
+export { TeamService, type Team, type TeamMember, type TeamRepoAccess } from './team-service.js';
+export { registerTeamRoutes } from './team-routes.js';

--- a/tools/web-server/src/server/deployment/hosted/teams/team-routes.ts
+++ b/tools/web-server/src/server/deployment/hosted/teams/team-routes.ts
@@ -1,0 +1,116 @@
+import type { FastifyInstance } from 'fastify';
+import type { User } from '../../types.js';
+import type { TeamService } from './team-service.js';
+
+export function registerTeamRoutes(app: FastifyInstance, teamService: TeamService): void {
+  // Create team
+  app.post<{ Body: { name: string; description?: string } }>(
+    '/api/teams',
+    async (request, reply) => {
+      const user = (request as typeof request & { user?: User }).user;
+      if (!user?.id) return reply.code(401).send({ error: 'Unauthorized' });
+      const { name, description } = request.body;
+      const team = await teamService.createTeam(name, description ?? '', user.id);
+      return team;
+    },
+  );
+
+  // List all teams
+  app.get('/api/teams', async () => {
+    return teamService.getAllTeams();
+  });
+
+  // Get team detail
+  app.get<{ Params: { teamId: string } }>(
+    '/api/teams/:teamId',
+    async (request, reply) => {
+      const detail = await teamService.getTeamDetail(request.params.teamId);
+      if (!detail) return reply.code(404).send({ error: 'Team not found' });
+      return detail;
+    },
+  );
+
+  // Delete team
+  app.delete<{ Params: { teamId: string } }>(
+    '/api/teams/:teamId',
+    async (request, reply) => {
+      const user = (request as typeof request & { user?: User }).user;
+      if (!user?.id) return reply.code(401).send({ error: 'Unauthorized' });
+      await teamService.deleteTeam(request.params.teamId);
+      return { success: true };
+    },
+  );
+
+  // Add member to team
+  app.post<{ Params: { teamId: string }; Body: { userId: string } }>(
+    '/api/teams/:teamId/members',
+    async (request, reply) => {
+      const user = (request as typeof request & { user?: User }).user;
+      if (!user?.id) return reply.code(401).send({ error: 'Unauthorized' });
+      const { teamId } = request.params;
+      const { userId } = request.body;
+      await teamService.addMember(teamId, userId);
+      return { success: true };
+    },
+  );
+
+  // Remove member from team
+  app.delete<{ Params: { teamId: string; userId: string } }>(
+    '/api/teams/:teamId/members/:userId',
+    async (request, reply) => {
+      const user = (request as typeof request & { user?: User }).user;
+      if (!user?.id) return reply.code(401).send({ error: 'Unauthorized' });
+      const { teamId, userId } = request.params;
+      await teamService.removeMember(teamId, userId);
+      return { success: true };
+    },
+  );
+
+  // Set team repo access
+  app.post<{
+    Params: { teamId: string };
+    Body: { repoId: number; roleName: 'admin' | 'developer' | 'viewer' };
+  }>(
+    '/api/teams/:teamId/repos',
+    async (request, reply) => {
+      const user = (request as typeof request & { user?: User }).user;
+      if (!user?.id) return reply.code(401).send({ error: 'Unauthorized' });
+      const { teamId } = request.params;
+      const { repoId, roleName } = request.body;
+      await teamService.setTeamRepoAccess(teamId, repoId, roleName);
+      return { success: true };
+    },
+  );
+
+  // Remove team repo access
+  app.delete<{ Params: { teamId: string; repoId: string } }>(
+    '/api/teams/:teamId/repos/:repoId',
+    async (request, reply) => {
+      const user = (request as typeof request & { user?: User }).user;
+      if (!user?.id) return reply.code(401).send({ error: 'Unauthorized' });
+      const { teamId, repoId } = request.params;
+      await teamService.removeTeamRepoAccess(teamId, parseInt(repoId, 10));
+      return { success: true };
+    },
+  );
+
+  // Get user's teams
+  app.get<{ Params: { userId: string } }>(
+    '/api/users/:userId/teams',
+    async (request) => {
+      return teamService.getUserTeams(request.params.userId);
+    },
+  );
+
+  // Get effective role for a user on a repo
+  app.get<{ Params: { userId: string; repoId: string } }>(
+    '/api/users/:userId/repos/:repoId/effective-role',
+    async (request) => {
+      const role = await teamService.getEffectiveRole(
+        request.params.userId,
+        request.params.repoId,
+      );
+      return { effectiveRole: role };
+    },
+  );
+}

--- a/tools/web-server/src/server/deployment/hosted/teams/team-service.ts
+++ b/tools/web-server/src/server/deployment/hosted/teams/team-service.ts
@@ -1,0 +1,164 @@
+import type { Pool } from 'pg';
+import { type RoleName, ROLE_HIERARCHY } from '../rbac/role-service.js';
+
+export interface Team {
+  id: string;
+  name: string;
+  description: string | null;
+  created_by: string;
+  created_at: Date;
+  updated_at: Date;
+}
+
+export interface TeamMember {
+  id: string;
+  team_id: string;
+  user_id: string;
+  added_at: Date;
+  username?: string;
+}
+
+export interface TeamRepoAccess {
+  id: string;
+  team_id: string;
+  repo_id: number;
+  role_name: string;
+  created_at: Date;
+  repo_name?: string;
+}
+
+export class TeamService {
+  constructor(private readonly pool: Pool) {}
+
+  async createTeam(name: string, description: string, createdBy: string): Promise<Team> {
+    const result = await this.pool.query<Team>(
+      `INSERT INTO teams (name, description, created_by) VALUES ($1, $2, $3) RETURNING *`,
+      [name, description, createdBy],
+    );
+    return result.rows[0];
+  }
+
+  async deleteTeam(teamId: string): Promise<void> {
+    await this.pool.query(`DELETE FROM teams WHERE id = $1`, [teamId]);
+  }
+
+  async addMember(teamId: string, userId: string): Promise<void> {
+    await this.pool.query(
+      `INSERT INTO team_members (team_id, user_id) VALUES ($1, $2) ON CONFLICT DO NOTHING`,
+      [teamId, userId],
+    );
+  }
+
+  async removeMember(teamId: string, userId: string): Promise<void> {
+    await this.pool.query(
+      `DELETE FROM team_members WHERE team_id = $1 AND user_id = $2`,
+      [teamId, userId],
+    );
+  }
+
+  async getTeamMembers(teamId: string): Promise<TeamMember[]> {
+    const result = await this.pool.query<TeamMember>(
+      `SELECT tm.*, u.username FROM team_members tm
+       JOIN users u ON u.id = tm.user_id
+       WHERE tm.team_id = $1`,
+      [teamId],
+    );
+    return result.rows;
+  }
+
+  async setTeamRepoAccess(
+    teamId: string,
+    repoId: number,
+    roleName: 'admin' | 'developer' | 'viewer',
+  ): Promise<void> {
+    await this.pool.query(
+      `INSERT INTO team_repo_access (team_id, repo_id, role_name)
+       VALUES ($1, $2, $3)
+       ON CONFLICT (team_id, repo_id) DO UPDATE SET role_name = $3`,
+      [teamId, repoId, roleName],
+    );
+  }
+
+  async removeTeamRepoAccess(teamId: string, repoId: number): Promise<void> {
+    await this.pool.query(
+      `DELETE FROM team_repo_access WHERE team_id = $1 AND repo_id = $2`,
+      [teamId, repoId],
+    );
+  }
+
+  async getUserTeams(userId: string): Promise<Team[]> {
+    const result = await this.pool.query<Team>(
+      `SELECT t.* FROM teams t
+       JOIN team_members tm ON tm.team_id = t.id
+       WHERE tm.user_id = $1`,
+      [userId],
+    );
+    return result.rows;
+  }
+
+  async getEffectiveRole(userId: string, repoId: string): Promise<RoleName | null> {
+    // Individual role (repo-specific + global)
+    const individualResult = await this.pool.query<{ role_name: RoleName }>(
+      `SELECT role_name FROM roles
+       WHERE user_id = $1 AND (repo_id = $2::integer OR repo_id IS NULL)
+       ORDER BY CASE role_name
+         WHEN 'global_admin' THEN 4
+         WHEN 'admin' THEN 3
+         WHEN 'developer' THEN 2
+         WHEN 'viewer' THEN 1
+       END DESC
+       LIMIT 1`,
+      [userId, repoId],
+    );
+
+    // Team roles
+    const teamResult = await this.pool.query<{ role_name: RoleName }>(
+      `SELECT tra.role_name FROM team_repo_access tra
+       JOIN team_members tm ON tm.team_id = tra.team_id
+       WHERE tm.user_id = $1 AND tra.repo_id = $2::integer`,
+      [userId, repoId],
+    );
+
+    const allRoles: RoleName[] = [];
+    if (individualResult.rows.length > 0) allRoles.push(individualResult.rows[0].role_name);
+    for (const row of teamResult.rows) allRoles.push(row.role_name);
+
+    if (allRoles.length === 0) return null;
+    return allRoles.reduce((max, r) => (ROLE_HIERARCHY[r] > ROLE_HIERARCHY[max] ? r : max));
+  }
+
+  async getAllTeams(): Promise<(Team & { member_count: number })[]> {
+    const result = await this.pool.query<Team & { member_count: number }>(
+      `SELECT t.*, COUNT(tm.id)::int AS member_count
+       FROM teams t
+       LEFT JOIN team_members tm ON tm.team_id = t.id
+       GROUP BY t.id`,
+    );
+    return result.rows;
+  }
+
+  async getTeamDetail(
+    teamId: string,
+  ): Promise<{ team: Team; members: TeamMember[]; repoAccess: TeamRepoAccess[] } | null> {
+    const teamResult = await this.pool.query<Team>(
+      `SELECT * FROM teams WHERE id = $1`,
+      [teamId],
+    );
+    if (teamResult.rows.length === 0) return null;
+
+    const members = await this.getTeamMembers(teamId);
+
+    const accessResult = await this.pool.query<TeamRepoAccess>(
+      `SELECT tra.*, r.name as repo_name FROM team_repo_access tra
+       JOIN repos r ON r.id = tra.repo_id
+       WHERE tra.team_id = $1`,
+      [teamId],
+    );
+
+    return {
+      team: teamResult.rows[0],
+      members,
+      repoAccess: accessResult.rows,
+    };
+  }
+}

--- a/tools/web-server/src/server/deployment/index.ts
+++ b/tools/web-server/src/server/deployment/index.ts
@@ -19,3 +19,7 @@ export { runMigrations } from './hosted/db/migrate.js';
 // RBAC
 export { RoleService, type RoleName, ROLE_HIERARCHY, requireRole, extractRepoId } from './hosted/rbac/index.js';
 export { registerRbacRoutes } from './hosted/rbac/index.js';
+
+// Teams
+export { TeamService, type Team, type TeamMember, type TeamRepoAccess } from './hosted/teams/index.js';
+export { registerTeamRoutes } from './hosted/teams/index.js';


### PR DESCRIPTION
## Summary
- Adds teams, team_members, team_repo_access tables (003_teams.sql migration)
- Implements TeamService with CRUD, member management, repo access, and effective role computation (max of individual + team roles)
- Adds team API routes: create/list/detail/delete teams, manage members, set/revoke repo access, get user teams, get effective role
- Adds TeamManagement page with team list, create form, and delete confirmation
- Adds TeamDetail page with member management and repo access configuration
- Wires team routes into hosted deployment context alongside RBAC
- Adds Teams navigation link in sidebar with Users icon

## Implementation Details
- `TeamService.getEffectiveRole()` computes the highest role from individual assignments and all team-based repo access, integrating with the RBAC role hierarchy
- Migration uses `IF NOT EXISTS` for idempotent startup execution
- UI follows existing Settings page patterns (Tailwind, react-query, apiFetch)
- Routes registered only in hosted mode (requires PostgreSQL pool)

## Files Added/Modified
- `tools/web-server/src/server/deployment/hosted/db/migrations/003_teams.sql` - Schema migration
- `tools/web-server/src/server/deployment/hosted/teams/team-service.ts` - Service layer
- `tools/web-server/src/server/deployment/hosted/teams/team-routes.ts` - API routes
- `tools/web-server/src/server/deployment/hosted/teams/index.ts` - Barrel export
- `tools/web-server/src/server/deployment/index.ts` - Add team exports
- `tools/web-server/src/server/app.ts` - Wire team routes in hosted mode
- `tools/web-server/src/client/pages/TeamManagement.tsx` - Team list + create
- `tools/web-server/src/client/pages/TeamDetail.tsx` - Team detail with members + repo access
- `tools/web-server/src/client/App.tsx` - Add team routes
- `tools/web-server/src/client/components/layout/Sidebar.tsx` - Add Teams nav link

Closes #28