### PR TITLE
feat(jira): Jira ticket auto-pull filters with JQL override (#15)

### DIFF
--- a/tools/kanban-cli/src/config/schema.ts
+++ b/tools/kanban-cli/src/config/schema.ts
@@ -41,12 +41,22 @@ const jiraStatusMapSchema = z.object({
   all_stages_done: z.string().optional(),
 }).strict().optional();
 
+const jiraFilterConfigSchema = z.object({
+  labels: z.array(z.string()).default([]),
+  statuses: z.array(z.string()).default([]),
+  assignee: z.string().nullable().default(null),
+  custom_fields: z.record(z.unknown()).default({}),
+  logic: z.enum(['AND', 'OR']).default('AND'),
+  jql_override: z.string().nullable().default(null),
+}).optional();
+
 const jiraConfigSchema = z.object({
   reading_script: z.string().nullable().optional(),
   writing_script: z.string().nullable().optional(),
   project: z.string().nullable().optional(),
   assignee: z.string().nullable().optional(),
   status_map: jiraStatusMapSchema,
+  filters: jiraFilterConfigSchema,
 }).nullable().optional();
 
 const cronJobConfigSchema = z.object({

--- a/tools/kanban-cli/src/jira/filter.ts
+++ b/tools/kanban-cli/src/jira/filter.ts
@@ -1,0 +1,32 @@
+import type { JiraFilterConfig } from '../types/pipeline.js';
+
+/**
+ * Build a JQL query string from a JiraFilterConfig.
+ *
+ * If jql_override is set, it is returned as-is.
+ * Otherwise, filter dimensions are combined using the configured logic (AND/OR).
+ * Returns a safe fallback JQL if no clauses are produced.
+ */
+export function buildJqlFromFilter(filter: JiraFilterConfig): string {
+  if (filter.jql_override) return filter.jql_override;
+
+  const clauses: string[] = [];
+
+  if (filter.labels.length > 0) {
+    clauses.push(`labels in (${filter.labels.map((l) => `"${l}"`).join(', ')})`);
+  }
+
+  if (filter.statuses.length > 0) {
+    clauses.push(`status in (${filter.statuses.map((s) => `"${s}"`).join(', ')})`);
+  }
+
+  if (filter.assignee) {
+    clauses.push(`assignee = "${filter.assignee}"`);
+  }
+
+  for (const [k, v] of Object.entries(filter.custom_fields)) {
+    clauses.push(`cf[${k}] = "${String(v)}"`);
+  }
+
+  return clauses.join(` ${filter.logic} `) || 'ORDER BY created DESC';
+}

--- a/tools/kanban-cli/src/jira/index.ts
+++ b/tools/kanban-cli/src/jira/index.ts
@@ -30,3 +30,6 @@ export type {
 // Executor
 export { createJiraExecutor, JiraScriptError, JiraTimeoutError, JiraValidationError } from './executor.js';
 export type { JiraExecutorOptions } from './executor.js';
+
+// Filter / JQL
+export { buildJqlFromFilter } from './filter.js';

--- a/tools/kanban-cli/src/types/pipeline.ts
+++ b/tools/kanban-cli/src/types/pipeline.ts
@@ -42,6 +42,27 @@ export interface JiraStatusMap {
 }
 
 /**
+ * Multi-dimensional filter controlling which Jira tickets are auto-pulled.
+ */
+export interface JiraFilterConfig {
+  labels: string[];
+  statuses: string[];
+  assignee: string | null;
+  custom_fields: Record<string, unknown>;
+  logic: 'AND' | 'OR';
+  jql_override: string | null;
+}
+
+export const DEFAULT_JIRA_FILTER_CONFIG: JiraFilterConfig = {
+  labels: ['claude-workflow'],
+  statuses: ['To Do', 'Ready for Dev'],
+  assignee: null,
+  custom_fields: {},
+  logic: 'AND',
+  jql_override: null,
+};
+
+/**
  * Jira integration configuration.
  * When null or undefined, Jira integration is disabled.
  */
@@ -51,6 +72,7 @@ export interface JiraConfig {
   project?: string | null;
   assignee?: string | null;
   status_map?: JiraStatusMap;
+  filters?: JiraFilterConfig;
 }
 
 /**

--- a/tools/kanban-cli/tests/jira/filter.test.ts
+++ b/tools/kanban-cli/tests/jira/filter.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import { buildJqlFromFilter } from '../../src/jira/filter.js';
+import type { JiraFilterConfig } from '../../src/types/pipeline.js';
+import { DEFAULT_JIRA_FILTER_CONFIG } from '../../src/types/pipeline.js';
+
+function makeFilter(overrides: Partial<JiraFilterConfig> = {}): JiraFilterConfig {
+  return { ...DEFAULT_JIRA_FILTER_CONFIG, ...overrides };
+}
+
+describe('buildJqlFromFilter', () => {
+  it('returns jql_override as-is when set', () => {
+    const filter = makeFilter({ jql_override: 'project = FOO AND sprint in openSprints()' });
+    expect(buildJqlFromFilter(filter)).toBe('project = FOO AND sprint in openSprints()');
+  });
+
+  it('returns fallback when no clauses', () => {
+    const filter = makeFilter({ labels: [], statuses: [], assignee: null, custom_fields: {}, jql_override: null });
+    expect(buildJqlFromFilter(filter)).toBe('ORDER BY created DESC');
+  });
+
+  it('builds label clause', () => {
+    const filter = makeFilter({ labels: ['claude-workflow'], statuses: [], assignee: null, custom_fields: {} });
+    expect(buildJqlFromFilter(filter)).toBe('labels in ("claude-workflow")');
+  });
+
+  it('builds status clause', () => {
+    const filter = makeFilter({ labels: [], statuses: ['To Do', 'Ready for Dev'], assignee: null, custom_fields: {} });
+    expect(buildJqlFromFilter(filter)).toBe('status in ("To Do", "Ready for Dev")');
+  });
+
+  it('builds assignee clause', () => {
+    const filter = makeFilter({ labels: [], statuses: [], assignee: 'johndoe', custom_fields: {} });
+    expect(buildJqlFromFilter(filter)).toBe('assignee = "johndoe"');
+  });
+
+  it('builds custom_fields clauses', () => {
+    const filter = makeFilter({ labels: [], statuses: [], assignee: null, custom_fields: { '10001': 'High' } });
+    expect(buildJqlFromFilter(filter)).toBe('cf[10001] = "High"');
+  });
+
+  it('combines clauses with AND by default', () => {
+    const filter = makeFilter({
+      labels: ['foo'],
+      statuses: ['To Do'],
+      assignee: null,
+      custom_fields: {},
+      logic: 'AND',
+    });
+    expect(buildJqlFromFilter(filter)).toBe('labels in ("foo") AND status in ("To Do")');
+  });
+
+  it('combines clauses with OR when logic is OR', () => {
+    const filter = makeFilter({
+      labels: ['foo'],
+      statuses: ['To Do'],
+      assignee: null,
+      custom_fields: {},
+      logic: 'OR',
+    });
+    expect(buildJqlFromFilter(filter)).toBe('labels in ("foo") OR status in ("To Do")');
+  });
+
+  it('builds full multi-dimensional filter', () => {
+    const filter = makeFilter({
+      labels: ['claude-workflow'],
+      statuses: ['To Do', 'Ready for Dev'],
+      assignee: 'alice',
+      custom_fields: { '10001': 'High' },
+      logic: 'AND',
+    });
+    expect(buildJqlFromFilter(filter)).toBe(
+      'labels in ("claude-workflow") AND status in ("To Do", "Ready for Dev") AND assignee = "alice" AND cf[10001] = "High"',
+    );
+  });
+
+  it('default config produces expected JQL', () => {
+    const jql = buildJqlFromFilter(DEFAULT_JIRA_FILTER_CONFIG);
+    expect(jql).toBe('labels in ("claude-workflow") AND status in ("To Do", "Ready for Dev")');
+  });
+});

--- a/tools/web-server/src/client/pages/Settings.tsx
+++ b/tools/web-server/src/client/pages/Settings.tsx
@@ -1,14 +1,36 @@
 import { useState, useEffect } from 'react';
+import { ChevronDown, ChevronUp } from 'lucide-react';
 import { useCurrentUser } from '../api/hooks.js';
 import { can } from '../utils/permissions.js';
 
 const STORAGE_KEY = 'ccw-settings';
 
+// ─── Jira filter types (mirrored from server) ─────────────────────────────────
+
+interface JiraFilterConfig {
+  labels: string[];
+  statuses: string[];
+  assignee: string | null;
+  custom_fields: Record<string, unknown>;
+  logic: 'AND' | 'OR';
+  jql_override: string | null;
+}
+
+const DEFAULT_JIRA_FILTER_CONFIG: JiraFilterConfig = {
+  labels: ['claude-workflow'],
+  statuses: ['To Do', 'Ready for Dev'],
+  assignee: null,
+  custom_fields: {},
+  logic: 'AND',
+  jql_override: null,
+};
+
+// ─── App settings ─────────────────────────────────────────────────────────────
+
 interface JiraSettings {
   instanceUrl: string;
   apiToken: string;
   defaultProjectKey: string;
-  autoPullFilter: string;
 }
 
 interface GitHubSettings {
@@ -51,7 +73,6 @@ const defaultSettings: AppSettings = {
     instanceUrl: '',
     apiToken: '',
     defaultProjectKey: '',
-    autoPullFilter: '',
   },
   github: {
     personalAccessToken: '',
@@ -101,7 +122,7 @@ function saveSection<K extends keyof AppSettings>(key: K, value: AppSettings[K])
   localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
 }
 
-// --- Shared UI primitives ---
+// ─── Shared UI primitives ─────────────────────────────────────────────────────
 
 function SectionCard({ title, children }: { title: string; children: React.ReactNode }) {
   return (
@@ -219,11 +240,158 @@ function ActionButtons({
   );
 }
 
-// --- Section components ---
+// ─── Jira Filter Form ─────────────────────────────────────────────────────────
+
+/** Parse a comma-separated string into a trimmed array of non-empty strings. */
+function parseList(value: string): string[] {
+  return value.split(',').map((s) => s.trim()).filter(Boolean);
+}
+
+function JiraFilterForm({
+  initial,
+  onSaved,
+}: {
+  initial: JiraFilterConfig;
+  onSaved?: () => void;
+}) {
+  const [labels, setLabels] = useState(initial.labels.join(', '));
+  const [statuses, setStatuses] = useState(initial.statuses.join(', '));
+  const [assignee, setAssignee] = useState(initial.assignee ?? '');
+  const [logic, setLogic] = useState<'AND' | 'OR'>(initial.logic);
+  const [jqlOpen, setJqlOpen] = useState(!!initial.jql_override);
+  const [jqlOverride, setJqlOverride] = useState(initial.jql_override ?? '');
+  const [toast, setToast] = useState<string | null>(null);
+
+  async function handleSave() {
+    const config: JiraFilterConfig = {
+      labels: parseList(labels),
+      statuses: parseList(statuses),
+      assignee: assignee.trim() || null,
+      custom_fields: initial.custom_fields,
+      logic,
+      jql_override: jqlOverride.trim() || null,
+    };
+    try {
+      const res = await fetch('/api/settings/jira/filters', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(config),
+      });
+      if (!res.ok) {
+        const data = await res.json() as { error?: string };
+        setToast(`Error: ${data.error ?? res.status}`);
+      } else {
+        setToast('Saved.');
+        onSaved?.();
+      }
+    } catch (err) {
+      setToast(`Error: ${String(err)}`);
+    }
+    setTimeout(() => setToast(null), 2500);
+  }
+
+  return (
+    <div className="mt-4 rounded-md border border-slate-200 bg-slate-50 p-4 space-y-4">
+      <h3 className="text-sm font-semibold text-slate-700">Auto-pull Filters</h3>
+      <p className="text-xs text-slate-500">
+        Controls which Jira tickets are fetched on the Import Issues page. Combine dimensions with AND / OR, or override with raw JQL.
+      </p>
+
+      <FieldRow label="Labels">
+        <TextInput
+          value={labels}
+          onChange={setLabels}
+          placeholder="claude-workflow, my-label"
+        />
+        <p className="mt-1 text-xs text-slate-400">Comma-separated label names</p>
+      </FieldRow>
+
+      <FieldRow label="Statuses">
+        <TextInput
+          value={statuses}
+          onChange={setStatuses}
+          placeholder="To Do, Ready for Dev"
+        />
+        <p className="mt-1 text-xs text-slate-400">Comma-separated status names</p>
+      </FieldRow>
+
+      <FieldRow label="Assignee">
+        <TextInput
+          value={assignee}
+          onChange={setAssignee}
+          placeholder="username (leave blank for any)"
+        />
+      </FieldRow>
+
+      <FieldRow label="Combine with">
+        <div className="flex gap-3">
+          {(['AND', 'OR'] as const).map((opt) => (
+            <button
+              key={opt}
+              onClick={() => setLogic(opt)}
+              className={`rounded-md border px-4 py-1.5 text-sm font-medium transition-colors ${
+                logic === opt
+                  ? 'border-blue-600 bg-blue-600 text-white'
+                  : 'border-slate-300 bg-white text-slate-700 hover:bg-slate-50'
+              }`}
+            >
+              {opt}
+            </button>
+          ))}
+        </div>
+      </FieldRow>
+
+      {/* Collapsible JQL override */}
+      <div>
+        <button
+          onClick={() => setJqlOpen((v) => !v)}
+          className="flex items-center gap-1 text-xs font-medium text-slate-600 hover:text-slate-800"
+        >
+          {jqlOpen ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
+          JQL Override {jqlOpen ? '(active)' : '(optional)'}
+        </button>
+        {jqlOpen && (
+          <div className="mt-2">
+            <textarea
+              value={jqlOverride}
+              onChange={(e) => setJqlOverride(e.target.value)}
+              placeholder="project = MYPROJ AND sprint in openSprints()"
+              rows={3}
+              className="w-full rounded-md border border-slate-300 px-3 py-2 font-mono text-xs text-slate-900 placeholder-slate-400 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            />
+            <p className="mt-1 text-xs text-slate-400">
+              When set, this raw JQL overrides all dimension filters above.
+            </p>
+          </div>
+        )}
+      </div>
+
+      <div className="flex items-center gap-3 border-t border-slate-100 pt-3">
+        <button
+          onClick={handleSave}
+          className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+        >
+          Save Filters
+        </button>
+        {toast && <span className="text-sm text-slate-500">{toast}</span>}
+      </div>
+    </div>
+  );
+}
+
+// ─── Section components ───────────────────────────────────────────────────────
 
 function JiraSection({ initial }: { initial: JiraSettings }) {
   const [form, setForm] = useState<JiraSettings>(initial);
   const [toast, setToast] = useState<string | null>(null);
+  const [filterConfig, setFilterConfig] = useState<JiraFilterConfig>(DEFAULT_JIRA_FILTER_CONFIG);
+
+  useEffect(() => {
+    fetch('/api/settings/jira/filters')
+      .then((r) => r.json())
+      .then((data) => setFilterConfig({ ...DEFAULT_JIRA_FILTER_CONFIG, ...(data as Partial<JiraFilterConfig>) }))
+      .catch(() => { /* keep default */ });
+  }, []);
 
   function field<K extends keyof JiraSettings>(key: K) {
     return (value: JiraSettings[K]) => setForm((prev) => ({ ...prev, [key]: value }));
@@ -251,10 +419,8 @@ function JiraSection({ initial }: { initial: JiraSettings }) {
       <FieldRow label="Default Project Key">
         <TextInput value={form.defaultProjectKey} onChange={field('defaultProjectKey')} placeholder="MYPROJ" />
       </FieldRow>
-      <FieldRow label="Auto-pull Filter">
-        <TextInput value={form.autoPullFilter} onChange={field('autoPullFilter')} placeholder="assignee = currentUser()" />
-      </FieldRow>
       <ActionButtons onSave={handleSave} onTest={handleTest} toast={toast} />
+      <JiraFilterForm initial={filterConfig} />
     </SectionCard>
   );
 }
@@ -450,7 +616,7 @@ function PreferencesSection({ initial }: { initial: PreferencesSettings }) {
   );
 }
 
-// --- Main page ---
+// ─── Main page ────────────────────────────────────────────────────────────────
 
 export function Settings() {
   const { data: me } = useCurrentUser();

--- a/tools/web-server/src/server/routes/import.ts
+++ b/tools/web-server/src/server/routes/import.ts
@@ -3,6 +3,7 @@ import fp from 'fastify-plugin';
 import { z } from 'zod';
 import { existsSync, readdirSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
 import { join, dirname } from 'path';
+import os from 'os';
 import matter from 'gray-matter';
 import type { RoleService } from '../deployment/hosted/rbac/role-service.js';
 import { requireRole } from '../deployment/hosted/rbac/rbac-middleware.js';
@@ -10,6 +11,77 @@ import { requireRole } from '../deployment/hosted/rbac/rbac-middleware.js';
 export interface ImportRouteOptions {
   roleService?: RoleService;
 }
+
+// ─── Jira filter types (inlined — web-server has no dep on kanban-cli) ────────
+
+export interface JiraFilterConfig {
+  labels: string[];
+  statuses: string[];
+  assignee: string | null;
+  custom_fields: Record<string, unknown>;
+  logic: 'AND' | 'OR';
+  jql_override: string | null;
+}
+
+const DEFAULT_JIRA_FILTER_CONFIG: JiraFilterConfig = {
+  labels: ['claude-workflow'],
+  statuses: ['To Do', 'Ready for Dev'],
+  assignee: null,
+  custom_fields: {},
+  logic: 'AND',
+  jql_override: null,
+};
+
+/**
+ * Build a JQL query string from a JiraFilterConfig.
+ * If jql_override is set it is returned as-is.
+ */
+function buildJqlFromFilter(filter: JiraFilterConfig): string {
+  if (filter.jql_override) return filter.jql_override;
+
+  const clauses: string[] = [];
+
+  if (filter.labels.length > 0) {
+    clauses.push(`labels in (${filter.labels.map((l) => `"${l}"`).join(', ')})`);
+  }
+  if (filter.statuses.length > 0) {
+    clauses.push(`status in (${filter.statuses.map((s) => `"${s}"`).join(', ')})`);
+  }
+  if (filter.assignee) {
+    clauses.push(`assignee = "${filter.assignee}"`);
+  }
+  for (const [k, v] of Object.entries(filter.custom_fields)) {
+    clauses.push(`cf[${k}] = "${String(v)}"`);
+  }
+
+  return clauses.join(` ${filter.logic} `) || 'ORDER BY created DESC';
+}
+
+// ─── Settings persistence ─────────────────────────────────────────────────────
+
+const SETTINGS_DIR = join(os.homedir(), '.config', 'kanban-workflow');
+const JIRA_FILTER_SETTINGS_PATH = join(SETTINGS_DIR, 'jira-filters.json');
+
+function loadJiraFilterConfig(): JiraFilterConfig {
+  try {
+    if (existsSync(JIRA_FILTER_SETTINGS_PATH)) {
+      const raw = readFileSync(JIRA_FILTER_SETTINGS_PATH, 'utf-8');
+      return { ...DEFAULT_JIRA_FILTER_CONFIG, ...(JSON.parse(raw) as Partial<JiraFilterConfig>) };
+    }
+  } catch {
+    // fall through to default
+  }
+  return { ...DEFAULT_JIRA_FILTER_CONFIG };
+}
+
+function saveJiraFilterConfig(config: JiraFilterConfig): void {
+  if (!existsSync(SETTINGS_DIR)) {
+    mkdirSync(SETTINGS_DIR, { recursive: true });
+  }
+  writeFileSync(JIRA_FILTER_SETTINGS_PATH, JSON.stringify(config, null, 2), 'utf-8');
+}
+
+// ─── Zod schemas ──────────────────────────────────────────────────────────────
 
 const githubQuerySchema = z.object({
   owner: z.string().min(1),
@@ -32,6 +104,15 @@ const jiraQuerySchema = z.object({
   apiToken: z.string().min(1),
 });
 
+const jiraFilterBodySchema = z.object({
+  labels: z.array(z.string()).default([]),
+  statuses: z.array(z.string()).default([]),
+  assignee: z.string().nullable().default(null),
+  custom_fields: z.record(z.string(), z.unknown()).default({}),
+  logic: z.enum(['AND', 'OR']).default('AND'),
+  jql_override: z.string().nullable().default(null),
+});
+
 const importBodySchema = z.object({
   provider: z.enum(['github', 'gitlab', 'jira']),
   issues: z.array(z.object({
@@ -45,6 +126,8 @@ const importBodySchema = z.object({
   })),
   epicId: z.string().optional(),
 });
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
 
 export interface RemoteIssue {
   id: number;
@@ -80,6 +163,8 @@ function findExistingSourceIds(ticketsDir: string, provider: string): Set<string
   }
   return sourceIds;
 }
+
+// ─── Routes ───────────────────────────────────────────────────────────────────
 
 const importPlugin: FastifyPluginCallback<ImportRouteOptions> = (app, opts, done) => {
   const { roleService } = opts;
@@ -172,7 +257,7 @@ const importPlugin: FastifyPluginCallback<ImportRouteOptions> = (app, opts, done
     }
   });
 
-  // GET /api/import/jira/issues
+  // GET /api/import/jira/issues — applies saved JiraFilterConfig to build the JQL query
   app.get('/api/import/jira/issues', fetchOpts, async (request, reply) => {
     const parseResult = jiraQuerySchema.safeParse(request.query);
     if (!parseResult.success) {
@@ -188,7 +273,15 @@ const importPlugin: FastifyPluginCallback<ImportRouteOptions> = (app, opts, done
 
     try {
       const base = instanceUrl.replace(/\/$/, '');
-      const url = `${base}/rest/api/3/search?jql=project=${encodeURIComponent(projectKey)}&maxResults=50`;
+
+      // Build JQL from saved filter config, scoped to the project
+      const filterConfig = loadJiraFilterConfig();
+      const filterJql = buildJqlFromFilter(filterConfig);
+      const jql = filterJql === 'ORDER BY created DESC'
+        ? `project=${encodeURIComponent(projectKey)}`
+        : `project=${encodeURIComponent(projectKey)} AND (${filterJql})`;
+
+      const url = `${base}/rest/api/3/search?jql=${encodeURIComponent(jql)}&maxResults=50`;
       const res = await fetch(url, { headers });
       if (!res.ok) {
         const msg = await res.text();
@@ -221,6 +314,26 @@ const importPlugin: FastifyPluginCallback<ImportRouteOptions> = (app, opts, done
       return reply.send({ issues });
     } catch (err) {
       return reply.status(500).send({ error: String(err) });
+    }
+  });
+
+  // GET /api/settings/jira/filters — return current JiraFilterConfig
+  app.get('/api/settings/jira/filters', async (_request, reply) => {
+    return reply.send(loadJiraFilterConfig());
+  });
+
+  // PUT /api/settings/jira/filters — save JiraFilterConfig
+  app.put('/api/settings/jira/filters', async (request, reply) => {
+    const parseResult = jiraFilterBodySchema.safeParse(request.body);
+    if (!parseResult.success) {
+      return reply.status(400).send({ error: 'Invalid filter config', details: parseResult.error.issues });
+    }
+    const config: JiraFilterConfig = parseResult.data;
+    try {
+      saveJiraFilterConfig(config);
+      return reply.send(config);
+    } catch (err) {
+      return reply.status(500).send({ error: `Failed to save filter config: ${String(err)}` });
     }
   });
 


### PR DESCRIPTION
## Summary

- Adds `JiraFilterConfig` type with labels, statuses, assignee, custom_fields, AND/OR logic, and jql_override fields to `kanban-cli` pipeline types and Zod schema
- Adds `buildJqlFromFilter()` utility that composes JQL from filter dimensions or returns jql_override directly
- Applies saved filter config to `GET /api/import/jira/issues` so only matching tickets are fetched
- Adds `GET /api/settings/jira/filters` and `PUT /api/settings/jira/filters` API endpoints, persisted to `~/.config/kanban-workflow/jira-filters.json`
- Replaces the flat `autoPullFilter` text field in Settings UI with a rich form: labels, statuses, assignee, AND/OR toggle, and collapsible JQL override textarea

## Test plan

- [x] 10 unit tests for `buildJqlFromFilter` covering: jql_override passthrough, empty filter fallback, individual dimensions (labels, statuses, assignee, custom_fields), AND/OR logic combination, full multi-dimensional filter, and default config output
- [x] All pre-existing kanban-cli tests pass (16 pre-existing failures in `default-scripts.test.ts` are unrelated to this change — they require `atlassian-tools` plugin)
- [x] No new TypeScript errors introduced in changed files (`import.ts`, `Settings.tsx`)

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)