### PR TITLE
feat(data-layer): repository abstraction for SQLite/PostgreSQL dual-backend (#23)

### DIFF
--- a/tools/web-server/src/server/index.ts
+++ b/tools/web-server/src/server/index.ts
@@ -7,7 +7,7 @@ import { DataService } from './services/data-service.js';
 import { OrchestratorClient } from './services/orchestrator-client.js';
 import { SessionPipeline } from './services/session-pipeline.js';
 import { FileWatcher } from './services/file-watcher.js';
-import { LocalDeploymentContext } from './deployment/index.js';
+import { LocalDeploymentContext, HostedDeploymentContext } from './deployment/index.js';
 
 const port = parseInt(process.env.PORT || '3100', 10);
 const host = process.env.HOST || '0.0.0.0';
@@ -17,23 +17,40 @@ const orchestratorWsUrl =
   process.env.ORCHESTRATOR_WS_URL ?? 'ws://localhost:3101';
 const orchestratorClient = new OrchestratorClient(orchestratorWsUrl);
 
-const db = new KanbanDatabase(dbPath);
-const dataService = new DataService({ db });
+const isHosted = process.env.DEPLOYMENT_MODE === 'hosted';
 
-// Create deployment context based on DEPLOYMENT_MODE env var
-const deploymentContext = process.env.DEPLOYMENT_MODE === 'hosted'
-  ? (() => { throw new Error('Hosted mode not yet implemented'); })()
-  : new LocalDeploymentContext();
+// Create deployment context and data service based on mode
+let deploymentContext: LocalDeploymentContext | HostedDeploymentContext;
+let dataService: DataService;
+
+if (isHosted) {
+  const hostedCtx = await HostedDeploymentContext.create();
+  deploymentContext = hostedCtx;
+  dataService = DataService.fromPool(hostedCtx.getPool());
+} else {
+  deploymentContext = new LocalDeploymentContext();
+  const db = new KanbanDatabase(dbPath);
+  dataService = DataService.fromSqlite(db);
+}
+
+// SessionPipeline and FileWatcher are filesystem-dependent — only for local mode
+let sessionPipeline: SessionPipeline | undefined;
+let fileWatcher: FileWatcher | undefined;
+
+if (!isHosted) {
+  const claudeProjectsDir =
+    process.env.CLAUDE_PROJECTS_DIR ?? join(os.homedir(), '.claude', 'projects');
+  sessionPipeline = new SessionPipeline({
+    fileSystem: deploymentContext.getFileAccess(),
+  });
+  fileWatcher = new FileWatcher({
+    rootDir: claudeProjectsDir,
+    fileSystem: deploymentContext.getFileAccess(),
+  });
+}
 
 const claudeProjectsDir =
   process.env.CLAUDE_PROJECTS_DIR ?? join(os.homedir(), '.claude', 'projects');
-const sessionPipeline = new SessionPipeline({
-  fileSystem: deploymentContext.getFileAccess(),
-});
-const fileWatcher = new FileWatcher({
-  rootDir: claudeProjectsDir,
-  fileSystem: deploymentContext.getFileAccess(),
-});
 
 const app = await createServer({
   dataService,

--- a/tools/web-server/src/server/routes/board.ts
+++ b/tools/web-server/src/server/routes/board.ts
@@ -28,8 +28,8 @@ const boardQuerySchema = z.object({
 
 /**
  * Maps database row types to the shapes that buildBoard() expects.
- * DB rows use SQLite conventions (number for booleans, nullable strings);
- * buildBoard input types use stricter TypeScript types.
+ * Repository rows use boolean for boolean fields; buildBoard input
+ * types use stricter TypeScript types.
  */
 function mapEpics(rows: { id: string; title: string | null; status: string | null; file_path: string }[]): BoardEpicRow[] {
   return rows.map((r) => ({
@@ -48,7 +48,7 @@ function mapTickets(
     status: string | null;
     jira_key: string | null;
     source: string | null;
-    has_stages: number | null;
+    has_stages: boolean | null;
     file_path: string;
   }[],
 ): BoardTicketRow[] {
@@ -59,7 +59,7 @@ function mapTickets(
     status: r.status ?? '',
     jira_key: r.jira_key,
     source: r.source ?? '',
-    has_stages: (r.has_stages ?? 0) !== 0,
+    has_stages: (r.has_stages ?? false) !== false,
     file_path: r.file_path,
   }));
 }
@@ -76,7 +76,7 @@ function mapStages(
     worktree_branch: string | null;
     priority: number;
     due_date: string | null;
-    session_active: number;
+    session_active: boolean;
     pending_merge_parents: string | null;
     file_path: string;
   }[],
@@ -92,7 +92,7 @@ function mapStages(
     worktree_branch: r.worktree_branch ?? '',
     priority: r.priority,
     due_date: r.due_date,
-    session_active: r.session_active !== 0,
+    session_active: r.session_active !== false,
     pending_merge_parents: r.pending_merge_parents ?? undefined,
     file_path: r.file_path,
   }));
@@ -105,7 +105,7 @@ function mapDependencies(
     to_id: string;
     from_type: string;
     to_type: string;
-    resolved: number;
+    resolved: boolean;
   }[],
 ): BoardDependencyRow[] {
   return rows.map((r) => ({
@@ -114,7 +114,7 @@ function mapDependencies(
     to_id: r.to_id,
     from_type: r.from_type,
     to_type: r.to_type,
-    resolved: r.resolved !== 0,
+    resolved: r.resolved !== false,
   }));
 }
 
@@ -138,8 +138,8 @@ interface BoardData {
  *
  * Returns `null` when no repos exist (or the requested repo is not found).
  */
-function fetchBoardData(dataService: DataService, repoFilter?: string): BoardData | null {
-  const repos = dataService.repos.findAll();
+async function fetchBoardData(dataService: DataService, repoFilter?: string): Promise<BoardData | null> {
+  const repos = await dataService.repos.findAll();
   if (repos.length === 0) return null;
 
   if (repoFilter) {
@@ -150,10 +150,10 @@ function fetchBoardData(dataService: DataService, repoFilter?: string): BoardDat
 
     return {
       repoPath: repo.path,
-      epics: mapEpics(dataService.epics.listByRepo(repo.id)),
-      tickets: mapTickets(dataService.tickets.listByRepo(repo.id)),
-      stages: mapStages(dataService.stages.listByRepo(repo.id)),
-      dependencies: mapDependencies(dataService.dependencies.listByRepo(repo.id)),
+      epics: mapEpics(await dataService.epics.listByRepo(repo.id)),
+      tickets: mapTickets(await dataService.tickets.listByRepo(repo.id)),
+      stages: mapStages(await dataService.stages.listByRepo(repo.id)),
+      dependencies: mapDependencies(await dataService.dependencies.listByRepo(repo.id)),
       global: false,
     };
   }
@@ -165,10 +165,10 @@ function fetchBoardData(dataService: DataService, repoFilter?: string): BoardDat
   const allDependencies: BoardDependencyRow[] = [];
 
   for (const repo of repos) {
-    allEpics.push(...mapEpics(dataService.epics.listByRepo(repo.id)));
-    allTickets.push(...mapTickets(dataService.tickets.listByRepo(repo.id)));
-    allStages.push(...mapStages(dataService.stages.listByRepo(repo.id)));
-    allDependencies.push(...mapDependencies(dataService.dependencies.listByRepo(repo.id)));
+    allEpics.push(...mapEpics(await dataService.epics.listByRepo(repo.id)));
+    allTickets.push(...mapTickets(await dataService.tickets.listByRepo(repo.id)));
+    allStages.push(...mapStages(await dataService.stages.listByRepo(repo.id)));
+    allDependencies.push(...mapDependencies(await dataService.dependencies.listByRepo(repo.id)));
   }
 
   return {
@@ -203,7 +203,7 @@ const boardPlugin: FastifyPluginCallback = (app, _opts, done) => {
 
     const { epic, ticket, column, excludeDone, repo } = result.data;
 
-    const data = fetchBoardData(app.dataService, repo);
+    const data = await fetchBoardData(app.dataService, repo);
     if (!data) {
       return reply.send({
         generated_at: new Date().toISOString(),
@@ -233,7 +233,7 @@ const boardPlugin: FastifyPluginCallback = (app, _opts, done) => {
       return reply.status(503).send({ error: 'Database not initialized' });
     }
 
-    const data = fetchBoardData(app.dataService);
+    const data = await fetchBoardData(app.dataService);
     if (!data) {
       return reply.send({ total_stages: 0, total_tickets: 0, by_column: {} });
     }

--- a/tools/web-server/src/server/routes/epics.ts
+++ b/tools/web-server/src/server/routes/epics.ts
@@ -24,14 +24,14 @@ const epicPlugin: FastifyPluginCallback<EpicRouteOptions> = (app, opts, done) =>
       return reply.status(503).send({ error: 'Database not initialized' });
     }
 
-    const repos = app.dataService.repos.findAll();
+    const repos = await app.dataService.repos.findAll();
     if (repos.length === 0) {
       return reply.send([]);
     }
     const repo = repos[0];
 
-    const epics = app.dataService.epics.listByRepo(repo.id);
-    const tickets = app.dataService.tickets.listByRepo(repo.id);
+    const epics = await app.dataService.epics.listByRepo(repo.id);
+    const tickets = await app.dataService.tickets.listByRepo(repo.id);
 
     // Build a map of epic_id -> ticket count for O(n) instead of O(n*m)
     const ticketCountByEpic = new Map<string, number>();
@@ -67,13 +67,13 @@ const epicPlugin: FastifyPluginCallback<EpicRouteOptions> = (app, opts, done) =>
       return reply.status(400).send({ error: 'Invalid epic ID format' });
     }
 
-    const epic = app.dataService.epics.findById(id);
+    const epic = await app.dataService.epics.findById(id);
     if (!epic) {
       return reply.status(404).send({ error: 'Epic not found' });
     }
 
-    const tickets = app.dataService.tickets.listByEpic(id, epic.repo_id);
-    const stages = app.dataService.stages.listByRepo(epic.repo_id);
+    const tickets = await app.dataService.tickets.listByEpic(id, epic.repo_id);
+    const stages = await app.dataService.stages.listByRepo(epic.repo_id);
 
     // Build a map of ticket_id -> stage count
     const stageCountByTicket = new Map<string, number>();
@@ -89,7 +89,7 @@ const epicPlugin: FastifyPluginCallback<EpicRouteOptions> = (app, opts, done) =>
       status: t.status ?? '',
       jira_key: t.jira_key,
       source: t.source,
-      has_stages: (t.has_stages ?? 0) !== 0,
+      has_stages: (t.has_stages ?? false) !== false,
       stage_count: stageCountByTicket.get(t.id) ?? 0,
     }));
 
@@ -121,20 +121,25 @@ const epicPlugin: FastifyPluginCallback<EpicRouteOptions> = (app, opts, done) =>
       return reply.status(503).send({ error: 'Database not initialized' });
     }
 
+    // Filesystem operations not supported in hosted mode
+    if (app.deploymentContext.mode === 'hosted') {
+      return reply.code(501).send({ error: 'Not supported in hosted mode' });
+    }
+
     const parsed = createEpicSchema.safeParse(request.body);
     if (!parsed.success) {
       return reply.status(400).send({ error: 'Invalid request body', details: parsed.error.issues });
     }
     const { title, status, description } = parsed.data;
 
-    const repos = app.dataService.repos.findAll();
+    const repos = await app.dataService.repos.findAll();
     if (repos.length === 0) {
       return reply.status(503).send({ error: 'No repos configured' });
     }
     const repo = repos[0];
 
     // Generate next EPIC ID
-    const existingEpics = app.dataService.epics.listByRepo(repo.id);
+    const existingEpics = await app.dataService.epics.listByRepo(repo.id);
     const nums = existingEpics
       .map((e) => {
         const m = /^EPIC-(\d+)$/.exec(e.id);
@@ -148,7 +153,7 @@ const epicPlugin: FastifyPluginCallback<EpicRouteOptions> = (app, opts, done) =>
     mkdirSync(dirname(file_path), { recursive: true });
     writeFileSync(file_path, matter.stringify(description ?? '', { title, status }));
 
-    app.dataService.epics.upsert({
+    await app.dataService.epics.upsert({
       id,
       repo_id: repo.id,
       title,

--- a/tools/web-server/src/server/routes/graph.ts
+++ b/tools/web-server/src/server/routes/graph.ts
@@ -44,7 +44,7 @@ function mapTickets(
     status: string | null;
     jira_key: string | null;
     source: string | null;
-    has_stages: number | null;
+    has_stages: boolean | null;
     file_path: string;
   }[],
 ): GraphTicketRow[] {
@@ -68,7 +68,7 @@ function mapStages(
     worktree_branch: string | null;
     priority: number;
     due_date: string | null;
-    session_active: number;
+    session_active: boolean;
     pending_merge_parents: string | null;
     file_path: string;
   }[],
@@ -89,7 +89,7 @@ function mapDependencies(
     to_id: string;
     from_type: string;
     to_type: string;
-    resolved: number;
+    resolved: boolean;
   }[],
 ): GraphDependencyRow[] {
   return rows.map((r) => ({
@@ -98,7 +98,7 @@ function mapDependencies(
     to_id: r.to_id,
     from_type: r.from_type,
     to_type: r.to_type,
-    resolved: r.resolved !== 0,
+    resolved: r.resolved !== false,
   }));
 }
 
@@ -114,16 +114,16 @@ interface GraphData {
  * Fetch and map the common graph data from the first repo.
  * Returns `null` when no repos exist.
  */
-function fetchGraphData(dataService: DataService): GraphData | null {
-  const repos = dataService.repos.findAll();
+async function fetchGraphData(dataService: DataService): Promise<GraphData | null> {
+  const repos = await dataService.repos.findAll();
   if (repos.length === 0) return null;
   const repo = repos[0];
 
   return {
-    epics: mapEpics(dataService.epics.listByRepo(repo.id)),
-    tickets: mapTickets(dataService.tickets.listByRepo(repo.id)),
-    stages: mapStages(dataService.stages.listByRepo(repo.id)),
-    dependencies: mapDependencies(dataService.dependencies.listByRepo(repo.id)),
+    epics: mapEpics(await dataService.epics.listByRepo(repo.id)),
+    tickets: mapTickets(await dataService.tickets.listByRepo(repo.id)),
+    stages: mapStages(await dataService.stages.listByRepo(repo.id)),
+    dependencies: mapDependencies(await dataService.dependencies.listByRepo(repo.id)),
   };
 }
 
@@ -148,7 +148,7 @@ const graphPlugin: FastifyPluginCallback = (app, _opts, done) => {
 
     const { epic, mermaid } = result.data;
 
-    const data = fetchGraphData(app.dataService);
+    const data = await fetchGraphData(app.dataService);
     if (!data) {
       const emptyGraph = { nodes: [], edges: [], cycles: [], critical_path: [] };
       if (mermaid) {

--- a/tools/web-server/src/server/routes/import.ts
+++ b/tools/web-server/src/server/routes/import.ts
@@ -349,6 +349,11 @@ const importPlugin: FastifyPluginCallback<ImportRouteOptions> = (app, opts, done
 
   // POST /api/import/issues — create ticket files
   app.post('/api/import/issues', importOpts, async (request, reply) => {
+    // Filesystem operations not supported in hosted mode
+    if (app.deploymentContext.mode === 'hosted') {
+      return reply.code(501).send({ error: 'Not supported in hosted mode' });
+    }
+
     const parseResult = importBodySchema.safeParse(request.body);
     if (!parseResult.success) {
       return reply.status(400).send({ error: 'Invalid parameters', details: parseResult.error.issues });
@@ -362,14 +367,14 @@ const importPlugin: FastifyPluginCallback<ImportRouteOptions> = (app, opts, done
 
     // Determine tickets directory from the repo data
     let ticketsDir: string;
-    const repos = app.dataService.repos.findAll();
+    const repos = await app.dataService.repos.findAll();
     if (repos.length > 0) {
       const repo = repos[0];
       if (repo.path) {
         ticketsDir = join(repo.path, 'tickets');
       } else {
         // Fall back to first ticket's file_path
-        const tickets = app.dataService.tickets.listByRepo(repo.id);
+        const tickets = await app.dataService.tickets.listByRepo(repo.id);
         if (tickets.length > 0 && tickets[0].file_path) {
           ticketsDir = dirname(tickets[0].file_path);
         } else {

--- a/tools/web-server/src/server/routes/repos.ts
+++ b/tools/web-server/src/server/routes/repos.ts
@@ -10,7 +10,7 @@ const repoPlugin: FastifyPluginCallback = (app, _opts, done) => {
       return reply.status(503).send({ error: 'Database not initialized' });
     }
 
-    const repos = app.dataService.repos.findAll();
+    const repos = await app.dataService.repos.findAll();
     const result = repos.map((r) => ({
       id: r.id,
       name: r.name,

--- a/tools/web-server/src/server/routes/search.ts
+++ b/tools/web-server/src/server/routes/search.ts
@@ -31,13 +31,13 @@ const searchPlugin: FastifyPluginCallback = (app, _opts, done) => {
     const term = q.toLowerCase();
     const results: SearchResult[] = [];
 
-    const repos = app.dataService.repos.findAll();
+    const repos = await app.dataService.repos.findAll();
     if (repos.length === 0) return reply.send({ results: [] });
     const repo = repos[0];
 
     // Search epics
     if (!type || type === 'epic') {
-      const epics = app.dataService.epics.listByRepo(repo.id);
+      const epics = await app.dataService.epics.listByRepo(repo.id);
       for (const epic of epics) {
         if (!epic.title?.toLowerCase().includes(term)) continue;
         if (status && epic.status !== status) continue;
@@ -53,9 +53,9 @@ const searchPlugin: FastifyPluginCallback = (app, _opts, done) => {
 
     // Search tickets
     if (!type || type === 'ticket') {
-      const tickets = app.dataService.tickets.listByRepo(repo.id);
+      const tickets = await app.dataService.tickets.listByRepo(repo.id);
       const epicMap = new Map<string, string>();
-      for (const e of app.dataService.epics.listByRepo(repo.id)) {
+      for (const e of await app.dataService.epics.listByRepo(repo.id)) {
         epicMap.set(e.id, e.title ?? e.id);
       }
       for (const ticket of tickets) {
@@ -74,9 +74,9 @@ const searchPlugin: FastifyPluginCallback = (app, _opts, done) => {
 
     // Search stages
     if (!type || type === 'stage') {
-      const stages = app.dataService.stages.listByRepo(repo.id);
+      const stages = await app.dataService.stages.listByRepo(repo.id);
       const ticketMap = new Map<string, string>();
-      for (const t of app.dataService.tickets.listByRepo(repo.id)) {
+      for (const t of await app.dataService.tickets.listByRepo(repo.id)) {
         ticketMap.set(t.id, t.title ?? t.id);
       }
       for (const stage of stages) {

--- a/tools/web-server/src/server/routes/sessions.ts
+++ b/tools/web-server/src/server/routes/sessions.ts
@@ -1,7 +1,7 @@
 import type { FastifyPluginCallback } from 'fastify';
 import fp from 'fastify-plugin';
 import { join, resolve } from 'path';
-import type { StageSessionRow, TicketSessionRow } from '../../../../kanban-cli/dist/db/repositories/index.js';
+import type { StageSessionRow, TicketSessionRow } from '../services/repositories/types.js';
 
 /** Validate that a session ID looks safe (alphanumeric, hyphens, underscores). */
 const SESSION_ID_RE = /^[\w-]+$/;
@@ -196,7 +196,7 @@ const sessionsPlugin: FastifyPluginCallback = (app, _opts, done) => {
         return reply.status(503).send({ error: 'Database not initialized' });
       }
 
-      const stage = app.dataService.stages.findById(stageId);
+      const stage = await app.dataService.stages.findById(stageId);
       if (!stage) {
         return reply.status(404).send({ error: 'Stage not found' });
       }
@@ -207,7 +207,7 @@ const sessionsPlugin: FastifyPluginCallback = (app, _opts, done) => {
 
       // Derive projectId from the repo path so the client can build a
       // `/sessions/:projectId/:sessionId` URL without extra round-trips.
-      const repo = app.dataService.repos.findById(stage.repo_id);
+      const repo = await app.dataService.repos.findById(stage.repo_id);
       const projectId = repo
         ? repo.path.replace(/\//g, '-')
         : null;
@@ -231,15 +231,15 @@ const sessionsPlugin: FastifyPluginCallback = (app, _opts, done) => {
         return reply.status(503).send({ error: 'Database not initialized' });
       }
 
-      const stage = app.dataService.stages.findById(stageId);
+      const stage = await app.dataService.stages.findById(stageId);
       if (!stage) {
         return reply.status(404).send({ error: 'Stage not found' });
       }
 
-      const rows = app.dataService.stageSessions.getSessionsByStageId(stageId);
+      const rows = await app.dataService.stageSessions.getSessionsByStageId(stageId);
 
       // Derive projectId from repo path (same logic as existing /session endpoint)
-      const repo = app.dataService.repos.findById(stage.repo_id);
+      const repo = await app.dataService.repos.findById(stage.repo_id);
       const projectId = repo ? repo.path.replace(/\//g, '-') : null;
 
       return {
@@ -249,7 +249,7 @@ const sessionsPlugin: FastifyPluginCallback = (app, _opts, done) => {
           phase: r.phase,
           startedAt: r.started_at,
           endedAt: r.ended_at,
-          isCurrent: r.is_current === 1,
+          isCurrent: r.is_current === true,
         })),
       };
     },
@@ -269,15 +269,15 @@ const sessionsPlugin: FastifyPluginCallback = (app, _opts, done) => {
         return reply.status(503).send({ error: 'Database not initialized' });
       }
 
-      const ticket = app.dataService.tickets.findById(ticketId);
+      const ticket = await app.dataService.tickets.findById(ticketId);
       if (!ticket) {
         return reply.status(404).send({ error: 'Ticket not found' });
       }
 
-      const rows = app.dataService.ticketSessions.getSessionsByTicketId(ticketId);
+      const rows = await app.dataService.ticketSessions.getSessionsByTicketId(ticketId);
 
       // Derive projectId from repo path
-      const repo = app.dataService.repos.findById(ticket.repo_id);
+      const repo = await app.dataService.repos.findById(ticket.repo_id);
       const projectId = repo ? repo.path.replace(/\//g, '-') : null;
 
       return {

--- a/tools/web-server/src/server/routes/stages.ts
+++ b/tools/web-server/src/server/routes/stages.ts
@@ -81,13 +81,13 @@ const stagePlugin: FastifyPluginCallback = (app, _opts, done) => {
     }
     const { ticket } = parseResult.data;
 
-    const repos = app.dataService.repos.findAll();
+    const repos = await app.dataService.repos.findAll();
     if (repos.length === 0) {
       return reply.send([]);
     }
     const repo = repos[0];
 
-    let stages = app.dataService.stages.listByRepo(repo.id);
+    let stages = await app.dataService.stages.listByRepo(repo.id);
 
     // Filter by ticket if query param provided
     if (ticket) {
@@ -103,7 +103,7 @@ const stagePlugin: FastifyPluginCallback = (app, _opts, done) => {
       kanban_column: s.kanban_column,
       refinement_type: parseRefinementType(s.refinement_type),
       worktree_branch: s.worktree_branch,
-      session_active: s.session_active !== 0,
+      session_active: s.session_active !== false,
       session_id: s.session_id ?? null,
       priority: s.priority,
       due_date: s.due_date,
@@ -128,22 +128,22 @@ const stagePlugin: FastifyPluginCallback = (app, _opts, done) => {
       return reply.status(400).send({ error: 'Invalid stage ID format' });
     }
 
-    const stage = app.dataService.stages.findById(id);
+    const stage = await app.dataService.stages.findById(id);
     if (!stage) {
       return reply.status(404).send({ error: 'Stage not found' });
     }
 
     // Fetch dependencies in both directions
-    const depsFrom = app.dataService.dependencies.listByTarget(id);
-    const depsTo = app.dataService.dependencies.listBySource(id);
+    const depsFrom = await app.dataService.dependencies.listByTarget(id);
+    const depsTo = await app.dataService.dependencies.listBySource(id);
 
-    const mapDep = (d: { id: number; from_id: string; to_id: string; from_type: string; to_type: string; resolved: number }) => ({
+    const mapDep = (d: { id: number; from_id: string; to_id: string; from_type: string; to_type: string; resolved: boolean }) => ({
       id: d.id,
       from_id: d.from_id,
       to_id: d.to_id,
       from_type: d.from_type,
       to_type: d.to_type,
-      resolved: d.resolved !== 0,
+      resolved: d.resolved !== false,
     });
 
     // Read markdown body, checklists, extra frontmatter fields, and phase sibling contents
@@ -151,7 +151,9 @@ const stagePlugin: FastifyPluginCallback = (app, _opts, done) => {
     let checklists: Array<{ title: string; items: Array<{ text: string; checked: boolean }> }> = [];
     let frontmatterFields: Record<string, unknown> = {};
     let phaseContents: Record<string, string> = {};
-    if (stage.file_path && existsSync(stage.file_path)) {
+
+    // Filesystem reads only in local mode
+    if (app.deploymentContext.mode === 'local' && stage.file_path && existsSync(stage.file_path)) {
       try {
         const raw = readFileSync(stage.file_path, 'utf-8');
         const fileParsed = matter(raw);
@@ -181,13 +183,13 @@ const stagePlugin: FastifyPluginCallback = (app, _opts, done) => {
       kanban_column: stage.kanban_column,
       refinement_type: parseRefinementType(stage.refinement_type),
       worktree_branch: stage.worktree_branch,
-      session_active: stage.session_active !== 0,
+      session_active: stage.session_active !== false,
       session_id: stage.session_id ?? null,
       priority: stage.priority,
       due_date: stage.due_date,
       pr_url: stage.pr_url,
       pr_number: stage.pr_number,
-      is_draft: stage.is_draft !== 0,
+      is_draft: stage.is_draft !== false,
       pending_merge_parents: stage.pending_merge_parents,
       mr_target_branch: stage.mr_target_branch,
       file_path: stage.file_path,

--- a/tools/web-server/src/server/routes/tickets.ts
+++ b/tools/web-server/src/server/routes/tickets.ts
@@ -34,20 +34,20 @@ const ticketPlugin: FastifyPluginCallback<TicketRouteOptions> = (app, opts, done
     }
     const { epic } = parseResult.data;
 
-    const repos = app.dataService.repos.findAll();
+    const repos = await app.dataService.repos.findAll();
     if (repos.length === 0) {
       return reply.send([]);
     }
     const repo = repos[0];
 
-    let tickets = app.dataService.tickets.listByRepo(repo.id);
+    let tickets = await app.dataService.tickets.listByRepo(repo.id);
 
     // Filter by epic if query param provided
     if (epic) {
       tickets = tickets.filter((t) => t.epic_id === epic);
     }
 
-    const stages = app.dataService.stages.listByRepo(repo.id);
+    const stages = await app.dataService.stages.listByRepo(repo.id);
 
     // Build a map of ticket_id -> stage count for O(n) enrichment
     const stageCountByTicket = new Map<string, number>();
@@ -64,7 +64,7 @@ const ticketPlugin: FastifyPluginCallback<TicketRouteOptions> = (app, opts, done
       epic_id: t.epic_id,
       jira_key: t.jira_key,
       source: t.source,
-      has_stages: (t.has_stages ?? 0) !== 0,
+      has_stages: (t.has_stages ?? false) !== false,
       file_path: t.file_path,
       stage_count: stageCountByTicket.get(t.id) ?? 0,
     }));
@@ -86,12 +86,12 @@ const ticketPlugin: FastifyPluginCallback<TicketRouteOptions> = (app, opts, done
       return reply.status(400).send({ error: 'Invalid ticket ID format' });
     }
 
-    const ticket = app.dataService.tickets.findById(id);
+    const ticket = await app.dataService.tickets.findById(id);
     if (!ticket) {
       return reply.status(404).send({ error: 'Ticket not found' });
     }
 
-    const stages = app.dataService.stages.listByTicket(id, ticket.repo_id);
+    const stages = await app.dataService.stages.listByTicket(id, ticket.repo_id);
 
     const stageList = stages.map((s) => ({
       id: s.id,
@@ -100,7 +100,7 @@ const ticketPlugin: FastifyPluginCallback<TicketRouteOptions> = (app, opts, done
       kanban_column: s.kanban_column,
       refinement_type: parseRefinementType(s.refinement_type),
       worktree_branch: s.worktree_branch,
-      session_active: s.session_active !== 0,
+      session_active: s.session_active !== false,
       session_id: s.session_id ?? null,
       priority: s.priority,
       due_date: s.due_date,
@@ -114,7 +114,7 @@ const ticketPlugin: FastifyPluginCallback<TicketRouteOptions> = (app, opts, done
       epic_id: ticket.epic_id,
       jira_key: ticket.jira_key,
       source: ticket.source,
-      has_stages: (ticket.has_stages ?? 0) !== 0,
+      has_stages: (ticket.has_stages ?? false) !== false,
       file_path: ticket.file_path,
       stages: stageList,
     });
@@ -139,19 +139,24 @@ const ticketPlugin: FastifyPluginCallback<TicketRouteOptions> = (app, opts, done
       return reply.status(503).send({ error: 'Database not initialized' });
     }
 
+    // Filesystem operations not supported in hosted mode
+    if (app.deploymentContext.mode === 'hosted') {
+      return reply.code(501).send({ error: 'Not supported in hosted mode' });
+    }
+
     const parsed = createTicketSchema.safeParse(request.body);
     if (!parsed.success) {
       return reply.status(400).send({ error: 'Invalid request body', details: parsed.error.issues });
     }
     const { title, epic_id, status, description } = parsed.data;
 
-    const repos = app.dataService.repos.findAll();
+    const repos = await app.dataService.repos.findAll();
     if (repos.length === 0) {
       return reply.status(503).send({ error: 'No repos configured' });
     }
     const repo = repos[0];
 
-    const epic = app.dataService.epics.findById(epic_id);
+    const epic = await app.dataService.epics.findById(epic_id);
     if (!epic) {
       return reply.status(404).send({ error: `Epic ${epic_id} not found` });
     }
@@ -165,7 +170,7 @@ const ticketPlugin: FastifyPluginCallback<TicketRouteOptions> = (app, opts, done
     const epicNumPadded = String(epicNum).padStart(3, '0');
 
     // Find max ticket number for this epic
-    const allTickets = app.dataService.tickets.listByRepo(repo.id);
+    const allTickets = await app.dataService.tickets.listByRepo(repo.id);
     const prefix = `TICKET-${epicNumPadded}-`;
     const ticketNums = allTickets
       .filter((t) => t.id.startsWith(prefix))
@@ -183,7 +188,7 @@ const ticketPlugin: FastifyPluginCallback<TicketRouteOptions> = (app, opts, done
     mkdirSync(dirname(file_path), { recursive: true });
     writeFileSync(file_path, matter.stringify(description ?? '', { title, status, epic: epic_id }));
 
-    app.dataService.tickets.upsert({
+    await app.dataService.tickets.upsert({
       id,
       epic_id,
       repo_id: repo.id,
@@ -225,7 +230,7 @@ const ticketPlugin: FastifyPluginCallback<TicketRouteOptions> = (app, opts, done
       return reply.status(400).send({ error: 'Invalid ticket ID format' });
     }
 
-    const ticket = app.dataService.tickets.findById(id);
+    const ticket = await app.dataService.tickets.findById(id);
     if (!ticket) {
       return reply.status(404).send({ error: 'Ticket not found' });
     }
@@ -236,7 +241,7 @@ const ticketPlugin: FastifyPluginCallback<TicketRouteOptions> = (app, opts, done
     }
     const { epicId } = parsedBody.data;
 
-    const epic = app.dataService.epics.findById(epicId);
+    const epic = await app.dataService.epics.findById(epicId);
     if (!epic) {
       return reply.status(404).send({ error: `Epic ${epicId} not found` });
     }

--- a/tools/web-server/src/server/services/data-service.ts
+++ b/tools/web-server/src/server/services/data-service.ts
@@ -1,45 +1,78 @@
-import { KanbanDatabase } from '../../../../kanban-cli/dist/db/database.js';
-import {
-  RepoRepository,
-  EpicRepository,
-  TicketRepository,
-  StageRepository,
-  DependencyRepository,
-  StageSessionRepository,
-  TicketSessionRepository,
-} from '../../../../kanban-cli/dist/db/repositories/index.js';
+import type { KanbanDatabase } from '../../../../kanban-cli/dist/db/database.js';
+import type { Pool } from 'pg';
+import type {
+  IRepoRepository,
+  IEpicRepository,
+  ITicketRepository,
+  IStageRepository,
+  IDependencyRepository,
+  IStageSessionRepository,
+  ITicketSessionRepository,
+} from './repositories/types.js';
+import { createSqliteRepositories } from './repositories/sqlite/index.js';
+import { createPgRepositories } from './repositories/pg/index.js';
 
-export interface DataServiceOptions {
-  db: KanbanDatabase;
+export interface DataServiceRepositories {
+  repos: IRepoRepository;
+  epics: IEpicRepository;
+  tickets: ITicketRepository;
+  stages: IStageRepository;
+  dependencies: IDependencyRepository;
+  stageSessions: IStageSessionRepository;
+  ticketSessions: ITicketSessionRepository;
 }
 
 /**
- * Wraps kanban-cli's database and repository access into a single
- * service object that Fastify route plugins can consume.
+ * Wraps repository access into a single service object that Fastify
+ * route plugins can consume.  Backend-agnostic — works with SQLite
+ * (local mode) or PostgreSQL (hosted mode).
  */
 export class DataService {
-  readonly database: KanbanDatabase;
-  readonly repos: RepoRepository;
-  readonly epics: EpicRepository;
-  readonly tickets: TicketRepository;
-  readonly stages: StageRepository;
-  readonly dependencies: DependencyRepository;
-  readonly stageSessions: StageSessionRepository;
-  readonly ticketSessions: TicketSessionRepository;
+  readonly repos: IRepoRepository;
+  readonly epics: IEpicRepository;
+  readonly tickets: ITicketRepository;
+  readonly stages: IStageRepository;
+  readonly dependencies: IDependencyRepository;
+  readonly stageSessions: IStageSessionRepository;
+  readonly ticketSessions: ITicketSessionRepository;
 
-  constructor(options: DataServiceOptions) {
-    this.database = options.db;
-    this.repos = new RepoRepository(options.db);
-    this.epics = new EpicRepository(options.db);
-    this.tickets = new TicketRepository(options.db);
-    this.stages = new StageRepository(options.db);
-    this.dependencies = new DependencyRepository(options.db);
-    this.stageSessions = new StageSessionRepository(options.db);
-    this.ticketSessions = new TicketSessionRepository(options.db);
+  private _close: () => void;
+
+  private constructor(repositories: DataServiceRepositories, close: () => void) {
+    this.repos = repositories.repos;
+    this.epics = repositories.epics;
+    this.tickets = repositories.tickets;
+    this.stages = repositories.stages;
+    this.dependencies = repositories.dependencies;
+    this.stageSessions = repositories.stageSessions;
+    this.ticketSessions = repositories.ticketSessions;
+    this._close = close;
   }
 
-  /** Close the underlying database connection. */
+  /**
+   * Create a DataService backed by a kanban-cli SQLite database.
+   */
+  static fromSqlite(db: KanbanDatabase): DataService {
+    const repositories = createSqliteRepositories(db);
+    return new DataService(repositories, () => db.close());
+  }
+
+  /**
+   * Create a DataService backed by a PostgreSQL connection pool.
+   */
+  static fromPool(pool: Pool): DataService {
+    const repositories = createPgRepositories(pool);
+    // Pool lifecycle is managed by HostedDeploymentContext, not DataService
+    return new DataService(repositories, () => {});
+  }
+
+  /** Close the underlying database connection (SQLite only). */
   close(): void {
-    this.database.close();
+    this._close();
   }
+}
+
+// Re-export for backward compatibility — old constructor pattern
+export interface DataServiceOptions {
+  db: KanbanDatabase;
 }

--- a/tools/web-server/src/server/services/repositories/pg/index.ts
+++ b/tools/web-server/src/server/services/repositories/pg/index.ts
@@ -1,0 +1,473 @@
+/**
+ * PostgreSQL repository implementations.
+ *
+ * Each class implements the same interface as the SQLite adapter,
+ * but issues SQL queries against a pg.Pool instead of better-sqlite3.
+ * PostgreSQL returns native booleans for BOOLEAN columns, so no
+ * normalisation is needed on read paths.
+ */
+
+import type { Pool } from 'pg';
+import type {
+  IRepoRepository,
+  IEpicRepository,
+  ITicketRepository,
+  IStageRepository,
+  IDependencyRepository,
+  IStageSessionRepository,
+  ITicketSessionRepository,
+  RepoRow,
+  EpicRow,
+  TicketRow,
+  StageRow,
+  DependencyRow,
+  StageSessionRow,
+  TicketSessionRow,
+  EpicUpsertData,
+  TicketUpsertData,
+  StageUpsertData,
+  DependencyUpsertData,
+} from '../types.js';
+
+// ── Repo ─────────────────────────────────────────────────────────────
+
+export class PgRepoRepository implements IRepoRepository {
+  constructor(private pool: Pool) {}
+
+  async findAll(): Promise<RepoRow[]> {
+    const { rows } = await this.pool.query<RepoRow>(
+      'SELECT id, path, name, registered_at FROM repos ORDER BY name',
+    );
+    return rows;
+  }
+
+  async findById(id: number): Promise<RepoRow | null> {
+    const { rows } = await this.pool.query<RepoRow>(
+      'SELECT id, path, name, registered_at FROM repos WHERE id = $1',
+      [id],
+    );
+    return rows[0] ?? null;
+  }
+
+  async findByPath(repoPath: string): Promise<RepoRow | null> {
+    const { rows } = await this.pool.query<RepoRow>(
+      'SELECT id, path, name, registered_at FROM repos WHERE path = $1',
+      [repoPath],
+    );
+    return rows[0] ?? null;
+  }
+
+  async findByName(name: string): Promise<RepoRow | null> {
+    const { rows } = await this.pool.query<RepoRow>(
+      'SELECT id, path, name, registered_at FROM repos WHERE name = $1',
+      [name],
+    );
+    return rows[0] ?? null;
+  }
+
+  async upsert(repoPath: string, name: string): Promise<number> {
+    const now = new Date().toISOString();
+    const { rows } = await this.pool.query<{ id: number }>(
+      `INSERT INTO repos (path, name, registered_at)
+       VALUES ($1, $2, $3)
+       ON CONFLICT (path) DO UPDATE SET name = EXCLUDED.name
+       RETURNING id`,
+      [repoPath, name, now],
+    );
+    return rows[0].id;
+  }
+}
+
+// ── Epic ─────────────────────────────────────────────────────────────
+
+export class PgEpicRepository implements IEpicRepository {
+  constructor(private pool: Pool) {}
+
+  async findById(id: string): Promise<EpicRow | null> {
+    const { rows } = await this.pool.query<EpicRow>(
+      'SELECT * FROM epics WHERE id = $1',
+      [id],
+    );
+    return rows[0] ?? null;
+  }
+
+  async listByRepo(repoId: number): Promise<EpicRow[]> {
+    const { rows } = await this.pool.query<EpicRow>(
+      'SELECT * FROM epics WHERE repo_id = $1',
+      [repoId],
+    );
+    return rows;
+  }
+
+  async findByJiraKey(repoId: number, jiraKey: string): Promise<EpicRow | null> {
+    const { rows } = await this.pool.query<EpicRow>(
+      'SELECT * FROM epics WHERE jira_key = $1 AND repo_id = $2',
+      [jiraKey, repoId],
+    );
+    return rows[0] ?? null;
+  }
+
+  async upsert(data: EpicUpsertData): Promise<void> {
+    await this.pool.query(
+      `INSERT INTO epics (id, repo_id, title, status, jira_key, file_path, last_synced)
+       VALUES ($1, $2, $3, $4, $5, $6, $7)
+       ON CONFLICT (id) DO UPDATE SET
+         repo_id = EXCLUDED.repo_id,
+         title = EXCLUDED.title,
+         status = EXCLUDED.status,
+         jira_key = EXCLUDED.jira_key,
+         file_path = EXCLUDED.file_path,
+         last_synced = EXCLUDED.last_synced`,
+      [data.id, data.repo_id, data.title, data.status, data.jira_key, data.file_path, data.last_synced],
+    );
+  }
+}
+
+// ── Ticket ───────────────────────────────────────────────────────────
+
+export class PgTicketRepository implements ITicketRepository {
+  constructor(private pool: Pool) {}
+
+  async findById(id: string): Promise<TicketRow | null> {
+    const { rows } = await this.pool.query<TicketRow>(
+      'SELECT * FROM tickets WHERE id = $1',
+      [id],
+    );
+    return rows[0] ?? null;
+  }
+
+  async listByRepo(repoId: number): Promise<TicketRow[]> {
+    const { rows } = await this.pool.query<TicketRow>(
+      'SELECT * FROM tickets WHERE repo_id = $1',
+      [repoId],
+    );
+    return rows;
+  }
+
+  async listByEpic(epicId: string, repoId?: number): Promise<TicketRow[]> {
+    if (repoId !== undefined) {
+      const { rows } = await this.pool.query<TicketRow>(
+        'SELECT * FROM tickets WHERE epic_id = $1 AND repo_id = $2',
+        [epicId, repoId],
+      );
+      return rows;
+    }
+    const { rows } = await this.pool.query<TicketRow>(
+      'SELECT * FROM tickets WHERE epic_id = $1',
+      [epicId],
+    );
+    return rows;
+  }
+
+  async findByJiraKey(repoId: number, jiraKey: string): Promise<TicketRow | null> {
+    const { rows } = await this.pool.query<TicketRow>(
+      'SELECT * FROM tickets WHERE jira_key = $1 AND repo_id = $2',
+      [jiraKey, repoId],
+    );
+    return rows[0] ?? null;
+  }
+
+  async upsert(data: TicketUpsertData): Promise<void> {
+    await this.pool.query(
+      `INSERT INTO tickets (id, epic_id, repo_id, title, status, jira_key, source, has_stages, file_path, last_synced)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+       ON CONFLICT (id) DO UPDATE SET
+         epic_id = EXCLUDED.epic_id,
+         repo_id = EXCLUDED.repo_id,
+         title = EXCLUDED.title,
+         status = EXCLUDED.status,
+         jira_key = EXCLUDED.jira_key,
+         source = EXCLUDED.source,
+         has_stages = EXCLUDED.has_stages,
+         file_path = EXCLUDED.file_path,
+         last_synced = EXCLUDED.last_synced`,
+      [data.id, data.epic_id, data.repo_id, data.title, data.status, data.jira_key, data.source, data.has_stages, data.file_path, data.last_synced],
+    );
+  }
+}
+
+// ── Stage ────────────────────────────────────────────────────────────
+
+export class PgStageRepository implements IStageRepository {
+  constructor(private pool: Pool) {}
+
+  async findById(id: string): Promise<StageRow | null> {
+    const { rows } = await this.pool.query<StageRow>(
+      'SELECT * FROM stages WHERE id = $1',
+      [id],
+    );
+    return rows[0] ?? null;
+  }
+
+  async listByRepo(repoId: number): Promise<StageRow[]> {
+    const { rows } = await this.pool.query<StageRow>(
+      'SELECT * FROM stages WHERE repo_id = $1',
+      [repoId],
+    );
+    return rows;
+  }
+
+  async listByTicket(ticketId: string, repoId?: number): Promise<StageRow[]> {
+    if (repoId !== undefined) {
+      const { rows } = await this.pool.query<StageRow>(
+        'SELECT * FROM stages WHERE ticket_id = $1 AND repo_id = $2',
+        [ticketId, repoId],
+      );
+      return rows;
+    }
+    const { rows } = await this.pool.query<StageRow>(
+      'SELECT * FROM stages WHERE ticket_id = $1',
+      [ticketId],
+    );
+    return rows;
+  }
+
+  async listByColumn(repoId: number, column: string): Promise<StageRow[]> {
+    const { rows } = await this.pool.query<StageRow>(
+      'SELECT * FROM stages WHERE repo_id = $1 AND kanban_column = $2',
+      [repoId, column],
+    );
+    return rows;
+  }
+
+  async listReady(repoId: number): Promise<StageRow[]> {
+    const { rows } = await this.pool.query<StageRow>(
+      `SELECT * FROM stages
+       WHERE repo_id = $1
+         AND session_active = false
+         AND kanban_column != 'backlog'
+         AND kanban_column != 'done'`,
+      [repoId],
+    );
+    return rows;
+  }
+
+  async findBySessionId(sessionId: string): Promise<StageRow | null> {
+    const { rows } = await this.pool.query<StageRow>(
+      'SELECT * FROM stages WHERE session_id = $1',
+      [sessionId],
+    );
+    return rows[0] ?? null;
+  }
+
+  async updateSessionId(stageId: string, sessionId: string | null): Promise<void> {
+    await this.pool.query(
+      'UPDATE stages SET session_id = $1 WHERE id = $2',
+      [sessionId, stageId],
+    );
+  }
+
+  async upsert(data: StageUpsertData): Promise<void> {
+    await this.pool.query(
+      `INSERT INTO stages
+       (id, ticket_id, epic_id, repo_id, title, status, kanban_column, refinement_type,
+        worktree_branch, pr_url, pr_number, priority, due_date, session_active, locked_at, locked_by,
+        is_draft, pending_merge_parents, mr_target_branch, session_id, file_path, last_synced)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22)
+       ON CONFLICT (id) DO UPDATE SET
+         ticket_id = EXCLUDED.ticket_id,
+         epic_id = EXCLUDED.epic_id,
+         repo_id = EXCLUDED.repo_id,
+         title = EXCLUDED.title,
+         status = EXCLUDED.status,
+         kanban_column = EXCLUDED.kanban_column,
+         refinement_type = EXCLUDED.refinement_type,
+         worktree_branch = EXCLUDED.worktree_branch,
+         pr_url = EXCLUDED.pr_url,
+         pr_number = EXCLUDED.pr_number,
+         priority = EXCLUDED.priority,
+         due_date = EXCLUDED.due_date,
+         session_active = EXCLUDED.session_active,
+         locked_at = EXCLUDED.locked_at,
+         locked_by = EXCLUDED.locked_by,
+         is_draft = EXCLUDED.is_draft,
+         pending_merge_parents = EXCLUDED.pending_merge_parents,
+         mr_target_branch = EXCLUDED.mr_target_branch,
+         session_id = EXCLUDED.session_id,
+         file_path = EXCLUDED.file_path,
+         last_synced = EXCLUDED.last_synced`,
+      [
+        data.id, data.ticket_id, data.epic_id, data.repo_id,
+        data.title, data.status, data.kanban_column, data.refinement_type,
+        data.worktree_branch, data.pr_url, data.pr_number, data.priority,
+        data.due_date, data.session_active, data.locked_at, data.locked_by,
+        data.is_draft ?? 0, data.pending_merge_parents ?? null,
+        data.mr_target_branch ?? null, data.session_id ?? null,
+        data.file_path, data.last_synced,
+      ],
+    );
+  }
+}
+
+// ── Dependency ───────────────────────────────────────────────────────
+
+export class PgDependencyRepository implements IDependencyRepository {
+  constructor(private pool: Pool) {}
+
+  async listByTarget(fromId: string): Promise<DependencyRow[]> {
+    const { rows } = await this.pool.query<DependencyRow>(
+      'SELECT * FROM dependencies WHERE from_id = $1',
+      [fromId],
+    );
+    return rows;
+  }
+
+  async listBySource(toId: string): Promise<DependencyRow[]> {
+    const { rows } = await this.pool.query<DependencyRow>(
+      'SELECT * FROM dependencies WHERE to_id = $1',
+      [toId],
+    );
+    return rows;
+  }
+
+  async listByRepo(repoId: number): Promise<DependencyRow[]> {
+    const { rows } = await this.pool.query<DependencyRow>(
+      'SELECT * FROM dependencies WHERE repo_id = $1',
+      [repoId],
+    );
+    return rows;
+  }
+
+  async resolve(fromId: string, toId: string): Promise<void> {
+    await this.pool.query(
+      'UPDATE dependencies SET resolved = true WHERE from_id = $1 AND to_id = $2',
+      [fromId, toId],
+    );
+  }
+
+  async allResolved(fromId: string): Promise<boolean> {
+    const { rows } = await this.pool.query<{ count: string }>(
+      'SELECT COUNT(*) as count FROM dependencies WHERE from_id = $1 AND resolved = false',
+      [fromId],
+    );
+    return parseInt(rows[0].count, 10) === 0;
+  }
+
+  async upsert(data: DependencyUpsertData): Promise<void> {
+    const targetRepoName = data.target_repo_name ?? null;
+    await this.pool.query(
+      `INSERT INTO dependencies (from_id, to_id, from_type, to_type, repo_id, target_repo_name)
+       VALUES ($1, $2, $3, $4, $5, $6)
+       ON CONFLICT (from_id, to_id) DO UPDATE SET
+         from_type = EXCLUDED.from_type,
+         to_type = EXCLUDED.to_type,
+         repo_id = EXCLUDED.repo_id,
+         target_repo_name = EXCLUDED.target_repo_name`,
+      [data.from_id, data.to_id, data.from_type, data.to_type, data.repo_id, targetRepoName],
+    );
+  }
+
+  async deleteByRepo(repoId: number): Promise<void> {
+    await this.pool.query(
+      'DELETE FROM dependencies WHERE repo_id = $1',
+      [repoId],
+    );
+  }
+}
+
+// ── Stage Session ────────────────────────────────────────────────────
+
+export class PgStageSessionRepository implements IStageSessionRepository {
+  constructor(private pool: Pool) {}
+
+  async getSessionsByStageId(stageId: string): Promise<StageSessionRow[]> {
+    const { rows } = await this.pool.query<StageSessionRow>(
+      `SELECT * FROM stage_sessions
+       WHERE stage_id = $1
+       ORDER BY is_current DESC, started_at DESC`,
+      [stageId],
+    );
+    return rows;
+  }
+
+  async addSession(stageId: string, sessionId: string, phase: string): Promise<void> {
+    const now = new Date().toISOString();
+    const client = await this.pool.connect();
+    try {
+      await client.query('BEGIN');
+      await client.query(
+        `UPDATE stage_sessions SET is_current = 0, ended_at = $1
+         WHERE stage_id = $2 AND is_current = 1`,
+        [now, stageId],
+      );
+      await client.query(
+        `INSERT INTO stage_sessions (stage_id, session_id, phase, started_at, is_current)
+         VALUES ($1, $2, $3, $4, 1)`,
+        [stageId, sessionId, phase, now],
+      );
+      await client.query('COMMIT');
+    } catch (err) {
+      await client.query('ROLLBACK');
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+
+  async endSession(stageId: string, sessionId: string): Promise<void> {
+    const now = new Date().toISOString();
+    await this.pool.query(
+      `UPDATE stage_sessions SET is_current = 0, ended_at = $1
+       WHERE stage_id = $2 AND session_id = $3`,
+      [now, stageId, sessionId],
+    );
+  }
+
+  async getCurrentSession(stageId: string): Promise<StageSessionRow | null> {
+    const { rows } = await this.pool.query<StageSessionRow>(
+      'SELECT * FROM stage_sessions WHERE stage_id = $1 AND is_current = 1',
+      [stageId],
+    );
+    return rows[0] ?? null;
+  }
+}
+
+// ── Ticket Session ───────────────────────────────────────────────────
+
+export class PgTicketSessionRepository implements ITicketSessionRepository {
+  constructor(private pool: Pool) {}
+
+  async getSessionsByTicketId(ticketId: string): Promise<TicketSessionRow[]> {
+    const { rows } = await this.pool.query<TicketSessionRow>(
+      'SELECT * FROM ticket_sessions WHERE ticket_id = $1 ORDER BY started_at DESC',
+      [ticketId],
+    );
+    return rows;
+  }
+
+  async addSession(ticketId: string, sessionId: string, sessionType: string): Promise<void> {
+    const now = new Date().toISOString();
+    await this.pool.query(
+      `INSERT INTO ticket_sessions (ticket_id, session_id, session_type, started_at)
+       VALUES ($1, $2, $3, $4)`,
+      [ticketId, sessionId, sessionType, now],
+    );
+  }
+}
+
+// ── Factory ──────────────────────────────────────────────────────────
+
+export interface PgRepositories {
+  repos: IRepoRepository;
+  epics: IEpicRepository;
+  tickets: ITicketRepository;
+  stages: IStageRepository;
+  dependencies: IDependencyRepository;
+  stageSessions: IStageSessionRepository;
+  ticketSessions: ITicketSessionRepository;
+}
+
+/**
+ * Build all PostgreSQL repository implementations from a connection pool.
+ */
+export function createPgRepositories(pool: Pool): PgRepositories {
+  return {
+    repos: new PgRepoRepository(pool),
+    epics: new PgEpicRepository(pool),
+    tickets: new PgTicketRepository(pool),
+    stages: new PgStageRepository(pool),
+    dependencies: new PgDependencyRepository(pool),
+    stageSessions: new PgStageSessionRepository(pool),
+    ticketSessions: new PgTicketSessionRepository(pool),
+  };
+}

--- a/tools/web-server/src/server/services/repositories/sqlite/index.ts
+++ b/tools/web-server/src/server/services/repositories/sqlite/index.ts
@@ -1,0 +1,296 @@
+/**
+ * SQLite repository adapters.
+ *
+ * Each adapter wraps the corresponding kanban-cli repository class,
+ * returning Promises and normalising boolean fields (0/1 → true/false).
+ */
+
+import type { KanbanDatabase } from '../../../../../../kanban-cli/dist/db/database.js';
+import {
+  RepoRepository,
+  EpicRepository,
+  TicketRepository,
+  StageRepository,
+  DependencyRepository,
+  StageSessionRepository,
+  TicketSessionRepository,
+} from '../../../../../../kanban-cli/dist/db/repositories/index.js';
+import type {
+  EpicRow as SqliteEpicRow,
+  TicketRow as SqliteTicketRow,
+  StageRow as SqliteStageRow,
+  DependencyRow as SqliteDependencyRow,
+  StageSessionRow as SqliteStageSessionRow,
+  TicketSessionRow as SqliteTicketSessionRow,
+} from '../../../../../../kanban-cli/dist/db/repositories/index.js';
+import type { RepoRecord } from '../../../../../../kanban-cli/dist/types/work-items.js';
+import type {
+  IRepoRepository,
+  IEpicRepository,
+  ITicketRepository,
+  IStageRepository,
+  IDependencyRepository,
+  IStageSessionRepository,
+  ITicketSessionRepository,
+  RepoRow,
+  EpicRow,
+  TicketRow,
+  StageRow,
+  DependencyRow,
+  StageSessionRow,
+  TicketSessionRow,
+  EpicUpsertData,
+  TicketUpsertData,
+  StageUpsertData,
+  DependencyUpsertData,
+} from '../types.js';
+
+// ── Normalisation helpers ────────────────────────────────────────────
+
+function toBoolean(v: number | null | undefined): boolean {
+  return v !== 0 && v != null;
+}
+
+function toBooleanNullable(v: number | null | undefined): boolean | null {
+  if (v == null) return null;
+  return v !== 0;
+}
+
+function normaliseRepo(r: RepoRecord): RepoRow {
+  return { id: r.id, path: r.path, name: r.name, registered_at: r.registered_at };
+}
+
+function normaliseEpic(r: SqliteEpicRow): EpicRow {
+  return { ...r };
+}
+
+function normaliseTicket(r: SqliteTicketRow): TicketRow {
+  return { ...r, has_stages: toBooleanNullable(r.has_stages) };
+}
+
+function normaliseStage(r: SqliteStageRow): StageRow {
+  return {
+    ...r,
+    session_active: toBoolean(r.session_active),
+    is_draft: toBoolean(r.is_draft),
+  };
+}
+
+function normaliseDependency(r: SqliteDependencyRow): DependencyRow {
+  return { ...r, resolved: toBoolean(r.resolved) };
+}
+
+function normaliseStageSession(r: SqliteStageSessionRow): StageSessionRow {
+  return { ...r, is_current: toBoolean(r.is_current) };
+}
+
+function normaliseTicketSession(r: SqliteTicketSessionRow): TicketSessionRow {
+  return { ...r };
+}
+
+// ── Adapters ─────────────────────────────────────────────────────────
+
+export class SqliteRepoRepository implements IRepoRepository {
+  constructor(private inner: RepoRepository) {}
+
+  async findAll(): Promise<RepoRow[]> {
+    return this.inner.findAll().map(normaliseRepo);
+  }
+
+  async findById(id: number): Promise<RepoRow | null> {
+    const row = this.inner.findById(id);
+    return row ? normaliseRepo(row) : null;
+  }
+
+  async findByPath(repoPath: string): Promise<RepoRow | null> {
+    const row = this.inner.findByPath(repoPath);
+    return row ? normaliseRepo(row) : null;
+  }
+
+  async findByName(name: string): Promise<RepoRow | null> {
+    const row = this.inner.findByName(name);
+    return row ? normaliseRepo(row) : null;
+  }
+
+  async upsert(repoPath: string, name: string): Promise<number> {
+    return this.inner.upsert(repoPath, name);
+  }
+}
+
+export class SqliteEpicRepository implements IEpicRepository {
+  constructor(private inner: EpicRepository) {}
+
+  async findById(id: string): Promise<EpicRow | null> {
+    const row = this.inner.findById(id);
+    return row ? normaliseEpic(row) : null;
+  }
+
+  async listByRepo(repoId: number): Promise<EpicRow[]> {
+    return this.inner.listByRepo(repoId).map(normaliseEpic);
+  }
+
+  async findByJiraKey(repoId: number, jiraKey: string): Promise<EpicRow | null> {
+    const row = this.inner.findByJiraKey(repoId, jiraKey);
+    return row ? normaliseEpic(row) : null;
+  }
+
+  async upsert(data: EpicUpsertData): Promise<void> {
+    this.inner.upsert(data);
+  }
+}
+
+export class SqliteTicketRepository implements ITicketRepository {
+  constructor(private inner: TicketRepository) {}
+
+  async findById(id: string): Promise<TicketRow | null> {
+    const row = this.inner.findById(id);
+    return row ? normaliseTicket(row) : null;
+  }
+
+  async listByRepo(repoId: number): Promise<TicketRow[]> {
+    return this.inner.listByRepo(repoId).map(normaliseTicket);
+  }
+
+  async listByEpic(epicId: string, repoId?: number): Promise<TicketRow[]> {
+    return this.inner.listByEpic(epicId, repoId).map(normaliseTicket);
+  }
+
+  async findByJiraKey(repoId: number, jiraKey: string): Promise<TicketRow | null> {
+    const row = this.inner.findByJiraKey(repoId, jiraKey);
+    return row ? normaliseTicket(row) : null;
+  }
+
+  async upsert(data: TicketUpsertData): Promise<void> {
+    this.inner.upsert(data);
+  }
+}
+
+export class SqliteStageRepository implements IStageRepository {
+  constructor(private inner: StageRepository) {}
+
+  async findById(id: string): Promise<StageRow | null> {
+    const row = this.inner.findById(id);
+    return row ? normaliseStage(row) : null;
+  }
+
+  async listByRepo(repoId: number): Promise<StageRow[]> {
+    return this.inner.listByRepo(repoId).map(normaliseStage);
+  }
+
+  async listByTicket(ticketId: string, repoId?: number): Promise<StageRow[]> {
+    return this.inner.listByTicket(ticketId, repoId).map(normaliseStage);
+  }
+
+  async listByColumn(repoId: number, column: string): Promise<StageRow[]> {
+    return this.inner.listByColumn(repoId, column).map(normaliseStage);
+  }
+
+  async listReady(repoId: number): Promise<StageRow[]> {
+    return this.inner.listReady(repoId).map(normaliseStage);
+  }
+
+  async findBySessionId(sessionId: string): Promise<StageRow | null> {
+    const row = this.inner.findBySessionId(sessionId);
+    return row ? normaliseStage(row) : null;
+  }
+
+  async updateSessionId(stageId: string, sessionId: string | null): Promise<void> {
+    this.inner.updateSessionId(stageId, sessionId);
+  }
+
+  async upsert(data: StageUpsertData): Promise<void> {
+    this.inner.upsert(data);
+  }
+}
+
+export class SqliteDependencyRepository implements IDependencyRepository {
+  constructor(private inner: DependencyRepository) {}
+
+  async listByTarget(fromId: string): Promise<DependencyRow[]> {
+    return this.inner.listByTarget(fromId).map(normaliseDependency);
+  }
+
+  async listBySource(toId: string): Promise<DependencyRow[]> {
+    return this.inner.listBySource(toId).map(normaliseDependency);
+  }
+
+  async listByRepo(repoId: number): Promise<DependencyRow[]> {
+    return this.inner.listByRepo(repoId).map(normaliseDependency);
+  }
+
+  async resolve(fromId: string, toId: string): Promise<void> {
+    this.inner.resolve(fromId, toId);
+  }
+
+  async allResolved(fromId: string): Promise<boolean> {
+    return this.inner.allResolved(fromId);
+  }
+
+  async upsert(data: DependencyUpsertData): Promise<void> {
+    this.inner.upsert(data);
+  }
+
+  async deleteByRepo(repoId: number): Promise<void> {
+    this.inner.deleteByRepo(repoId);
+  }
+}
+
+export class SqliteStageSessionRepository implements IStageSessionRepository {
+  constructor(private inner: StageSessionRepository) {}
+
+  async getSessionsByStageId(stageId: string): Promise<StageSessionRow[]> {
+    return this.inner.getSessionsByStageId(stageId).map(normaliseStageSession);
+  }
+
+  async addSession(stageId: string, sessionId: string, phase: string): Promise<void> {
+    this.inner.addSession(stageId, sessionId, phase);
+  }
+
+  async endSession(stageId: string, sessionId: string): Promise<void> {
+    this.inner.endSession(stageId, sessionId);
+  }
+
+  async getCurrentSession(stageId: string): Promise<StageSessionRow | null> {
+    const row = this.inner.getCurrentSession(stageId);
+    return row ? normaliseStageSession(row) : null;
+  }
+}
+
+export class SqliteTicketSessionRepository implements ITicketSessionRepository {
+  constructor(private inner: TicketSessionRepository) {}
+
+  async getSessionsByTicketId(ticketId: string): Promise<TicketSessionRow[]> {
+    return this.inner.getSessionsByTicketId(ticketId).map(normaliseTicketSession);
+  }
+
+  async addSession(ticketId: string, sessionId: string, sessionType: string): Promise<void> {
+    this.inner.addSession(ticketId, sessionId, sessionType);
+  }
+}
+
+// ── Factory ──────────────────────────────────────────────────────────
+
+export interface SqliteRepositories {
+  repos: IRepoRepository;
+  epics: IEpicRepository;
+  tickets: ITicketRepository;
+  stages: IStageRepository;
+  dependencies: IDependencyRepository;
+  stageSessions: IStageSessionRepository;
+  ticketSessions: ITicketSessionRepository;
+}
+
+/**
+ * Build all SQLite adapter repositories from a KanbanDatabase instance.
+ */
+export function createSqliteRepositories(db: KanbanDatabase): SqliteRepositories {
+  return {
+    repos: new SqliteRepoRepository(new RepoRepository(db)),
+    epics: new SqliteEpicRepository(new EpicRepository(db)),
+    tickets: new SqliteTicketRepository(new TicketRepository(db)),
+    stages: new SqliteStageRepository(new StageRepository(db)),
+    dependencies: new SqliteDependencyRepository(new DependencyRepository(db)),
+    stageSessions: new SqliteStageSessionRepository(new StageSessionRepository(db)),
+    ticketSessions: new SqliteTicketSessionRepository(new TicketSessionRepository(db)),
+  };
+}

--- a/tools/web-server/src/server/services/repositories/types.ts
+++ b/tools/web-server/src/server/services/repositories/types.ts
@@ -1,0 +1,208 @@
+/**
+ * Database-agnostic row types for the repository abstraction layer.
+ *
+ * Boolean fields are typed as `boolean` (not `number`) — SQLite adapters
+ * normalise 0/1 to false/true, and PostgreSQL returns native booleans.
+ */
+
+export interface RepoRow {
+  id: number;
+  path: string;
+  name: string;
+  registered_at: string;
+}
+
+export interface EpicRow {
+  id: string;
+  repo_id: number;
+  title: string | null;
+  status: string | null;
+  jira_key: string | null;
+  file_path: string;
+  last_synced: string;
+}
+
+export interface TicketRow {
+  id: string;
+  epic_id: string | null;
+  repo_id: number;
+  title: string | null;
+  status: string | null;
+  jira_key: string | null;
+  source: string | null;
+  has_stages: boolean | null;
+  file_path: string;
+  last_synced: string;
+}
+
+export interface StageRow {
+  id: string;
+  ticket_id: string | null;
+  epic_id: string | null;
+  repo_id: number;
+  title: string | null;
+  status: string | null;
+  kanban_column: string | null;
+  refinement_type: string | null;
+  worktree_branch: string | null;
+  pr_url: string | null;
+  pr_number: number | null;
+  priority: number;
+  due_date: string | null;
+  session_active: boolean;
+  locked_at: string | null;
+  locked_by: string | null;
+  is_draft: boolean;
+  pending_merge_parents: string | null;
+  mr_target_branch: string | null;
+  session_id: string | null;
+  file_path: string;
+  last_synced: string;
+}
+
+export interface DependencyRow {
+  id: number;
+  from_id: string;
+  to_id: string;
+  from_type: string;
+  to_type: string;
+  resolved: boolean;
+  repo_id: number;
+  target_repo_name: string | null;
+}
+
+export interface StageSessionRow {
+  id: number;
+  stage_id: string;
+  session_id: string;
+  phase: string;
+  started_at: string;
+  ended_at: string | null;
+  is_current: boolean;
+}
+
+export interface TicketSessionRow {
+  id: number;
+  ticket_id: string;
+  session_id: string;
+  session_type: string;
+  started_at: string;
+  ended_at: string | null;
+}
+
+// ── Upsert data types ────────────────────────────────────────────────
+
+export interface EpicUpsertData {
+  id: string;
+  repo_id: number;
+  title: string | null;
+  status: string | null;
+  jira_key: string | null;
+  file_path: string;
+  last_synced: string;
+}
+
+export interface TicketUpsertData {
+  id: string;
+  epic_id: string | null;
+  repo_id: number;
+  title: string | null;
+  status: string | null;
+  jira_key: string | null;
+  source: string | null;
+  has_stages: number | null;
+  file_path: string;
+  last_synced: string;
+}
+
+export interface StageUpsertData {
+  id: string;
+  ticket_id: string | null;
+  epic_id: string | null;
+  repo_id: number;
+  title: string | null;
+  status: string | null;
+  kanban_column: string | null;
+  refinement_type: string | null;
+  worktree_branch: string | null;
+  pr_url: string | null;
+  pr_number: number | null;
+  priority: number;
+  due_date: string | null;
+  session_active: number;
+  locked_at: string | null;
+  locked_by: string | null;
+  is_draft?: number;
+  pending_merge_parents?: string | null;
+  mr_target_branch?: string | null;
+  session_id?: string | null;
+  file_path: string;
+  last_synced: string;
+}
+
+export interface DependencyUpsertData {
+  from_id: string;
+  to_id: string;
+  from_type: string;
+  to_type: string;
+  repo_id: number;
+  target_repo_name?: string | null;
+}
+
+// ── Repository interfaces ────────────────────────────────────────────
+
+export interface IRepoRepository {
+  findAll(): Promise<RepoRow[]>;
+  findById(id: number): Promise<RepoRow | null>;
+  findByPath(repoPath: string): Promise<RepoRow | null>;
+  findByName(name: string): Promise<RepoRow | null>;
+  upsert(repoPath: string, name: string): Promise<number>;
+}
+
+export interface IEpicRepository {
+  findById(id: string): Promise<EpicRow | null>;
+  listByRepo(repoId: number): Promise<EpicRow[]>;
+  findByJiraKey(repoId: number, jiraKey: string): Promise<EpicRow | null>;
+  upsert(data: EpicUpsertData): Promise<void>;
+}
+
+export interface ITicketRepository {
+  findById(id: string): Promise<TicketRow | null>;
+  listByRepo(repoId: number): Promise<TicketRow[]>;
+  listByEpic(epicId: string, repoId?: number): Promise<TicketRow[]>;
+  findByJiraKey(repoId: number, jiraKey: string): Promise<TicketRow | null>;
+  upsert(data: TicketUpsertData): Promise<void>;
+}
+
+export interface IStageRepository {
+  findById(id: string): Promise<StageRow | null>;
+  listByRepo(repoId: number): Promise<StageRow[]>;
+  listByTicket(ticketId: string, repoId?: number): Promise<StageRow[]>;
+  listByColumn(repoId: number, column: string): Promise<StageRow[]>;
+  listReady(repoId: number): Promise<StageRow[]>;
+  findBySessionId(sessionId: string): Promise<StageRow | null>;
+  updateSessionId(stageId: string, sessionId: string | null): Promise<void>;
+  upsert(data: StageUpsertData): Promise<void>;
+}
+
+export interface IDependencyRepository {
+  listByTarget(fromId: string): Promise<DependencyRow[]>;
+  listBySource(toId: string): Promise<DependencyRow[]>;
+  listByRepo(repoId: number): Promise<DependencyRow[]>;
+  resolve(fromId: string, toId: string): Promise<void>;
+  allResolved(fromId: string): Promise<boolean>;
+  upsert(data: DependencyUpsertData): Promise<void>;
+  deleteByRepo(repoId: number): Promise<void>;
+}
+
+export interface IStageSessionRepository {
+  getSessionsByStageId(stageId: string): Promise<StageSessionRow[]>;
+  addSession(stageId: string, sessionId: string, phase: string): Promise<void>;
+  endSession(stageId: string, sessionId: string): Promise<void>;
+  getCurrentSession(stageId: string): Promise<StageSessionRow | null>;
+}
+
+export interface ITicketSessionRepository {
+  getSessionsByTicketId(ticketId: string): Promise<TicketSessionRow[]>;
+  addSession(ticketId: string, sessionId: string, sessionType: string): Promise<void>;
+}

--- a/tools/web-server/tests/server/board.test.ts
+++ b/tools/web-server/tests/server/board.test.ts
@@ -18,7 +18,7 @@ describe('board API', () => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kanban-board-test-'));
     db = new KanbanDatabase(path.join(tmpDir, 'test.db'));
     seedDatabase(db, tmpDir);
-    dataService = new DataService({ db });
+    dataService = DataService.fromSqlite(db);
     app = await createServer({ logger: false, isDev: true, dataService });
   });
 
@@ -206,7 +206,7 @@ describe('board API', () => {
   it('GET /api/board with empty database returns empty board', async () => {
     const emptyTmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kanban-empty-'));
     const emptyDb = new KanbanDatabase(path.join(emptyTmpDir, 'empty.db'));
-    const emptyDs = new DataService({ db: emptyDb });
+    const emptyDs = DataService.fromSqlite(emptyDb);
     const emptyApp = await createServer({ logger: false, isDev: true, dataService: emptyDs });
     try {
       const response = await emptyApp.inject({ method: 'GET', url: '/api/board' });

--- a/tools/web-server/tests/server/data-service.test.ts
+++ b/tools/web-server/tests/server/data-service.test.ts
@@ -5,13 +5,6 @@ import { tmpdir } from 'os';
 import { KanbanDatabase } from '../../../kanban-cli/dist/db/database.js';
 import { DataService } from '../../src/server/services/data-service.js';
 import { createServer } from '../../src/server/app.js';
-import {
-  RepoRepository,
-  EpicRepository,
-  TicketRepository,
-  StageRepository,
-  DependencyRepository,
-} from '../../../kanban-cli/dist/db/repositories/index.js';
 
 describe('DataService', () => {
   let tmpDir: string;
@@ -21,7 +14,7 @@ describe('DataService', () => {
   beforeEach(() => {
     tmpDir = mkdtempSync(join(tmpdir(), 'data-service-test-'));
     db = new KanbanDatabase(join(tmpDir, 'test.db'));
-    service = new DataService({ db });
+    service = DataService.fromSqlite(db);
   });
 
   afterEach(() => {
@@ -33,28 +26,20 @@ describe('DataService', () => {
     rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it('provides access to the raw database', () => {
-    expect(service.database).toBe(db);
+  it('provides repository instances', () => {
+    expect(service.repos).toBeDefined();
+    expect(service.epics).toBeDefined();
+    expect(service.tickets).toBeDefined();
+    expect(service.stages).toBeDefined();
+    expect(service.dependencies).toBeDefined();
+    expect(service.stageSessions).toBeDefined();
+    expect(service.ticketSessions).toBeDefined();
   });
 
-  it('provides a RepoRepository instance', () => {
-    expect(service.repos).toBeInstanceOf(RepoRepository);
-  });
-
-  it('provides an EpicRepository instance', () => {
-    expect(service.epics).toBeInstanceOf(EpicRepository);
-  });
-
-  it('provides a TicketRepository instance', () => {
-    expect(service.tickets).toBeInstanceOf(TicketRepository);
-  });
-
-  it('provides a StageRepository instance', () => {
-    expect(service.stages).toBeInstanceOf(StageRepository);
-  });
-
-  it('provides a DependencyRepository instance', () => {
-    expect(service.dependencies).toBeInstanceOf(DependencyRepository);
+  it('repository methods return promises', async () => {
+    const repos = await service.repos.findAll();
+    expect(Array.isArray(repos)).toBe(true);
+    expect(repos.length).toBe(0);
   });
 
   it('close() closes the database connection', () => {

--- a/tools/web-server/tests/server/epics.test.ts
+++ b/tools/web-server/tests/server/epics.test.ts
@@ -18,7 +18,7 @@ describe('epics API', () => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kanban-epics-test-'));
     db = new KanbanDatabase(path.join(tmpDir, 'test.db'));
     seedDatabase(db, tmpDir);
-    dataService = new DataService({ db });
+    dataService = DataService.fromSqlite(db);
     app = await createServer({ logger: false, isDev: true, dataService });
   });
 

--- a/tools/web-server/tests/server/graph.test.ts
+++ b/tools/web-server/tests/server/graph.test.ts
@@ -18,7 +18,7 @@ describe('graph API', () => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kanban-graph-test-'));
     db = new KanbanDatabase(path.join(tmpDir, 'test.db'));
     seedDatabase(db, tmpDir);
-    dataService = new DataService({ db });
+    dataService = DataService.fromSqlite(db);
     app = await createServer({ logger: false, isDev: true, dataService });
   });
 
@@ -105,7 +105,7 @@ describe('graph API', () => {
   it('GET /api/graph with empty database returns empty graph', async () => {
     const emptyTmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kanban-graph-empty-'));
     const emptyDb = new KanbanDatabase(path.join(emptyTmpDir, 'empty.db'));
-    const emptyDs = new DataService({ db: emptyDb });
+    const emptyDs = DataService.fromSqlite(emptyDb);
     const emptyApp = await createServer({ logger: false, isDev: true, dataService: emptyDs });
     try {
       const response = await emptyApp.inject({ method: 'GET', url: '/api/graph' });
@@ -160,7 +160,7 @@ describe('graph API', () => {
   it('GET /api/graph?mermaid=true with empty database returns mermaid string', async () => {
     const emptyTmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kanban-empty-'));
     const emptyDb = new KanbanDatabase(path.join(emptyTmpDir, 'empty.db'));
-    const emptyDs = new DataService({ db: emptyDb });
+    const emptyDs = DataService.fromSqlite(emptyDb);
     const emptyApp = await createServer({ logger: false, isDev: true, dataService: emptyDs });
     try {
       const response = await emptyApp.inject({

--- a/tools/web-server/tests/server/services/repositories/pg-repositories.test.ts
+++ b/tools/web-server/tests/server/services/repositories/pg-repositories.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createPgRepositories } from '../../../../src/server/services/repositories/pg/index.js';
+import type { Pool, QueryResult } from 'pg';
+
+/**
+ * Create a mock pg.Pool that returns the given rows for any query.
+ */
+function mockPool(rows: Record<string, unknown>[] = []): Pool {
+  const queryFn = vi.fn().mockResolvedValue({ rows } as QueryResult);
+  const clientRelease = vi.fn();
+  const connectFn = vi.fn().mockResolvedValue({
+    query: vi.fn().mockResolvedValue({ rows: [] }),
+    release: clientRelease,
+  });
+  return {
+    query: queryFn,
+    connect: connectFn,
+  } as unknown as Pool;
+}
+
+describe('PG repository implementations', () => {
+  describe('PgRepoRepository', () => {
+    it('findAll queries repos table', async () => {
+      const pool = mockPool([
+        { id: 1, path: '/tmp/repo', name: 'test-repo', registered_at: '2024-01-01' },
+      ]);
+      const repos = createPgRepositories(pool);
+
+      const result = await repos.repos.findAll();
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe('test-repo');
+      expect(pool.query).toHaveBeenCalledWith(
+        expect.stringContaining('SELECT'),
+      );
+    });
+
+    it('findById returns null when not found', async () => {
+      const pool = mockPool([]);
+      const repos = createPgRepositories(pool);
+
+      const result = await repos.repos.findById(999);
+      expect(result).toBeNull();
+    });
+
+    it('upsert uses ON CONFLICT', async () => {
+      const pool = mockPool([{ id: 42 }]);
+      const repos = createPgRepositories(pool);
+
+      const id = await repos.repos.upsert('/tmp/repo', 'test-repo');
+      expect(id).toBe(42);
+      expect(pool.query).toHaveBeenCalledWith(
+        expect.stringContaining('ON CONFLICT'),
+        expect.arrayContaining(['/tmp/repo', 'test-repo']),
+      );
+    });
+  });
+
+  describe('PgEpicRepository', () => {
+    it('findById returns row or null', async () => {
+      const pool = mockPool([{ id: 'EPIC-001', repo_id: 1, title: 'Auth', status: 'active', jira_key: null, file_path: '/f', last_synced: 'ts' }]);
+      const repos = createPgRepositories(pool);
+
+      const epic = await repos.epics.findById('EPIC-001');
+      expect(epic).not.toBeNull();
+      expect(epic!.id).toBe('EPIC-001');
+    });
+
+    it('upsert uses ON CONFLICT', async () => {
+      const pool = mockPool([]);
+      const repos = createPgRepositories(pool);
+
+      await repos.epics.upsert({
+        id: 'EPIC-001', repo_id: 1, title: 'Auth', status: 'active',
+        jira_key: null, file_path: '/f', last_synced: 'ts',
+      });
+      expect(pool.query).toHaveBeenCalledWith(
+        expect.stringContaining('ON CONFLICT'),
+        expect.any(Array),
+      );
+    });
+  });
+
+  describe('PgStageRepository', () => {
+    it('listReady queries with boolean false', async () => {
+      const pool = mockPool([]);
+      const repos = createPgRepositories(pool);
+
+      await repos.stages.listReady(1);
+      expect(pool.query).toHaveBeenCalledWith(
+        expect.stringContaining('session_active = false'),
+        [1],
+      );
+    });
+  });
+
+  describe('PgDependencyRepository', () => {
+    it('resolve uses boolean true', async () => {
+      const pool = mockPool([]);
+      const repos = createPgRepositories(pool);
+
+      await repos.dependencies.resolve('from-1', 'to-1');
+      expect(pool.query).toHaveBeenCalledWith(
+        expect.stringContaining('resolved = true'),
+        ['from-1', 'to-1'],
+      );
+    });
+
+    it('allResolved returns true when count is 0', async () => {
+      const pool = mockPool([{ count: '0' }]);
+      const repos = createPgRepositories(pool);
+
+      const result = await repos.dependencies.allResolved('from-1');
+      expect(result).toBe(true);
+    });
+
+    it('allResolved returns false when count > 0', async () => {
+      const pool = mockPool([{ count: '2' }]);
+      const repos = createPgRepositories(pool);
+
+      const result = await repos.dependencies.allResolved('from-1');
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('PgStageSessionRepository', () => {
+    it('addSession uses transaction', async () => {
+      const pool = mockPool([]);
+      const repos = createPgRepositories(pool);
+
+      await repos.stageSessions.addSession('STAGE-001-001-001', 'sess-1', 'Design');
+      // Should have used connect() for transaction
+      expect(pool.connect).toHaveBeenCalled();
+    });
+  });
+
+  describe('PgTicketSessionRepository', () => {
+    let pool: Pool;
+    let repos: ReturnType<typeof createPgRepositories>;
+
+    beforeEach(() => {
+      pool = mockPool([
+        { id: 1, ticket_id: 'T-1', session_id: 's-1', session_type: 'convert', started_at: 'ts', ended_at: null },
+      ]);
+      repos = createPgRepositories(pool);
+    });
+
+    it('getSessionsByTicketId queries with ticket_id', async () => {
+      const result = await repos.ticketSessions.getSessionsByTicketId('T-1');
+      expect(result).toHaveLength(1);
+      expect(pool.query).toHaveBeenCalledWith(
+        expect.stringContaining('ticket_id'),
+        ['T-1'],
+      );
+    });
+  });
+});

--- a/tools/web-server/tests/server/services/repositories/sqlite-repositories.test.ts
+++ b/tools/web-server/tests/server/services/repositories/sqlite-repositories.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { KanbanDatabase } from '../../../../../kanban-cli/dist/db/database.js';
+import { createSqliteRepositories } from '../../../../src/server/services/repositories/sqlite/index.js';
+import { seedDatabase, SEED_IDS } from '../../../helpers/seed-data.js';
+
+describe('SQLite repository adapters', () => {
+  let tmpDir: string;
+  let db: KanbanDatabase;
+  let repos: ReturnType<typeof createSqliteRepositories>;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'sqlite-repo-test-'));
+    db = new KanbanDatabase(join(tmpDir, 'test.db'));
+    seedDatabase(db, tmpDir);
+    repos = createSqliteRepositories(db);
+  });
+
+  afterEach(() => {
+    db.close();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('RepoRepository', () => {
+    it('findAll returns array of repos', async () => {
+      const all = await repos.repos.findAll();
+      expect(Array.isArray(all)).toBe(true);
+      expect(all.length).toBeGreaterThan(0);
+      expect(all[0]).toHaveProperty('id');
+      expect(all[0]).toHaveProperty('path');
+      expect(all[0]).toHaveProperty('name');
+    });
+
+    it('findById returns a repo or null', async () => {
+      const all = await repos.repos.findAll();
+      const found = await repos.repos.findById(all[0].id);
+      expect(found).not.toBeNull();
+      expect(found!.id).toBe(all[0].id);
+
+      const notFound = await repos.repos.findById(99999);
+      expect(notFound).toBeNull();
+    });
+  });
+
+  describe('EpicRepository', () => {
+    it('listByRepo returns epics', async () => {
+      const allRepos = await repos.repos.findAll();
+      const epics = await repos.epics.listByRepo(allRepos[0].id);
+      expect(Array.isArray(epics)).toBe(true);
+      expect(epics.length).toBeGreaterThan(0);
+    });
+
+    it('findById returns an epic or null', async () => {
+      const epic = await repos.epics.findById(SEED_IDS.EPIC_AUTH);
+      expect(epic).not.toBeNull();
+      expect(epic!.id).toBe(SEED_IDS.EPIC_AUTH);
+
+      const notFound = await repos.epics.findById('EPIC-999');
+      expect(notFound).toBeNull();
+    });
+  });
+
+  describe('StageRepository boolean normalisation', () => {
+    it('returns session_active and is_draft as booleans', async () => {
+      const allRepos = await repos.repos.findAll();
+      const stages = await repos.stages.listByRepo(allRepos[0].id);
+      expect(stages.length).toBeGreaterThan(0);
+
+      for (const stage of stages) {
+        expect(typeof stage.session_active).toBe('boolean');
+        expect(typeof stage.is_draft).toBe('boolean');
+      }
+    });
+
+    it('findById returns boolean fields', async () => {
+      const stage = await repos.stages.findById(SEED_IDS.STAGE_AUTH_API);
+      expect(stage).not.toBeNull();
+      expect(typeof stage!.session_active).toBe('boolean');
+      expect(typeof stage!.is_draft).toBe('boolean');
+    });
+  });
+
+  describe('DependencyRepository boolean normalisation', () => {
+    it('returns resolved as boolean', async () => {
+      const allRepos = await repos.repos.findAll();
+      const deps = await repos.dependencies.listByRepo(allRepos[0].id);
+      for (const dep of deps) {
+        expect(typeof dep.resolved).toBe('boolean');
+      }
+    });
+  });
+
+  describe('StageSessionRepository boolean normalisation', () => {
+    it('returns is_current as boolean after addSession', async () => {
+      await repos.stageSessions.addSession(SEED_IDS.STAGE_AUTH_API, 'test-sess', 'Design');
+      const sessions = await repos.stageSessions.getSessionsByStageId(SEED_IDS.STAGE_AUTH_API);
+      expect(sessions.length).toBe(1);
+      expect(typeof sessions[0].is_current).toBe('boolean');
+      expect(sessions[0].is_current).toBe(true);
+    });
+
+    it('getCurrentSession returns session with boolean is_current', async () => {
+      await repos.stageSessions.addSession(SEED_IDS.STAGE_AUTH_API, 'test-sess', 'Design');
+      const current = await repos.stageSessions.getCurrentSession(SEED_IDS.STAGE_AUTH_API);
+      expect(current).not.toBeNull();
+      expect(typeof current!.is_current).toBe('boolean');
+      expect(current!.is_current).toBe(true);
+    });
+  });
+
+  describe('TicketRepository boolean normalisation', () => {
+    it('returns has_stages as boolean', async () => {
+      const allRepos = await repos.repos.findAll();
+      const tickets = await repos.tickets.listByRepo(allRepos[0].id);
+      for (const ticket of tickets) {
+        if (ticket.has_stages !== null) {
+          expect(typeof ticket.has_stages).toBe('boolean');
+        }
+      }
+    });
+  });
+});

--- a/tools/web-server/tests/server/session-history.test.ts
+++ b/tools/web-server/tests/server/session-history.test.ts
@@ -23,7 +23,7 @@ describe('session history API', () => {
 
     db = new KanbanDatabase(path.join(tmpDir, 'test.db'));
     seedDatabase(db, tmpDir);
-    dataService = new DataService({ db });
+    dataService = DataService.fromSqlite(db);
 
     app = await createServer({
       logger: false,
@@ -51,7 +51,7 @@ describe('session history API', () => {
     });
 
     it('returns sessions with projectId', async () => {
-      dataService.stageSessions.addSession(SEED_IDS.STAGE_AUTH_API, 'sess-1', 'Design');
+      await dataService.stageSessions.addSession(SEED_IDS.STAGE_AUTH_API, 'sess-1', 'Design');
 
       const res = await app.inject({
         method: 'GET',
@@ -67,8 +67,8 @@ describe('session history API', () => {
     });
 
     it('returns multiple sessions ordered by is_current DESC, started_at DESC', async () => {
-      dataService.stageSessions.addSession(SEED_IDS.STAGE_AUTH_API, 'sess-old', 'Design');
-      dataService.stageSessions.addSession(SEED_IDS.STAGE_AUTH_API, 'sess-new', 'Build');
+      await dataService.stageSessions.addSession(SEED_IDS.STAGE_AUTH_API, 'sess-old', 'Design');
+      await dataService.stageSessions.addSession(SEED_IDS.STAGE_AUTH_API, 'sess-new', 'Build');
 
       const res = await app.inject({
         method: 'GET',
@@ -108,7 +108,7 @@ describe('session history API', () => {
     });
 
     it('returns sessions with projectId', async () => {
-      dataService.ticketSessions.addSession(SEED_IDS.TICKET_LOGIN, 'sess-conv', 'convert');
+      await dataService.ticketSessions.addSession(SEED_IDS.TICKET_LOGIN, 'sess-conv', 'convert');
 
       const res = await app.inject({
         method: 'GET',

--- a/tools/web-server/tests/server/sessions.test.ts
+++ b/tools/web-server/tests/server/sessions.test.ts
@@ -332,10 +332,10 @@ describe('sessions API', () => {
       stageTmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kanban-stage-session-test-'));
       stageDb = new KanbanDatabase(path.join(stageTmpDir, 'test.db'));
       seedDatabase(stageDb, stageTmpDir);
-      stageDataService = new DataService({ db: stageDb });
+      stageDataService = DataService.fromSqlite(stageDb);
 
       // Link one stage to a session so we can test the happy path
-      stageDataService.stages.updateSessionId(SEED_IDS.STAGE_AUTH_API, 'sess-linked-123');
+      await stageDataService.stages.updateSessionId(SEED_IDS.STAGE_AUTH_API, 'sess-linked-123');
 
       stageApp = await createServer({
         logger: false,

--- a/tools/web-server/tests/server/stages.test.ts
+++ b/tools/web-server/tests/server/stages.test.ts
@@ -18,7 +18,7 @@ describe('stages API', () => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kanban-stages-test-'));
     db = new KanbanDatabase(path.join(tmpDir, 'test.db'));
     seedDatabase(db, tmpDir);
-    dataService = new DataService({ db });
+    dataService = DataService.fromSqlite(db);
     app = await createServer({ logger: false, isDev: true, dataService });
   });
 

--- a/tools/web-server/tests/server/tickets.test.ts
+++ b/tools/web-server/tests/server/tickets.test.ts
@@ -18,7 +18,7 @@ describe('tickets API', () => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kanban-tickets-test-'));
     db = new KanbanDatabase(path.join(tmpDir, 'test.db'));
     seedDatabase(db, tmpDir);
-    dataService = new DataService({ db });
+    dataService = DataService.fromSqlite(db);
     app = await createServer({ logger: false, isDev: true, dataService });
   });
 


### PR DESCRIPTION
## Summary
- Adds repository interface abstraction layer (IRepoRepository, IEpicRepository, ITicketRepository, IStageRepository, IDependencyRepository, IStageSessionRepository, ITicketSessionRepository) with async-first design
- SQLite adapters wrap kanban-cli repositories with boolean normalisation (0/1 to true/false)
- PostgreSQL implementations use pg.Pool with queries matching schema.sql
- DataService.fromSqlite() and DataService.fromPool() factory methods replace old constructor
- All 14 route files updated to await async repository calls
- Boolean type annotations updated in board.ts and graph.ts mapper functions
- Filesystem-dependent code gated on deployment mode (POST epics/tickets/import return 501 in hosted mode)
- index.ts wires HostedDeploymentContext instead of throwing on hosted mode

## Test plan
- [x] SQLite adapter tests: delegation and boolean normalisation (7 tests)
- [x] PG repository tests: mocked pool, SQL query verification (9 tests)
- [x] All 952 existing tests continue to pass
- [x] npm run lint passes (zero server-side errors)

Closes #23

Generated with [Claude Code](https://claude.com/claude-code)