### PR TITLE
feat(ui): ticket-to-stage conversion session UI (#18)

### DIFF
--- a/tools/web-server/src/client/api/hooks.ts
+++ b/tools/web-server/src/client/api/hooks.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useMutation } from '@tanstack/react-query';
 import { apiFetch } from './client.js';
 import type { ParsedSession, SessionMetrics, Process } from '@server/types/jsonl.js';
 import type { MeResponse } from '../utils/permissions.js';
@@ -465,5 +465,24 @@ export function useCurrentUser() {
     queryKey: ['me'],
     queryFn: () => apiFetch<MeResponse>('/me'),
     staleTime: 5 * 60 * 1000, // 5 minutes
+  });
+}
+
+// Conversion ------------------------------------------------------------------
+
+export interface ConvertTicketResponse {
+  ticketId: string;
+  epicId: string;
+  status: 'conversion_started';
+}
+
+/** Trigger ticket-to-stage conversion via the orchestrator. */
+export function useConvertTicket() {
+  return useMutation({
+    mutationFn: ({ ticketId, epicId }: { ticketId: string; epicId: string }) =>
+      apiFetch<ConvertTicketResponse>(`/tickets/${ticketId}/convert`, {
+        method: 'POST',
+        body: JSON.stringify({ epicId }),
+      }),
   });
 }

--- a/tools/web-server/src/client/components/board/BoardCard.tsx
+++ b/tools/web-server/src/client/components/board/BoardCard.tsx
@@ -1,6 +1,7 @@
 import { PendingBadge } from '../interaction/PendingBadge.js';
 import { SessionStatusIndicator } from './SessionStatusIndicator.js';
 import type { SessionMapEntry } from '../../store/board-store.js';
