### PR TITLE
feat(sync): hosted mode duplicate detection for issue import (#36)

### DIFF
--- a/tools/web-server/src/server/deployment/hosted/db/migrations/005_ticket_source.sql
+++ b/tools/web-server/src/server/deployment/hosted/db/migrations/005_ticket_source.sql
@@ -1,0 +1,7 @@
+-- Migration 005: Add source_id column to tickets for hosted-mode duplicate detection.
+
+ALTER TABLE tickets ADD COLUMN IF NOT EXISTS source_id TEXT;
+
+CREATE UNIQUE INDEX IF NOT EXISTS tickets_source_dedup_idx
+  ON tickets (repo_id, source, source_id)
+  WHERE source IS NOT NULL AND source_id IS NOT NULL;

--- a/tools/web-server/src/server/routes/tickets.ts
+++ b/tools/web-server/src/server/routes/tickets.ts
@@ -204,6 +204,7 @@ const ticketPlugin: FastifyPluginCallback<TicketRouteOptions> = (app, opts, done
       status,
       jira_key: null,
       source: null,
+      source_id: null,
       has_stages: 0,
       file_path,
       last_synced: new Date().toISOString(),

--- a/tools/web-server/src/server/services/issue-sync-service.ts
+++ b/tools/web-server/src/server/services/issue-sync-service.ts
@@ -435,24 +435,48 @@ export class IssueSyncService {
       let imported = 0;
       let skipped = 0;
 
-      if (this.isHosted() && this.dataService) {
-        // Hosted mode: check DB for existing source_id
-        const tickets = await this.dataService.tickets.listByRepo(config.repo_id);
-        const existingIds = new Set(
-          tickets
-            .filter((t) => t.source === config.provider)
-            .map((t) => {
-              // source_id is stored in frontmatter; check jira_key field as fallback
-              return t.jira_key ?? '';
-            }),
-        );
-
+      if (this.isHosted() && this.pool) {
+        // Hosted mode: check DB for existing source_id via dedicated index
         for (const issue of filtered) {
-          if (existingIds.has(String(issue.number))) {
+          const sourceId = String(issue.number);
+          const dupCheck = await this.pool.query<{ id: string }>(
+            'SELECT id FROM tickets WHERE repo_id = $1 AND source = $2 AND source_id = $3',
+            [config.repo_id, config.provider, sourceId],
+          );
+
+          if (dupCheck.rows.length > 0) {
+            console.log(`Skipping duplicate: ${config.provider}/${sourceId}`);
             skipped++;
             continue;
           }
-          // Create ticket in DB
+
+          // Insert new ticket
+          const now = new Date().toISOString();
+          const ticketId = `imported-${config.provider}-${config.repo_id}-${sourceId}`;
+          const slug = issue.title
+            .toLowerCase()
+            .replace(/[^a-z0-9]+/g, '-')
+            .slice(0, 40)
+            .replace(/-$/, '');
+          await this.pool.query(
+            `INSERT INTO tickets
+               (id, epic_id, repo_id, title, status, jira_key, source, source_id, has_stages, file_path, last_synced)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+             ON CONFLICT (id) DO NOTHING`,
+            [
+              ticketId,
+              null,
+              config.repo_id,
+              issue.title,
+              'to_convert',
+              null,
+              config.provider,
+              sourceId,
+              false,
+              `imported/${slug}.md`,
+              now,
+            ],
+          );
           imported++;
         }
       } else {

--- a/tools/web-server/src/server/services/repositories/pg/index.ts
+++ b/tools/web-server/src/server/services/repositories/pg/index.ts
@@ -169,8 +169,8 @@ export class PgTicketRepository implements ITicketRepository {
 
   async upsert(data: TicketUpsertData): Promise<void> {
     await this.pool.query(
-      `INSERT INTO tickets (id, epic_id, repo_id, title, status, jira_key, source, has_stages, file_path, last_synced)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+      `INSERT INTO tickets (id, epic_id, repo_id, title, status, jira_key, source, source_id, has_stages, file_path, last_synced)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
        ON CONFLICT (id) DO UPDATE SET
          epic_id = EXCLUDED.epic_id,
          repo_id = EXCLUDED.repo_id,
@@ -178,10 +178,11 @@ export class PgTicketRepository implements ITicketRepository {
          status = EXCLUDED.status,
          jira_key = EXCLUDED.jira_key,
          source = EXCLUDED.source,
+         source_id = EXCLUDED.source_id,
          has_stages = EXCLUDED.has_stages,
          file_path = EXCLUDED.file_path,
          last_synced = EXCLUDED.last_synced`,
-      [data.id, data.epic_id, data.repo_id, data.title, data.status, data.jira_key, data.source, data.has_stages, data.file_path, data.last_synced],
+      [data.id, data.epic_id, data.repo_id, data.title, data.status, data.jira_key, data.source, data.source_id, data.has_stages, data.file_path, data.last_synced],
     );
   }
 }

--- a/tools/web-server/src/server/services/repositories/sqlite/index.ts
+++ b/tools/web-server/src/server/services/repositories/sqlite/index.ts
@@ -65,7 +65,7 @@ function normaliseEpic(r: SqliteEpicRow): EpicRow {
 }
 
 function normaliseTicket(r: SqliteTicketRow): TicketRow {
-  return { ...r, has_stages: toBooleanNullable(r.has_stages) };
+  return { ...r, source_id: null, has_stages: toBooleanNullable(r.has_stages) };
 }
 
 function normaliseStage(r: SqliteStageRow): StageRow {

--- a/tools/web-server/src/server/services/repositories/types.ts
+++ b/tools/web-server/src/server/services/repositories/types.ts
@@ -30,6 +30,7 @@ export interface TicketRow {
   status: string | null;
   jira_key: string | null;
   source: string | null;
+  source_id: string | null;
   has_stages: boolean | null;
   file_path: string;
   last_synced: string;
@@ -110,6 +111,7 @@ export interface TicketUpsertData {
   status: string | null;
   jira_key: string | null;
   source: string | null;
+  source_id: string | null;
   has_stages: number | null;
   file_path: string;
   last_synced: string;

--- a/tools/web-server/tests/server/services/issue-sync-service.test.ts
+++ b/tools/web-server/tests/server/services/issue-sync-service.test.ts
@@ -306,6 +306,103 @@ describe('IssueSyncService', () => {
     });
   });
 
+  describe('syncConfig - hosted mode duplicate detection', () => {
+    it('skips issues where source+source_id already exist in DB', async () => {
+      const ghIssues = makeGitHubResponse([
+        { number: 10, title: 'Already imported' },
+        { number: 11, title: 'New issue' },
+      ]);
+      const mockFetch = makeMockFetch(ghIssues);
+
+      // Pool mock: issue 10 is a duplicate, issue 11 is new
+      const mockPool = {
+        query: vi.fn().mockImplementation((sql: string, params: unknown[]) => {
+          if (sql.includes('SELECT id FROM tickets')) {
+            const sourceId = (params as string[])[2];
+            // issue 10 exists, issue 11 does not
+            if (sourceId === '10') {
+              return Promise.resolve({ rows: [{ id: 'existing-ticket' }] });
+            }
+            return Promise.resolve({ rows: [] });
+          }
+          // INSERT or status upsert
+          return Promise.resolve({ rows: [], rowCount: 1 });
+        }),
+      };
+
+      const service = new IssueSyncService({
+        fetchFn: mockFetch,
+        pool: mockPool as any,
+      });
+
+      const result = await service.syncConfig(makeConfig());
+
+      expect(result.imported).toBe(1);
+      expect(result.skipped).toBe(1);
+      expect(result.error).toBeNull();
+    });
+
+    it('inserts non-duplicate issues with source and source_id', async () => {
+      const ghIssues = makeGitHubResponse([{ number: 99, title: 'Brand new issue' }]);
+      const mockFetch = makeMockFetch(ghIssues);
+
+      const insertCalls: unknown[][] = [];
+      const mockPool = {
+        query: vi.fn().mockImplementation((sql: string, params: unknown[]) => {
+          if (sql.includes('SELECT id FROM tickets')) {
+            return Promise.resolve({ rows: [] });
+          }
+          if (sql.includes('INSERT INTO tickets')) {
+            insertCalls.push(params);
+          }
+          return Promise.resolve({ rows: [], rowCount: 1 });
+        }),
+      };
+
+      const service = new IssueSyncService({
+        fetchFn: mockFetch,
+        pool: mockPool as any,
+      });
+
+      const result = await service.syncConfig(makeConfig());
+
+      expect(result.imported).toBe(1);
+      expect(result.skipped).toBe(0);
+      expect(insertCalls).toHaveLength(1);
+      // params: id, epic_id, repo_id, title, status, jira_key, source, source_id, has_stages, file_path, last_synced
+      const insertParams = insertCalls[0] as unknown[];
+      expect(insertParams[6]).toBe('github');   // source
+      expect(insertParams[7]).toBe('99');        // source_id
+    });
+
+    it('handles all duplicates returning zero imports', async () => {
+      const ghIssues = makeGitHubResponse([
+        { number: 1, title: 'Old 1' },
+        { number: 2, title: 'Old 2' },
+      ]);
+      const mockFetch = makeMockFetch(ghIssues);
+
+      const mockPool = {
+        query: vi.fn().mockImplementation((sql: string) => {
+          if (sql.includes('SELECT id FROM tickets')) {
+            return Promise.resolve({ rows: [{ id: 'existing' }] });
+          }
+          return Promise.resolve({ rows: [], rowCount: 0 });
+        }),
+      };
+
+      const service = new IssueSyncService({
+        fetchFn: mockFetch,
+        pool: mockPool as any,
+      });
+
+      const result = await service.syncConfig(makeConfig());
+
+      expect(result.imported).toBe(0);
+      expect(result.skipped).toBe(2);
+    });
+  });
+
   describe('syncAll', () => {
     it('skips disabled configs', async () => {
       const ghIssues = makeGitHubResponse([{ number: 100, title: 'Test' }]);


### PR DESCRIPTION
## Summary

- Adds `source_id TEXT` column to the `tickets` table via migration `005_ticket_source.sql`, with a partial unique index `(repo_id, source, source_id) WHERE source IS NOT NULL AND source_id IS NOT NULL` to enforce deduplication at the DB level
- Rewrites the hosted mode sync path in `IssueSyncService.syncConfig` to query `SELECT id FROM tickets WHERE repo_id=$1 AND source=$2 AND source_id=$3` before each insert, skipping duplicates with a log message
- Inserts new tickets with `source` and `source_id` populated so future syncs correctly detect them as duplicates
- Propagates `source_id` through `TicketRow`, `TicketUpsertData`, `PgTicketRepository.upsert`, `SqliteTicketRepository.normaliseTicket`, and the tickets route handler

## Test plan

- [x] 3 new vitest tests in `issue-sync-service.test.ts` under "syncConfig - hosted mode duplicate detection": skips existing source_id, inserts with correct source+source_id params, handles all-duplicate case
- [x] All 1043 existing tests continue to pass (2 pre-existing rbac-middleware failures unrelated to this change)
- [x] `npm run lint` passes clean (no TypeScript errors)

Closes #36