### PR TITLE
feat(docs): Slack integration test setup (#9)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,7 @@ NODE_ENV=production
 POSTGRES_DB=claude_workflow
 POSTGRES_USER=claude
 POSTGRES_PASSWORD=your_password
+
+# Slack integration testing
+SLACK_TEST_WEBHOOK_URL=
+SLACK_BOT_TOKEN=

--- a/docs/slack-test-setup.md
+++ b/docs/slack-test-setup.md
@@ -1,0 +1,102 @@
+# Slack Integration Test Setup
+
+This guide walks through configuring a Slack app and test channel for repeatable notification testing with the Claude workflow.
+
+## Prerequisites
+
+- Admin (or app-installation) access to a Slack workspace
+- Node.js 18+ installed locally
+
+---
+
+## Step 1: Create a Slack App
+
+1. Navigate to [api.slack.com/apps](https://api.slack.com/apps) and click **Create New App**.
+2. Choose **From scratch**.
+3. Enter an app name (e.g., `claude-workflow-test`) and select your target workspace.
+4. Click **Create App**.
+
+---
+
+## Step 2: Enable Incoming Webhooks
+
+1. In the app settings sidebar, click **Incoming Webhooks**.
+2. Toggle **Activate Incoming Webhooks** to **On**.
+3. Click **Add New Webhook to Workspace**.
+4. When prompted, select (or create) the channel `#claude-workflow-test` and click **Allow**.
+5. Copy the generated webhook URL — it will look like:
+   ```
+   https://hooks.slack.com/services/<TEAM_ID>/<BOT_ID>/<WEBHOOK_TOKEN>
+   ```
+6. Set this as your `SLACK_TEST_WEBHOOK_URL` environment variable.
+
+---
+
+## Step 3: Add Bot Token Scopes and Install the App
+
+1. In the sidebar, click **OAuth & Permissions**.
+2. Scroll to **Scopes → Bot Token Scopes** and add:
+   - `chat:write` — allows the bot to post messages
+   - `channels:history` — allows the bot to read channel message history
+3. Scroll to the top of the page and click **Install to Workspace** (or **Reinstall** if already installed).
+4. Review the permissions and click **Allow**.
+5. Copy the **Bot User OAuth Token** (starts with `xoxb-`).
+6. Set this as your `SLACK_BOT_TOKEN` environment variable.
+
+---
+
+## Step 4: Invite the Bot to the Test Channel
+
+In Slack, open `#claude-workflow-test` and run:
+
+```
+/invite @claude-workflow-test
+```
+
+Replace `claude-workflow-test` with the name you gave your app. The bot must be a member of the channel to read its history.
+
+---
+
+## Step 5: Configure Environment Variables
+
+Add the following to your local `.env` file (see `.env.example` for the full template):
+
+```bash
+SLACK_TEST_WEBHOOK_URL=https://hooks.slack.com/services/<TEAM_ID>/<BOT_ID>/<WEBHOOK_TOKEN>
+SLACK_BOT_TOKEN=xoxb-...
+```
+
+---
+
+## Step 6: Run the Verification Script
+
+```bash
+npx ts-node scripts/verify-slack.ts
+```
+
+The script will:
+1. Post a timestamped test message via the webhook.
+2. Wait 2 seconds for Slack to process the message.
+3. Look up the `#claude-workflow-test` channel ID via the Bot Token.
+4. Fetch recent channel history and confirm the test message appears.
+
+A successful run prints:
+
+```
+✓ Webhook POST succeeded
+✓ Found channel #claude-workflow-test (C01234ABCDE)
+✓ Test message found in channel history
+All checks passed.
+```
+
+---
+
+## Troubleshooting
+
+| Error | Cause | Fix |
+|---|---|---|
+| `invalid_auth` | `SLACK_BOT_TOKEN` is wrong or expired | Re-copy the `xoxb-` token from **OAuth & Permissions** |
+| `channel_not_found` | Bot is not a member of the channel, or channel name is wrong | Run `/invite @<app-name>` in `#claude-workflow-test` |
+| `missing_scope` | Required scope was not added before installing | Add the missing scope under **OAuth & Permissions → Bot Token Scopes**, then reinstall the app |
+| Webhook returns `no_service` | Webhook URL is stale or was regenerated | Copy the current webhook URL from **Incoming Webhooks** and update `SLACK_TEST_WEBHOOK_URL` |
+| Message not found in history | `channels:history` scope missing or bot not in channel | Verify scopes and channel membership, then re-run |

--- a/scripts/verify-slack.ts
+++ b/scripts/verify-slack.ts
@@ -1,0 +1,219 @@
+// Run with: npx ts-node scripts/verify-slack.ts
+
+import * as https from "https";
+import { URL } from "url";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function pass(msg: string): void {
+  console.log(`\u2713 ${msg}`);
+}
+
+function fail(msg: string): void {
+  console.error(`\u2717 ${msg}`);
+}
+
+function httpsPost(
+  urlStr: string,
+  body: string,
+  headers: Record<string, string>
+): Promise<{ statusCode: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    const parsed = new URL(urlStr);
+    const options: https.RequestOptions = {
+      hostname: parsed.hostname,
+      path: parsed.pathname + parsed.search,
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Content-Length": Buffer.byteLength(body),
+        ...headers,
+      },
+    };
+
+    const req = https.request(options, (res) => {
+      let data = "";
+      res.on("data", (chunk: Buffer) => {
+        data += chunk.toString();
+      });
+      res.on("end", () => {
+        resolve({ statusCode: res.statusCode ?? 0, body: data });
+      });
+    });
+
+    req.on("error", reject);
+    req.write(body);
+    req.end();
+  });
+}
+
+function httpsGet(
+  urlStr: string,
+  headers: Record<string, string>
+): Promise<{ statusCode: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    const parsed = new URL(urlStr);
+    const options: https.RequestOptions = {
+      hostname: parsed.hostname,
+      path: parsed.pathname + parsed.search,
+      method: "GET",
+      headers,
+    };
+
+    const req = https.request(options, (res) => {
+      let data = "";
+      res.on("data", (chunk: Buffer) => {
+        data += chunk.toString();
+      });
+      res.on("end", () => {
+        resolve({ statusCode: res.statusCode ?? 0, body: data });
+      });
+    });
+
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  // 1. Read and validate environment variables
+  const webhookUrl = process.env.SLACK_TEST_WEBHOOK_URL;
+  const botToken = process.env.SLACK_BOT_TOKEN;
+
+  if (!webhookUrl) {
+    console.error(
+      "Error: SLACK_TEST_WEBHOOK_URL is not set.\n" +
+        "Set it to the Incoming Webhook URL from your Slack app settings."
+    );
+    process.exit(1);
+  }
+
+  if (!botToken) {
+    console.error(
+      "Error: SLACK_BOT_TOKEN is not set.\n" +
+        "Set it to the Bot User OAuth Token (xoxb-...) from your Slack app settings."
+    );
+    process.exit(1);
+  }
+
+  const timestamp = new Date().toISOString();
+  const testText = `Claude workflow Slack test - ${timestamp}`;
+
+  // 2. POST message via webhook
+  let webhookOk = false;
+  try {
+    const webhookBody = JSON.stringify({ text: testText });
+    const webhookRes = await httpsPost(webhookUrl, webhookBody, {});
+
+    if (webhookRes.statusCode === 200 && webhookRes.body === "ok") {
+      pass("Webhook POST succeeded");
+      webhookOk = true;
+    } else {
+      fail(
+        `Webhook POST failed (status ${webhookRes.statusCode}): ${webhookRes.body}`
+      );
+    }
+  } catch (err) {
+    fail(`Webhook POST threw an error: ${(err as Error).message}`);
+  }
+
+  if (!webhookOk) {
+    process.exit(1);
+  }
+
+  // 3. Wait for Slack to process the message
+  await sleep(2000);
+
+  // 4. Find the #claude-workflow-test channel ID via conversations.list
+  const authHeader = { Authorization: `Bearer ${botToken}` };
+  let channelId: string | null = null;
+
+  try {
+    const listRes = await httpsGet(
+      "https://slack.com/api/conversations.list?types=public_channel,private_channel&limit=200",
+      authHeader
+    );
+
+    const listJson = JSON.parse(listRes.body) as {
+      ok: boolean;
+      error?: string;
+      channels?: Array<{ id: string; name: string }>;
+    };
+
+    if (!listJson.ok) {
+      fail(`conversations.list failed: ${listJson.error ?? "unknown error"}`);
+      process.exit(1);
+    }
+
+    const channel = (listJson.channels ?? []).find(
+      (c) => c.name === "claude-workflow-test"
+    );
+
+    if (!channel) {
+      fail(
+        "channel_not_found: #claude-workflow-test not found. " +
+          "Make sure the bot is invited to the channel (/invite @<app-name>)."
+      );
+      process.exit(1);
+    }
+
+    channelId = channel.id;
+    pass(`Found channel #claude-workflow-test (${channelId})`);
+  } catch (err) {
+    fail(`conversations.list threw an error: ${(err as Error).message}`);
+    process.exit(1);
+  }
+
+  // 5. Fetch channel history and verify the test message appears
+  try {
+    const historyRes = await httpsGet(
+      `https://slack.com/api/conversations.history?channel=${channelId}&limit=20`,
+      authHeader
+    );
+
+    const historyJson = JSON.parse(historyRes.body) as {
+      ok: boolean;
+      error?: string;
+      messages?: Array<{ text: string }>;
+    };
+
+    if (!historyJson.ok) {
+      fail(
+        `conversations.history failed: ${historyJson.error ?? "unknown error"}`
+      );
+      process.exit(1);
+    }
+
+    const found = (historyJson.messages ?? []).some((m) =>
+      m.text.includes(timestamp)
+    );
+
+    if (found) {
+      pass("Test message found in channel history");
+    } else {
+      fail(
+        "Test message not found in channel history. " +
+          "The webhook may have posted to a different channel, or the message was delayed."
+      );
+      process.exit(1);
+    }
+  } catch (err) {
+    fail(`conversations.history threw an error: ${(err as Error).message}`);
+    process.exit(1);
+  }
+
+  console.log("\nAll checks passed.");
+  process.exit(0);
+}
+
+main();


### PR DESCRIPTION
## Summary

- Adds `docs/slack-test-setup.md`: step-by-step guide for creating a Slack app, enabling Incoming Webhooks, configuring bot token scopes, inviting the bot to `#claude-workflow-test`, and troubleshooting common errors
- Adds `scripts/verify-slack.ts`: verification script using only built-in Node.js modules (`https`, `url`) that posts a timestamped message via webhook then confirms it appears in channel history via the Slack API
- Updates `.env.example` with `SLACK_TEST_WEBHOOK_URL` and `SLACK_BOT_TOKEN` variables

Closes #9

## Test plan

- [ ] Set `SLACK_TEST_WEBHOOK_URL` and `SLACK_BOT_TOKEN` from a real Slack app
- [ ] Run `npx ts-node scripts/verify-slack.ts` and confirm all three checks print with a checkmark and exit 0
- [ ] Unset one env var and confirm the script exits 1 with a clear error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)