### PR TITLE
feat(auth): GitHub OAuth routes and React login/logout UI (#22)

### DIFF
--- a/tools/web-server/src/client/App.tsx
+++ b/tools/web-server/src/client/App.tsx
@@ -18,6 +18,29 @@ import { useInteractionSSE } from './api/interaction-hooks.js';
 import { useSessionMap } from './api/use-session-map.js';
 import { InteractionOverlay } from './components/interaction/InteractionOverlay.js';
 import { GlobalSearch } from './components/search/GlobalSearch.js';
+import { AuthProvider, useAuthContext } from './components/AuthProvider.js';
+import { LoginPage } from './components/LoginPage.js';
+
+/**
+ * Gate component: in hosted mode, requires authentication before
+ * rendering children. In local mode, renders children directly.
+ */
+function AuthGate({ children }: { children: React.ReactNode }) {
+  const deploymentMode = (window as unknown as { __DEPLOYMENT_MODE__?: string }).__DEPLOYMENT_MODE__;
+
+  // Local mode: no auth required
+  if (deploymentMode !== 'hosted') {
+    return <>{children}</>;
+  }
+
+  // Hosted mode: check authentication
+  const { isAuthenticated } = useAuthContext();
+  if (!isAuthenticated) {
+    return <LoginPage />;
+  }
+
+  return <>{children}</>;
+}
 
 function AppContent() {
   // Hooks that require QueryClientProvider context must live here, not in App()
@@ -64,7 +87,11 @@ export function App() {
 
   return (
     <QueryClientProvider client={queryClient}>
-      <AppContent />
+      <AuthProvider>
+        <AuthGate>
+          <AppContent />
+        </AuthGate>
+      </AuthProvider>
     </QueryClientProvider>
   );
 }

--- a/tools/web-server/src/client/api/client.ts
+++ b/tools/web-server/src/client/api/client.ts
@@ -1,3 +1,5 @@
+import { getAuthHeaders, silentRefresh } from '../hooks/useAuth.js';
+
 const API_BASE = '/api';
 
 export async function apiFetch<T>(
@@ -10,11 +12,25 @@ export async function apiFetch<T>(
     defaultHeaders['Content-Type'] = 'application/json';
   }
 
-  const response = await fetch(`${API_BASE}${path}`, {
-    ...restInit,
-    body,
-    headers: { ...defaultHeaders, ...customHeaders },
-  });
+  // Attach auth headers when available (hosted mode)
+  const authHeaders = getAuthHeaders();
+
+  const doFetch = (extraHeaders: Record<string, string> = {}) =>
+    fetch(`${API_BASE}${path}`, {
+      ...restInit,
+      body,
+      headers: { ...defaultHeaders, ...authHeaders, ...extraHeaders, ...customHeaders },
+    });
+
+  let response = await doFetch();
+
+  // On 401: attempt a silent token refresh and retry once
+  if (response.status === 401) {
+    const refreshed = await silentRefresh();
+    if (refreshed) {
+      response = await doFetch({ Authorization: `Bearer ${refreshed.accessToken}` });
+    }
+  }
 
   if (!response.ok) {
     throw new Error(`API error: ${response.status} ${response.statusText}`);

--- a/tools/web-server/src/client/components/AuthProvider.tsx
+++ b/tools/web-server/src/client/components/AuthProvider.tsx
@@ -1,0 +1,155 @@
+import {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  useCallback,
+  type ReactNode,
+} from 'react';
+import {
+  getAccessToken,
+  getRefreshToken,
+  setTokens,
+  clearTokens,
+  silentRefresh,
+  logoutRequest,
+  getAuthHeaders,
+} from '../hooks/useAuth.js';
+
+interface AuthUser {
+  id: string;
+  email: string;
+  username?: string;
+  displayName?: string;
+  avatarUrl?: string;
+}
+
+interface AuthContextValue {
+  user: AuthUser | null;
+  accessToken: string | null;
+  isAuthenticated: boolean;
+  login: () => void;
+  logout: () => Promise<void>;
+  getAuthHeaders: () => Record<string, string>;
+}
+
+const AuthContext = createContext<AuthContextValue | null>(null);
+
+/**
+ * Decode the payload of a JWT without verifying it (client-side only).
+ * Returns null if the token is malformed.
+ */
+function decodeJwtPayload(token: string): AuthUser | null {
+  try {
+    const base64Url = token.split('.')[1];
+    if (!base64Url) return null;
+    const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
+    const json = decodeURIComponent(
+      atob(base64)
+        .split('')
+        .map((c) => '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2))
+        .join(''),
+    );
+    const payload = JSON.parse(json) as {
+      sub?: string;
+      email?: string;
+      username?: string;
+      displayName?: string;
+      avatarUrl?: string;
+    };
+    if (!payload.sub || !payload.email) return null;
+    return {
+      id: payload.sub,
+      email: payload.email,
+      username: payload.username,
+      displayName: payload.displayName,
+      avatarUrl: payload.avatarUrl,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<AuthUser | null>(() => {
+    const token = getAccessToken();
+    return token ? decodeJwtPayload(token) : null;
+  });
+
+  const [accessToken, setAccessToken] = useState<string | null>(getAccessToken);
+
+  // On mount, check if tokens exist and try silent refresh if access token is missing
+  useEffect(() => {
+    const token = getAccessToken();
+    if (token) {
+      setUser(decodeJwtPayload(token));
+      setAccessToken(token);
+    } else if (getRefreshToken()) {
+      // Access token expired but refresh token exists — attempt silent refresh
+      silentRefresh().then((result) => {
+        if (result) {
+          setAccessToken(result.accessToken);
+          setUser(decodeJwtPayload(result.accessToken));
+        } else {
+          setUser(null);
+          setAccessToken(null);
+        }
+      });
+    }
+  }, []);
+
+  // Listen for auth callback data stored in URL hash (after GitHub redirect)
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const callbackData = params.get('auth_callback');
+    if (callbackData) {
+      try {
+        const data = JSON.parse(atob(callbackData)) as {
+          accessToken: string;
+          refreshToken: string;
+          user: AuthUser;
+        };
+        setTokens({ accessToken: data.accessToken, refreshToken: data.refreshToken });
+        setAccessToken(data.accessToken);
+        setUser(data.user);
+        // Clean up URL
+        window.history.replaceState({}, '', window.location.pathname);
+      } catch {
+        // Ignore malformed callback data
+      }
+    }
+  }, []);
+
+  const login = useCallback(() => {
+    window.location.href = '/auth/github';
+  }, []);
+
+  const logout = useCallback(async () => {
+    await logoutRequest();
+    setUser(null);
+    setAccessToken(null);
+    clearTokens();
+  }, []);
+
+  const value: AuthContextValue = {
+    user,
+    accessToken,
+    isAuthenticated: user !== null && accessToken !== null,
+    login,
+    logout,
+    getAuthHeaders,
+  };
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+/**
+ * Access the auth context. Must be used within an <AuthProvider>.
+ */
+export function useAuthContext(): AuthContextValue {
+  const ctx = useContext(AuthContext);
+  if (!ctx) {
+    throw new Error('useAuthContext must be used within an <AuthProvider>');
+  }
+  return ctx;
+}

--- a/tools/web-server/src/client/components/LoginPage.tsx
+++ b/tools/web-server/src/client/components/LoginPage.tsx
@@ -1,0 +1,53 @@
+/**
+ * Login page shown to unauthenticated users in hosted mode.
+ * Presents a single "Sign in with GitHub" button that redirects to /auth/github.
+ */
+export function LoginPage() {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        minHeight: '100vh',
+        fontFamily: 'system-ui, -apple-system, sans-serif',
+        backgroundColor: '#0d1117',
+        color: '#c9d1d9',
+      }}
+    >
+      <h1 style={{ fontSize: '2rem', marginBottom: '0.5rem' }}>Kanban Workflow</h1>
+      <p style={{ marginBottom: '2rem', color: '#8b949e' }}>
+        Sign in to access your boards
+      </p>
+      <a
+        href="/auth/github"
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: '0.5rem',
+          padding: '0.75rem 1.5rem',
+          fontSize: '1rem',
+          fontWeight: 600,
+          color: '#ffffff',
+          backgroundColor: '#238636',
+          border: 'none',
+          borderRadius: '6px',
+          textDecoration: 'none',
+          cursor: 'pointer',
+        }}
+      >
+        <svg
+          width="20"
+          height="20"
+          viewBox="0 0 24 24"
+          fill="currentColor"
+          aria-hidden="true"
+        >
+          <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z" />
+        </svg>
+        Sign in with GitHub
+      </a>
+    </div>
+  );
+}

--- a/tools/web-server/src/client/hooks/useAuth.ts
+++ b/tools/web-server/src/client/hooks/useAuth.ts
@@ -1,0 +1,120 @@
+import { useCallback } from 'react';
+
+const TOKEN_KEY = 'auth_access_token';
+const REFRESH_KEY = 'auth_refresh_token';
+
+export interface AuthTokens {
+  accessToken: string;
+  refreshToken: string;
+}
+
+/**
+ * Read the current access token from localStorage.
+ */
+export function getAccessToken(): string | null {
+  return localStorage.getItem(TOKEN_KEY);
+}
+
+/**
+ * Read the current refresh token from localStorage.
+ */
+export function getRefreshToken(): string | null {
+  return localStorage.getItem(REFRESH_KEY);
+}
+
+/**
+ * Persist tokens in localStorage.
+ */
+export function setTokens(tokens: AuthTokens): void {
+  localStorage.setItem(TOKEN_KEY, tokens.accessToken);
+  localStorage.setItem(REFRESH_KEY, tokens.refreshToken);
+}
+
+/**
+ * Clear all auth tokens from localStorage.
+ */
+export function clearTokens(): void {
+  localStorage.removeItem(TOKEN_KEY);
+  localStorage.removeItem(REFRESH_KEY);
+}
+
+/**
+ * Build Authorization headers for API requests.
+ */
+export function getAuthHeaders(): Record<string, string> {
+  const token = getAccessToken();
+  if (!token) return {};
+  return { Authorization: `Bearer ${token}` };
+}
+
+/**
+ * Attempt a silent token refresh.
+ * Returns the new tokens on success, or null if refresh fails.
+ */
+export async function silentRefresh(): Promise<AuthTokens | null> {
+  const refreshToken = getRefreshToken();
+  if (!refreshToken) return null;
+
+  try {
+    const response = await fetch('/auth/refresh', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ refreshToken }),
+    });
+
+    if (!response.ok) {
+      clearTokens();
+      return null;
+    }
+
+    const data = (await response.json()) as AuthTokens;
+    setTokens(data);
+    return data;
+  } catch {
+    clearTokens();
+    return null;
+  }
+}
+
+/**
+ * Call POST /auth/logout and clear local tokens.
+ */
+export async function logoutRequest(): Promise<void> {
+  const refreshToken = getRefreshToken();
+  if (refreshToken) {
+    try {
+      await fetch('/auth/logout', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ refreshToken }),
+      });
+    } catch {
+      // Best-effort logout; clear tokens regardless
+    }
+  }
+  clearTokens();
+}
+
+/**
+ * React hook providing auth helpers.
+ */
+export function useAuth() {
+  const login = useCallback(() => {
+    window.location.href = '/auth/github';
+  }, []);
+
+  const logout = useCallback(async () => {
+    await logoutRequest();
+    window.location.href = '/';
+  }, []);
+
+  const isAuthenticated = getAccessToken() !== null;
+
+  return {
+    isAuthenticated,
+    login,
+    logout,
+    getAuthHeaders,
+    silentRefresh,
+  };
+}