+import { Zap } from 'lucide-react';
 
 interface Badge {
   label: string;
@@ -18,6 +19,8 @@ interface BoardCardProps {
   onClick: () => void;
   pendingCount?: number;
   sessionStatus?: Pick<SessionMapEntry, 'status' | 'waitingType'> | null;
+  /** When present, renders a "Convert" action button on the card. */
+  onConvert?: (e: React.MouseEvent) => void;
 }
 
 export type { Badge };
@@ -43,6 +46,7 @@ export function BoardCard({
   onClick,
   pendingCount = 0,
   sessionStatus,
+  onConvert,
 }: BoardCardProps) {
   const highlight = needsHighlight(sessionStatus);
 
@@ -114,6 +118,18 @@ export function BoardCard({
             className="h-full rounded-full bg-blue-500 transition-all"
             style={{ width: `${Math.min(100, Math.max(0, progress))}%` }}
           />
+        </div>
+      )}
+      {onConvert && (
+        <div className="mt-2 flex justify-end">
+          <button
+            onClick={onConvert}
+            className="inline-flex items-center gap-1 rounded px-2 py-1 text-[11px] font-medium text-indigo-600 hover:bg-indigo-50 hover:text-indigo-700"
+            aria-label={`Convert ${title} to stages`}
+          >
+            <Zap size={11} />
+            Convert
+          </button>
         </div>
       )}
     </div>

--- a/tools/web-server/src/client/components/detail/TicketDetailContent.tsx
+++ b/tools/web-server/src/client/components/detail/TicketDetailContent.tsx
@@ -1,5 +1,6 @@
-import { useEffect } from 'react';
-import { useTicket, useTicketSessions } from '../../api/hooks.js';
+import { useEffect, useState, useCallback } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { useTicket, useTicketSessions, useConvertTicket } from '../../api/hooks.js';
 import { useDrawerStore } from '../../store/drawer-store.js';
 import { useDrawerSessionStore } from '../../store/drawer-session-store.js';
 import { StatusBadge } from './StatusBadge.js';
@@ -7,8 +8,10 @@ import { DrawerTabs } from './DrawerTabs.js';
 import type { TabDef } from './DrawerTabs.js';
 import { SessionHistoryDropdown } from '../chat/SessionHistoryDropdown.js';
 import { EmbeddedSessionViewer } from '../chat/EmbeddedSessionViewer.js';
+import { EpicSelectModal } from '../ticket/EpicSelectModal.js';
 import { slugToTitle, columnColor } from '../../utils/formatters.js';
-import { ExternalLink, Loader2, AlertCircle } from 'lucide-react';
+import { useSSE } from '../../api/use-sse.js';
+import { ExternalLink, Loader2, AlertCircle, Zap } from 'lucide-react';
 import { JIRA_BASE_URL } from '../../utils/constants.js';
 
 interface TicketDetailContentProps {
@@ -19,19 +22,28 @@ export function TicketDetailContent({ ticketId }: TicketDetailContentProps) {
   const { data: ticket, isLoading, error } = useTicket(ticketId);
   const { open } = useDrawerStore();
   const { ticketActiveTab, setTicketActiveTab, activeTicketSession, setTicketSession } = useDrawerSessionStore();
-  const { data: sessionHistoryData } = useTicketSessions(ticketId);
+  const { data: sessionHistoryData, refetch: refetchSessions } = useTicketSessions(ticketId);
   const sessions = sessionHistoryData?.sessions ?? [];
   const hasSessions = sessions.length > 0;
+  const queryClient = useQueryClient();
+
+  const [showEpicModal, setShowEpicModal] = useState(false);
+  const [convertError, setConvertError] = useState<string | null>(null);
+  const [isConverting, setIsConverting] = useState(false);
+
+  const { mutate: convertTicket } = useConvertTicket();
+
+  const isToConvert = ticket?.status === 'to_convert';
 
   // Build tabs array
   const tabs: TabDef[] = [
     { id: 'details', label: 'Details' },
   ];
-  if (hasSessions) {
+  if (hasSessions || isConverting) {
     tabs.push({
       id: 'session',
       label: 'Session',
-      badge: String(sessions.length),
+      badge: sessions.length > 0 ? String(sessions.length) : undefined,
     });
   }
 
@@ -44,6 +56,48 @@ export function TicketDetailContent({ ticketId }: TicketDetailContentProps) {
       }
     }
   }, [ticketActiveTab, activeTicketSession, sessions, setTicketSession]);
+
+  // Listen for board-update SSE to refresh ticket data after conversion completes
+  const handleSSE = useCallback(
+    (_channel: string, _data: unknown) => {
+      void queryClient.invalidateQueries({ queryKey: ['tickets', ticketId] });
+      void queryClient.invalidateQueries({ queryKey: ['ticket', ticketId, 'sessions'] });
+      void refetchSessions();
+    },
+    [queryClient, ticketId, refetchSessions],
+  );
+  useSSE(['board-update'], handleSSE);
+
+  function handleConvertClick() {
+    setConvertError(null);
+    if (!ticket) return;
+    // If ticket already has an epic, go straight to conversion
+    if (ticket.epic_id) {
+      startConversion(ticket.epic_id);
+    } else {
+      setShowEpicModal(true);
+    }
+  }
+
+  function startConversion(epicId: string) {
+    setShowEpicModal(false);
+    setIsConverting(true);
+    setConvertError(null);
+    convertTicket(
+      { ticketId, epicId },
+      {
+        onSuccess: () => {
+          // Switch to session tab so user can watch progress
+          setTicketActiveTab('session');
+          void refetchSessions();
+        },
+        onError: (err) => {
+          setIsConverting(false);
+          setConvertError(err instanceof Error ? err.message : 'Conversion failed');
+        },
+      },
+    );
+  }
 
   if (isLoading) {
     return (
@@ -62,10 +116,20 @@ export function TicketDetailContent({ ticketId }: TicketDetailContentProps) {
     );
   }
 
+  const showTabs = hasSessions || isConverting;
+
   return (
     <div className="flex flex-col h-full">
-      {/* Tab bar (only show if ticket has sessions) */}
-      {hasSessions && (
+      {showEpicModal && (
+        <EpicSelectModal
+          ticketId={ticketId}
+          onConfirm={(epicId) => startConversion(epicId)}
+          onCancel={() => setShowEpicModal(false)}
+        />
+      )}
+
+      {/* Tab bar (only show if ticket has sessions or conversion in progress) */}
+      {showTabs && (
         <DrawerTabs
           tabs={tabs}
           activeTab={ticketActiveTab}
@@ -77,7 +141,7 @@ export function TicketDetailContent({ ticketId }: TicketDetailContentProps) {
         />
       )}
 
-      {/* Details tab content — existing content, unchanged */}
+      {/* Details tab content */}
       {ticketActiveTab === 'details' && (
         <div className="space-y-6 overflow-y-auto flex-1">
           {/* Header metadata */}
@@ -109,6 +173,30 @@ export function TicketDetailContent({ ticketId }: TicketDetailContentProps) {
                 </a>
               )}
             </div>
+
+            {/* Convert button — only shown for to_convert tickets */}
+            {isToConvert && (
+              <div className="mt-3">
+                {convertError && (
+                  <div className="mb-2 flex items-center gap-2 rounded-lg bg-red-50 px-3 py-2 text-sm text-red-700">
+                    <AlertCircle size={14} />
+                    {convertError}
+                  </div>
+                )}
+                <button
+                  onClick={handleConvertClick}
+                  disabled={isConverting}
+                  className="inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {isConverting ? (
+                    <Loader2 className="animate-spin" size={14} />
+                  ) : (
+                    <Zap size={14} />
+                  )}
+                  {isConverting ? 'Converting…' : 'Convert to Stages'}
+                </button>
+              </div>
+            )}
           </div>
 
           {/* Stage list */}
@@ -185,29 +273,38 @@ export function TicketDetailContent({ ticketId }: TicketDetailContentProps) {
       )}
 
       {/* Session tab content */}
-      {ticketActiveTab === 'session' && hasSessions && (
+      {ticketActiveTab === 'session' && (
         <div className="flex flex-col flex-1 min-h-0">
-          {/* Session dropdown */}
-          <SessionHistoryDropdown
-            sessions={sessions}
-            selectedSessionId={activeTicketSession?.sessionId ?? sessions[0]?.sessionId ?? ''}
-            onSelect={(sessionId) => {
-              const session = sessions.find((s) => s.sessionId === sessionId);
-              if (session?.projectId) {
-                setTicketSession(session.projectId, sessionId);
-              }
-            }}
-          />
+          {hasSessions ? (
+            <>
+              {/* Session dropdown */}
+              <SessionHistoryDropdown
+                sessions={sessions}
+                selectedSessionId={activeTicketSession?.sessionId ?? sessions[0]?.sessionId ?? ''}
+                onSelect={(sessionId) => {
+                  const session = sessions.find((s) => s.sessionId === sessionId);
+                  if (session?.projectId) {
+                    setTicketSession(session.projectId, sessionId);
+                  }
+                }}
+              />
 
-          {/* Embedded session viewer — all ticket sessions are read-only
-              (TicketSessionEntry has no isCurrent field) */}
-          {activeTicketSession && (
-            <EmbeddedSessionViewer
-              projectId={activeTicketSession.projectId}
-              sessionId={activeTicketSession.sessionId}
-              isReadOnly={true}
-            />
-          )}
+              {/* Embedded session viewer — all ticket sessions are read-only */}
+              {activeTicketSession && (
+                <EmbeddedSessionViewer
+                  projectId={activeTicketSession.projectId}
+                  sessionId={activeTicketSession.sessionId}
+                  isReadOnly={true}
+                />
+              )}
+            </>
+          ) : isConverting ? (
+            <div className="flex flex-col items-center justify-center gap-3 py-12 text-sm text-slate-500">
+              <Loader2 className="animate-spin text-indigo-400" size={24} />
+              <p>Conversion session starting…</p>
+              <p className="text-xs text-slate-400">The session will appear here once it begins.</p>
+            </div>
+          ) : null}
         </div>
       )}
     </div>

--- a/tools/web-server/src/client/components/ticket/EpicSelectModal.tsx
+++ b/tools/web-server/src/client/components/ticket/EpicSelectModal.tsx
@@ -1,0 +1,178 @@
+import { useState } from 'react';
+import { X, Loader2 } from 'lucide-react';
+import { useEpics } from '../../api/hooks.js';
+import { apiFetch } from '../../api/client.js';
+import type { EpicListItem } from '../../api/hooks.js';
+
+interface EpicSelectModalProps {
+  ticketId: string;
+  /** Called with the resolved epicId when user confirms. */
+  onConfirm: (epicId: string) => void;
+  onCancel: () => void;
+}
+
+/**
+ * Modal shown when a ticket has no epic attached and the user clicks Convert.
+ * Lets them pick an existing epic or create a new one.
+ */
+export function EpicSelectModal({ ticketId: _ticketId, onConfirm, onCancel }: EpicSelectModalProps) {
+  const { data: epics, isLoading: epicsLoading } = useEpics();
+  const [selectedEpicId, setSelectedEpicId] = useState<string>('');
+  const [isCreatingNew, setIsCreatingNew] = useState(false);
+  const [newEpicTitle, setNewEpicTitle] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const canConfirm = isCreatingNew ? newEpicTitle.trim().length > 0 : selectedEpicId !== '';
+
+  async function handleConfirm() {
+    setError(null);
+    setIsSubmitting(true);
+    try {
+      if (isCreatingNew) {
+        const result = await apiFetch<{ id: string }>('/epics', {
+          method: 'POST',
+          body: JSON.stringify({ title: newEpicTitle.trim(), status: 'in_progress' }),
+        });
+        onConfirm(result.id);
+      } else {
+        onConfirm(selectedEpicId);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create epic');
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        className="fixed inset-0 z-60 bg-black/40"
+        onClick={onCancel}
+        aria-hidden="true"
+      />
+      {/* Dialog */}
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="epic-select-title"
+        className="fixed left-1/2 top-1/2 z-70 w-full max-w-md -translate-x-1/2 -translate-y-1/2 rounded-xl bg-white p-6 shadow-2xl"
+      >
+        <div className="mb-4 flex items-center justify-between">
+          <h2 id="epic-select-title" className="text-base font-semibold text-slate-900">
+            Select Epic for Conversion
+          </h2>
+          <button
+            onClick={onCancel}
+            className="rounded p-1 text-slate-400 hover:bg-slate-100 hover:text-slate-600"
+            aria-label="Cancel"
+          >
+            <X size={16} />
+          </button>
+        </div>
+
+        <p className="mb-4 text-sm text-slate-500">
+          This ticket has no epic attached. Choose an existing epic or create a new one to proceed.
+        </p>
+
+        {error && (
+          <div className="mb-3 rounded-lg bg-red-50 px-3 py-2 text-sm text-red-700">
+            {error}
+          </div>
+        )}
+
+        {/* Toggle: existing vs. new */}
+        <div className="mb-4 flex gap-2">
+          <button
+            onClick={() => setIsCreatingNew(false)}
+            className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
+              !isCreatingNew
+                ? 'bg-blue-600 text-white'
+                : 'bg-slate-100 text-slate-600 hover:bg-slate-200'
+            }`}
+          >
+            Existing epic
+          </button>
+          <button
+            onClick={() => setIsCreatingNew(true)}
+            className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
+              isCreatingNew
+                ? 'bg-blue-600 text-white'
+                : 'bg-slate-100 text-slate-600 hover:bg-slate-200'
+            }`}
+          >
+            Create new epic
+          </button>
+        </div>
+
+        {isCreatingNew ? (
+          <div className="mb-4">
+            <label htmlFor="new-epic-title" className="mb-1 block text-xs font-medium text-slate-700">
+              Epic title
+            </label>
+            <input
+              id="new-epic-title"
+              type="text"
+              value={newEpicTitle}
+              onChange={(e) => setNewEpicTitle(e.target.value)}
+              placeholder="e.g. User Authentication"
+              className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+              autoFocus
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && canConfirm && !isSubmitting) {
+                  void handleConfirm();
+                }
+              }}
+            />
+          </div>
+        ) : (
+          <div className="mb-4">
+            {epicsLoading ? (
+              <div className="flex items-center gap-2 py-3 text-sm text-slate-400">
+                <Loader2 className="animate-spin" size={14} />
+                Loading epics…
+              </div>
+            ) : epics && epics.length > 0 ? (
+              <ul className="max-h-48 overflow-y-auto rounded-lg border border-slate-200 divide-y divide-slate-100">
+                {epics.map((epic: EpicListItem) => (
+                  <li key={epic.id}>
+                    <button
+                      onClick={() => setSelectedEpicId(epic.id)}
+                      className={`w-full px-3 py-2.5 text-left text-sm transition-colors hover:bg-slate-50 ${
+                        selectedEpicId === epic.id ? 'bg-blue-50 font-medium text-blue-700' : 'text-slate-800'
+                      }`}
+                    >
+                      <span className="font-mono text-xs text-slate-400 mr-2">{epic.id}</span>
+                      {epic.title}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p className="text-sm italic text-slate-400">No epics found. Create a new one instead.</p>
+            )}
+          </div>
+        )}
+
+        <div className="flex justify-end gap-2">
+          <button
+            onClick={onCancel}
+            disabled={isSubmitting}
+            className="rounded-lg px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-100 disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={() => void handleConfirm()}
+            disabled={!canConfirm || isSubmitting}
+            className="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {isSubmitting && <Loader2 className="animate-spin" size={14} />}
+            {isCreatingNew ? 'Create & Convert' : 'Convert'}
+          </button>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/tools/web-server/src/client/pages/Board.tsx
+++ b/tools/web-server/src/client/pages/Board.tsx
@@ -1,6 +1,6 @@
-import { useMemo, useCallback } from 'react';
+import { useMemo, useCallback, useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
-import { useBoard, useEpics, useTickets } from '../api/hooks.js';
+import { useBoard, useEpics, useTickets, useConvertTicket } from '../api/hooks.js';
 import { useBoardStore } from '../store/board-store.js';
 import type { SessionMapEntry } from '../store/board-store.js';
 import { useDrawerStore, type DrawerEntry } from '../store/drawer-store.js';
@@ -9,6 +9,7 @@ import { NewEpicButton } from '../components/board/NewEpicButton.js';
 import { BoardLayout } from '../components/board/BoardLayout.js';
 import { BoardColumn } from '../components/board/BoardColumn.js';
 import { BoardCard } from '../components/board/BoardCard.js';
+import { EpicSelectModal } from '../components/ticket/EpicSelectModal.js';
 import { slugToTitle, columnColor, statusColor } from '../utils/formatters.js';
 import { useSSE } from '../api/use-sse.js';
 import type { BoardStageItem, BoardTicketItem, BoardItem, EpicListItem, TicketListItem } from '../api/hooks.js';
@@ -52,6 +53,53 @@ export function Board() {
   const currentDrawerId = stack.length > 0 ? stack[stack.length - 1].id : null;
 
   const queryClient = useQueryClient();
+
+  // Conversion state — tracks which ticket is pending epic selection
+  const [convertingTicketId, setConvertingTicketId] = useState<string | null>(null);
+  const [convertingTicketEpicId, setConvertingTicketEpicId] = useState<string | null>(null);
+  const { mutate: convertTicket } = useConvertTicket();
+
+  function handleConvertClick(ticket: TicketListItem, e: React.MouseEvent) {
+    e.stopPropagation();
+    if (ticket.epic_id) {
+      // Epic already attached — launch conversion immediately
+      convertTicket(
+        { ticketId: ticket.id, epicId: ticket.epic_id },
+        {
+          onSuccess: () => {
+            open({ type: 'ticket', id: ticket.id });
+            void queryClient.invalidateQueries({ queryKey: ['board'] });
+            void queryClient.invalidateQueries({ queryKey: ['tickets'] });
+          },
+        },
+      );
+    } else {
+      // Need to pick an epic first
+      setConvertingTicketId(ticket.id);
+      setConvertingTicketEpicId(null);
+    }
+  }
+
+  function handleEpicSelected(epicId: string) {
+    if (!convertingTicketId) return;
+    const ticketId = convertingTicketId;
+    setConvertingTicketId(null);
+    setConvertingTicketEpicId(epicId);
+    convertTicket(
+      { ticketId, epicId },
+      {
+        onSuccess: () => {
+          open({ type: 'ticket', id: ticketId });
+          void queryClient.invalidateQueries({ queryKey: ['board'] });
+          void queryClient.invalidateQueries({ queryKey: ['tickets'] });
+          setConvertingTicketEpicId(null);
+        },
+        onError: () => {
+          setConvertingTicketEpicId(null);
+        },
+      },
+    );
+  }
 
   const handleSSE = useCallback(
     (_channel: string, _data: unknown) => {
@@ -136,8 +184,22 @@ export function Board() {
     return null;
   }, [currentDrawerId, columns, epicCards, convertedTickets]);
 
+  // Find to_convert tickets for the board column
+  const toConvertTickets: TicketListItem[] = tickets
+    ? tickets
+        .filter((t) => !t.has_stages && t.status === 'to_convert')
+        .sort((a, b) => a.id.localeCompare(b.id))
+    : [];
+
   return (
     <div>
+      {convertingTicketId && (
+        <EpicSelectModal
+          ticketId={convertingTicketId}
+          onConfirm={handleEpicSelected}
+          onCancel={() => setConvertingTicketId(null)}
+        />
+      )}
       <div className="mb-4 flex items-center justify-between">
         <h1 className="text-2xl font-bold text-slate-900">Board</h1>
         <NewEpicButton />
@@ -156,6 +218,15 @@ export function Board() {
             return (
               <BoardColumn key={col.slug} title={col.title} color={col.color} count={convertedTickets.length}>
                 {convertedTickets.map((ticket) => renderConvertedTicketCard(ticket, open, currentDrawerId))}
+              </BoardColumn>
+            );
+          }
+          if (col.slug === 'to_convert') {
+            return (
+              <BoardColumn key={col.slug} title={col.title} color={col.color} count={toConvertTickets.length}>
+                {toConvertTickets.map((ticket) =>
+                  renderToConvertTicketCard(ticket, open, currentDrawerId, handleConvertClick, convertingTicketEpicId === ticket.id)
+                )}
               </BoardColumn>
             );
           }
@@ -279,6 +350,35 @@ function renderConvertedTicketCard(
       badges={badges}
       isSelected={currentDrawerId === ticket.id}
       onClick={() => open({ type: 'ticket', id: ticket.id })}
+    />
+  );
+}
+
+function renderToConvertTicketCard(
+  ticket: TicketListItem,
+  open: (entry: DrawerEntry) => void,
+  currentDrawerId: string | null,
+  onConvert: (ticket: TicketListItem, e: React.MouseEvent) => void,
+  isConverting: boolean,
+) {
+  const badges: { label: string; color: string }[] = [];
+  if (ticket.jira_key) {
+    badges.push({ label: ticket.jira_key, color: '#3b82f6' });
+  }
+  if (isConverting) {
+    badges.push({ label: 'Converting…', color: '#6366f1' });
+  }
+
+  return (
+    <BoardCard
+      key={ticket.id}
+      id={ticket.id}
+      title={ticket.title}
+      subtitle={ticket.epic_id ?? undefined}
+      badges={badges.length > 0 ? badges : undefined}
+      isSelected={currentDrawerId === ticket.id}
+      onClick={() => open({ type: 'ticket', id: ticket.id })}
+      onConvert={isConverting ? undefined : (e) => onConvert(ticket, e)}
     />
   );
 }

--- a/tools/web-server/src/server/routes/tickets.ts
+++ b/tools/web-server/src/server/routes/tickets.ts
@@ -199,6 +199,57 @@ const ticketPlugin: FastifyPluginCallback<TicketRouteOptions> = (app, opts, done
     return reply.status(201).send({ id, title, status, epic_id, file_path });
   });
 
+  /**
+   * POST /api/tickets/:id/convert
+   *
+   * Launches a Claude session to convert the ticket into stage files.
+   * Requires an epicId in the request body. Sends a launch_conversion
+   * message to the orchestrator via WebSocket.
+   */
+  const convertTicketSchema = z.object({
+    epicId: z.string().min(1),
+  });
+
+  app.post('/api/tickets/:id/convert', async (request, reply) => {
+    if (!app.dataService) {
+      return reply.status(503).send({ error: 'Database not initialized' });
+    }
+
+    const { id } = request.params as { id: string };
+    const parsedId = ticketIdSchema.safeParse(id);
+    if (!parsedId.success) {
+      return reply.status(400).send({ error: 'Invalid ticket ID format' });
+    }
+
+    const ticket = app.dataService.tickets.findById(id);
+    if (!ticket) {
+      return reply.status(404).send({ error: 'Ticket not found' });
+    }
+
+    const parsedBody = convertTicketSchema.safeParse(request.body);
+    if (!parsedBody.success) {
+      return reply.status(400).send({ error: 'Invalid request body', details: parsedBody.error.issues });
+    }
+    const { epicId } = parsedBody.data;
+
+    const epic = app.dataService.epics.findById(epicId);
+    if (!epic) {
+      return reply.status(404).send({ error: `Epic ${epicId} not found` });
+    }
+
+    if (!app.orchestratorClient) {
+      return reply.status(503).send({ error: 'Orchestrator not connected' });
+    }
+
+    if (!app.orchestratorClient.isConnected()) {
+      return reply.status(503).send({ error: 'Orchestrator not connected' });
+    }
+
+    app.orchestratorClient.launchConversion(id, epicId);
+
+    return reply.status(202).send({ ticketId: id, epicId, status: 'conversion_started' });
+  });
+
   done();
 };
 

--- a/tools/web-server/src/server/services/orchestrator-client.ts
+++ b/tools/web-server/src/server/services/orchestrator-client.ts
@@ -121,6 +121,10 @@ export class OrchestratorClient extends EventEmitter {
     this.send({ type: 'interrupt', stageId });
   }
 
+  launchConversion(ticketId: string, epicId: string): void {
+    this.send({ type: 'launch_conversion', ticketId, epicId });
+  }
+
   getPendingForStage(stageId: string): PendingItem[] {
     const approvals = this.pendingApprovals.get(stageId) ?? [];
     const questions = this.pendingQuestions.get(stageId) ?? [];


### PR DESCRIPTION
## Summary

- Add **Convert button** on `to_convert` ticket cards (Board) and in the ticket detail drawer, visible only when `status === 'to_convert'`
- Add **EpicSelectModal** shown when clicking Convert on a ticket with no epic — lets user pick an existing epic or create a new one inline
- Add **`POST /api/tickets/:id/convert`** endpoint that sends a `launch_conversion` WS message to the orchestrator; returns `202` with `{ ticketId, epicId, status: 'conversion_started' }`
- Add **`launchConversion(ticketId, epicId)`** method on `OrchestratorClient`
- Add **`useConvertTicket()`** mutation hook in client API hooks
- **Session viewer in drawer**: after conversion starts, drawer switches to Session tab showing the existing `EmbeddedSessionViewer` with SSE-driven live updates
- **Board updates**: listens for `board-update` SSE events to invalidate board/ticket queries; ticket moves out of `to_convert` once stages are created

## Test plan

- [ ] Verify `npm run test` passes (783 tests, pre-existing server test failures due to missing kanban-cli dist artifacts are unrelated)
- [ ] Verify no TypeScript errors in changed files (`tsc --noEmit` produces zero errors from new/modified files)
- [ ] Manually: click Convert on a `to_convert` ticket card — confirm EpicSelectModal appears when no epic, confirmation sends POST to `/api/tickets/:id/convert`
- [ ] Confirm drawer opens ticket detail and switches to Session tab showing the conversion session
- [ ] Confirm ticket moves out of `to_convert` column once stages are created via SSE board-update

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)