--- a/tools/web-server/src/server/app.ts
+++ b/tools/web-server/src/server/app.ts
@@ -28,6 +28,7 @@ import { orchestratorRoutes, computeWaitingType } from './routes/orchestrator.js
 import { searchRoutes } from './routes/search.js';
 import { importRoutes } from './routes/import.js';
 import { meRoutes } from './routes/me.js';
+import { authRoutes } from './routes/auth.js';
 
 interface SessionStatusSSE {
   stageId: string;
@@ -94,6 +95,12 @@ export async function createServer(
 
   // Wire the module-level broadcastEvent() to the deployment context's EventBroadcaster
   setBroadcaster(deploymentContext.getEventBroadcaster());
+
+  // Register public auth routes BEFORE the auth middleware (hosted mode only)
+  if (deploymentContext.mode === 'hosted') {
+    const hostedCtx = deploymentContext as HostedDeploymentContext;
+    await app.register(authRoutes, { authProvider: hostedCtx.getHostedAuthProvider() });
+  }
 
   // Register auth plugin (no-op for local mode)
   await app.register(deploymentContext.getAuthProvider().requireAuth());

--- a/tools/web-server/src/server/deployment/hosted/hosted-auth-provider.ts
+++ b/tools/web-server/src/server/deployment/hosted/hosted-auth-provider.ts
@@ -241,6 +241,37 @@ export class HostedAuthProvider implements AuthProvider {
     return { accessToken, refreshToken };
   }
 
+  /**
+   * Revoke a refresh token's session (logout).
+   * Marks the session as revoked and adds the token to the revoked list.
+   */
+  async logout(refreshToken: string): Promise<void> {
+    let payload: RefreshTokenPayload;
+    try {
+      payload = jwt.verify(refreshToken, this.jwtSecret) as RefreshTokenPayload;
+    } catch {
+      // Token is already expired or invalid — treat as successful logout
+      return;
+    }
+
+    const { jti: tokenId, sub: userId, sessionId } = payload;
+
+    // Revoke the session
+    await this.pool.query(
+      `UPDATE auth_sessions SET revoked_at = NOW()
+       WHERE id = $1 AND revoked_at IS NULL`,
+      [sessionId],
+    );
+
+    // Mark the refresh token as revoked
+    await this.pool.query(
+      `INSERT INTO revoked_refresh_tokens (token_id, user_id, revoked_reason)
+       VALUES ($1, $2, $3)
+       ON CONFLICT (token_id) DO NOTHING`,
+      [tokenId, userId, 'logout'],
+    );
+  }
+
   // ----------------------------------------------------------------
   // Private helpers
   // ----------------------------------------------------------------

--- a/tools/web-server/src/server/routes/auth.ts
+++ b/tools/web-server/src/server/routes/auth.ts
@@ -1,0 +1,103 @@
+import type { FastifyPluginCallback } from 'fastify';
+import fp from 'fastify-plugin';
+import type { HostedAuthProvider } from '../deployment/hosted/hosted-auth-provider.js';
+
+export interface AuthRouteOptions {
+  authProvider: HostedAuthProvider;
+  /** GitHub OAuth client ID (read from env if not provided). */
+  githubClientId?: string;
+  /** Base URL for OAuth redirect (e.g. https://myapp.com). */
+  publicBaseUrl?: string;
+}
+
+const authPlugin: FastifyPluginCallback<AuthRouteOptions> = (app, opts, done) => {
+  const { authProvider } = opts;
+  const githubClientId = opts.githubClientId ?? process.env.GITHUB_OAUTH_CLIENT_ID ?? '';
+  const publicBaseUrl = opts.publicBaseUrl ?? process.env.PUBLIC_BASE_URL ?? '';
+
+  /**
+   * GET /auth/github — Redirect to GitHub OAuth authorization page.
+   */
+  app.get('/auth/github', async (_request, reply) => {
+    const redirectUri = `${publicBaseUrl}/auth/github/callback`;
+    const params = new URLSearchParams({
+      client_id: githubClientId,
+      redirect_uri: redirectUri,
+      scope: 'read:user,user:email',
+    });
+    return reply.redirect(`https://github.com/login/oauth/authorize?${params.toString()}`);
+  });
+
+  /**
+   * GET /auth/github/callback — Exchange authorization code for tokens.
+   * Returns { accessToken, refreshToken, user } on success.
+   */
+  app.get('/auth/github/callback', async (request, reply) => {
+    const { code } = request.query as { code?: string };
+
+    if (!code) {
+      return reply.code(400).send({ error: 'Missing authorization code' });
+    }
+
+    try {
+      const result = await authProvider.handleGitHubCallback(code);
+      return reply.send({
+        accessToken: result.accessToken,
+        refreshToken: result.refreshToken,
+        user: result.user,
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'OAuth callback failed';
+      return reply.code(401).send({ error: message });
+    }
+  });
+
+  /**
+   * POST /auth/refresh — Rotate a refresh token.
+   * Expects { refreshToken } in the request body.
+   * Returns new { accessToken, refreshToken }.
+   */
+  app.post('/auth/refresh', async (request, reply) => {
+    const { refreshToken } = (request.body ?? {}) as { refreshToken?: string };
+
+    if (!refreshToken) {
+      return reply.code(400).send({ error: 'Missing refreshToken' });
+    }
+
+    try {
+      const result = await authProvider.refreshTokens(refreshToken);
+      return reply.send({
+        accessToken: result.accessToken,
+        refreshToken: result.refreshToken,
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Token refresh failed';
+      // Reuse detection or invalid token → 401
+      return reply.code(401).send({ error: message });
+    }
+  });
+
+  /**
+   * POST /auth/logout — Revoke the current session.
+   * Expects { refreshToken } in the request body.
+   */
+  app.post('/auth/logout', async (request, reply) => {
+    const { refreshToken } = (request.body ?? {}) as { refreshToken?: string };
+
+    if (!refreshToken) {
+      return reply.code(400).send({ error: 'Missing refreshToken' });
+    }
+
+    try {
+      await authProvider.logout(refreshToken);
+      return reply.send({ ok: true });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Logout failed';
+      return reply.code(500).send({ error: message });
+    }
+  });
+
+  done();
+};
+
+export const authRoutes = fp(authPlugin, { name: 'auth-routes' });

--- a/tools/web-server/tests/server/auth-routes.test.ts
+++ b/tools/web-server/tests/server/auth-routes.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import Fastify, { type FastifyInstance } from 'fastify';
+import { authRoutes } from '../../src/server/routes/auth.js';
+import type { HostedAuthProvider } from '../../src/server/deployment/hosted/hosted-auth-provider.js';
+
+/**
+ * Create a mock HostedAuthProvider with controllable behavior.
+ */
+function createMockAuthProvider(overrides: Partial<HostedAuthProvider> = {}) {
+  return {
+    handleGitHubCallback: vi.fn().mockResolvedValue({
+      accessToken: 'mock-access-token',
+      refreshToken: 'mock-refresh-token',
+      user: {
+        id: 'user-1',
+        email: 'test@example.com',
+        username: 'testuser',
+        displayName: 'Test User',
+        avatarUrl: 'https://example.com/avatar.png',
+      },
+    }),
+    refreshTokens: vi.fn().mockResolvedValue({
+      accessToken: 'new-access-token',
+      refreshToken: 'new-refresh-token',
+    }),
+    logout: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  } as unknown as HostedAuthProvider;
+}
+
+describe('auth routes', () => {
+  let app: FastifyInstance;
+  let mockAuthProvider: HostedAuthProvider;
+
+  beforeEach(async () => {
+    mockAuthProvider = createMockAuthProvider();
+    app = Fastify({ logger: false });
+    await app.register(authRoutes, {
+      authProvider: mockAuthProvider,
+      githubClientId: 'test-client-id',
+      publicBaseUrl: 'https://app.example.com',
+    });
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  describe('GET /auth/github', () => {
+    it('redirects to GitHub OAuth URL with correct params', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/auth/github',
+      });
+
+      expect(response.statusCode).toBe(302);
+      const location = response.headers.location as string;
+      expect(location).toContain('https://github.com/login/oauth/authorize');
+      expect(location).toContain('client_id=test-client-id');
+      expect(location).toContain(encodeURIComponent('https://app.example.com/auth/github/callback'));
+      expect(location).toContain('scope=read%3Auser%2Cuser%3Aemail');
+    });
+  });
+
+  describe('GET /auth/github/callback', () => {
+    it('returns tokens and user on success', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/auth/github/callback?code=test-code',
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.accessToken).toBe('mock-access-token');
+      expect(body.refreshToken).toBe('mock-refresh-token');
+      expect(body.user).toEqual({
+        id: 'user-1',
+        email: 'test@example.com',
+        username: 'testuser',
+        displayName: 'Test User',
+        avatarUrl: 'https://example.com/avatar.png',
+      });
+      expect(mockAuthProvider.handleGitHubCallback).toHaveBeenCalledWith('test-code');
+    });
+
+    it('returns 400 when code is missing', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/auth/github/callback',
+      });
+
+      expect(response.statusCode).toBe(400);
+      const body = JSON.parse(response.body);
+      expect(body.error).toBe('Missing authorization code');
+    });
+
+    it('returns 401 when callback fails', async () => {
+      (mockAuthProvider.handleGitHubCallback as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+        new Error('GitHub OAuth error: bad_verification_code'),
+      );
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/auth/github/callback?code=bad-code',
+      });
+
+      expect(response.statusCode).toBe(401);
+      const body = JSON.parse(response.body);
+      expect(body.error).toBe('GitHub OAuth error: bad_verification_code');
+    });
+  });
+
+  describe('POST /auth/refresh', () => {
+    it('returns new token pair on success', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/auth/refresh',
+        headers: { 'content-type': 'application/json' },
+        payload: JSON.stringify({ refreshToken: 'old-refresh-token' }),
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.accessToken).toBe('new-access-token');
+      expect(body.refreshToken).toBe('new-refresh-token');
+      expect(mockAuthProvider.refreshTokens).toHaveBeenCalledWith('old-refresh-token');
+    });
+
+    it('returns 400 when refreshToken is missing', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/auth/refresh',
+        headers: { 'content-type': 'application/json' },
+        payload: JSON.stringify({}),
+      });
+
+      expect(response.statusCode).toBe(400);
+      const body = JSON.parse(response.body);
+      expect(body.error).toBe('Missing refreshToken');
+    });
+
+    it('returns 401 on reuse detection', async () => {
+      (mockAuthProvider.refreshTokens as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+        new Error('Refresh token reuse detected — session revoked'),
+      );
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/auth/refresh',
+        headers: { 'content-type': 'application/json' },
+        payload: JSON.stringify({ refreshToken: 'reused-token' }),
+      });
+
+      expect(response.statusCode).toBe(401);
+      const body = JSON.parse(response.body);
+      expect(body.error).toBe('Refresh token reuse detected — session revoked');
+    });
+  });
+
+  describe('POST /auth/logout', () => {
+    it('revokes session and returns ok', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/auth/logout',
+        headers: { 'content-type': 'application/json' },
+        payload: JSON.stringify({ refreshToken: 'valid-refresh-token' }),
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.ok).toBe(true);
+      expect(mockAuthProvider.logout).toHaveBeenCalledWith('valid-refresh-token');
+    });
+
+    it('returns 400 when refreshToken is missing', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/auth/logout',
+        headers: { 'content-type': 'application/json' },
+        payload: JSON.stringify({}),
+      });
+
+      expect(response.statusCode).toBe(400);
+      const body = JSON.parse(response.body);
+      expect(body.error).toBe('Missing refreshToken');
+    });
+
+    it('returns 500 when logout fails', async () => {
+      (mockAuthProvider.logout as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+        new Error('Database connection lost'),
+      );
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/auth/logout',
+        headers: { 'content-type': 'application/json' },
+        payload: JSON.stringify({ refreshToken: 'some-token' }),
+      });
+
+      expect(response.statusCode).toBe(500);
+      const body = JSON.parse(response.body);
+      expect(body.error).toBe('Database connection lost');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds GET /auth/github, GET /auth/github/callback, POST /auth/refresh, POST /auth/logout routes (public, registered before requireAuth middleware)
- Adds logout() method to HostedAuthProvider (revokes session + refresh token)
- React AuthProvider context, LoginPage component, and useAuth hook
- apiFetch automatically attaches auth headers and retries on 401 with silent token refresh
- All auth features gated on hosted deployment mode — local mode unaffected

## Test plan
- [x] Auth route tests: redirect, callback, refresh, logout, reuse detection (10 tests)
- [x] All existing 952 tests continue to pass (962 total)
- [x] Server TypeScript compiles cleanly (`tsc --noEmit` passes)

Closes #22